### PR TITLE
Fix empty npm tag for stable releases

### DIFF
--- a/scripts/release/publish-packages.ts
+++ b/scripts/release/publish-packages.ts
@@ -37,7 +37,7 @@ for (const pkg of packages) {
     continue;
   }
 
-  const tag = process.env.NPM_TAG ?? getNpmTag(version);
+  const tag = process.env.NPM_TAG || getNpmTag(version);
   const publishArgs = ["publish", "--access", "public", "--tag", tag, "--provenance"];
 
   runCommand("npm", publishArgs, pkg.dir);


### PR DESCRIPTION
## Summary
- Fix `??` → `||` for NPM_TAG env var — empty string needs to fall through to `getNpmTag()`
- Without this, `npm publish --tag ""` fails with "Tag name must not be a valid SemVer range"

## Test plan
- [x] Caused v0.1.0 npm publish failure
- [ ] Re-trigger release after merge