### PR TITLE
[codex] Split app lifecycle tools across integrations

### DIFF
--- a/docs/api/openclaw-plugin.md
+++ b/docs/api/openclaw-plugin.md
@@ -2,7 +2,7 @@
 
 The OpenClaw plugin discovers SLOP providers, injects their state into the prompt, and exposes five tools for interaction:
 
-- `discover_apps` — list discoverable apps
+- `list_apps` — list available apps
 - `connect_app` — connect and inspect an app
 - `disconnect_app` — stop tracking an app
 - `app_action` — perform a single action

--- a/docs/api/openclaw-plugin.md
+++ b/docs/api/openclaw-plugin.md
@@ -1,8 +1,10 @@
 # @slop-ai/openclaw-plugin
 
-The OpenClaw plugin discovers SLOP providers, injects their state into the prompt, and exposes three tools for interaction:
+The OpenClaw plugin discovers SLOP providers, injects their state into the prompt, and exposes five tools for interaction:
 
-- `connected_apps` — connect and inspect apps
+- `discover_apps` — list discoverable apps
+- `connect_app` — connect and inspect an app
+- `disconnect_app` — stop tracking an app
 - `app_action` — perform a single action
 - `app_action_batch` — perform multiple actions in one call
 
@@ -24,7 +26,7 @@ The plugin uses `@slop-ai/discovery` for provider discovery (local dirs, bridge,
 
 ### State injection
 
-A `before_prompt_build` hook injects connected providers' state trees as `prependContext` on every inference turn. The model sees live app state and available actions without calling any tool.
+A `before_prompt_build` hook injects connected providers' state trees as `prependContext` on every inference turn. The model sees live app state and available actions without calling any tool, and it can act using `app_action`, `app_action_batch`, or `disconnect_app`.
 
 ### Discovery
 

--- a/docs/guides/advanced/claude-code.md
+++ b/docs/guides/advanced/claude-code.md
@@ -3,7 +3,7 @@
 SLOP ships two Claude Code integrations:
 
 - `claude-slop-native` — direct-tool variant. Connected app affordances become first-class MCP tools, so Claude calls app-specific tools directly.
-- `claude-slop-mcp-proxy` — generic-action variant. Claude reads the injected state tree and uses five stable tools: `discover_apps`, `connect_app`, `disconnect_app`, `app_action`, and `app_action_batch`.
+- `claude-slop-mcp-proxy` — generic-action variant. Claude reads the injected state tree and uses five stable tools: `list_apps`, `connect_app`, `disconnect_app`, `app_action`, and `app_action_batch`.
 
 Use `claude-slop-native` by default for the best Claude Code UX. Use `claude-slop-mcp-proxy` when you want a fixed, low-overhead tool catalog.
 
@@ -83,7 +83,7 @@ Three lifecycle tools remain static and always available:
 
 | Tool | When to use |
 |---|---|
-| `discover_apps` | List all discovered apps and show which ones are already connected |
+| `list_apps` | List all available apps and show which ones are already connected |
 | `connect_app` | Connect to an app and trigger dynamic tool registration |
 | `disconnect_app` | Remove an app and its dynamic tools when you're done |
 
@@ -93,7 +93,7 @@ This variant keeps a stable five-tool surface:
 
 | Tool | When to use |
 |---|---|
-| `discover_apps` | List all discovered apps and show which ones are already connected |
+| `list_apps` | List all available apps and show which ones are already connected |
 | `connect_app` | Connect to an app and inject its current state |
 | `disconnect_app` | Remove an app from injected context |
 | `app_action` | Invoke one affordance by `app`, `path`, `action`, and `params` |
@@ -113,7 +113,7 @@ Claude reads the current state tree from context, then constructs `app_action` o
 
 ```
 User: What apps are available?
-→ Claude can answer from injected state, or call discover_apps when it needs a fresh discovery snapshot
+→ Claude can answer from injected state, or call list_apps when it needs a fresh availability snapshot
 
 User: Connect to the kanban board
 → Claude calls connect_app("kanban")

--- a/docs/guides/advanced/claude-code.md
+++ b/docs/guides/advanced/claude-code.md
@@ -3,7 +3,7 @@
 SLOP ships two Claude Code integrations:
 
 - `claude-slop-native` — direct-tool variant. Connected app affordances become first-class MCP tools, so Claude calls app-specific tools directly.
-- `claude-slop-mcp-proxy` — generic-action variant. Claude reads the injected state tree and uses four stable tools: `connected_apps`, `disconnect_app`, `app_action`, and `app_action_batch`.
+- `claude-slop-mcp-proxy` — generic-action variant. Claude reads the injected state tree and uses five stable tools: `discover_apps`, `connect_app`, `disconnect_app`, `app_action`, and `app_action_batch`.
 
 Use `claude-slop-native` by default for the best Claude Code UX. Use `claude-slop-mcp-proxy` when you want a fixed, low-overhead tool catalog.
 
@@ -79,20 +79,22 @@ Each dynamic tool has proper parameter schemas from the provider's affordance de
 
 Dynamic tools are rebuilt on every state change. When affordances appear or disappear (e.g., a node gains a new action, or a provider disconnects), the tool list updates automatically.
 
-Two tools remain static and always available:
+Three lifecycle tools remain static and always available:
 
 | Tool | When to use |
 |---|---|
-| `connected_apps` | Connect to an app or list all discovered apps |
+| `discover_apps` | List all discovered apps and show which ones are already connected |
+| `connect_app` | Connect to an app and trigger dynamic tool registration |
 | `disconnect_app` | Remove an app and its dynamic tools when you're done |
 
 ### `claude-slop-mcp-proxy`: fixed generic tools
 
-This variant keeps a stable four-tool surface:
+This variant keeps a stable five-tool surface:
 
 | Tool | When to use |
 |---|---|
-| `connected_apps` | Connect to an app or list all discovered apps |
+| `discover_apps` | List all discovered apps and show which ones are already connected |
+| `connect_app` | Connect to an app and inject its current state |
 | `disconnect_app` | Remove an app from injected context |
 | `app_action` | Invoke one affordance by `app`, `path`, `action`, and `params` |
 | `app_action_batch` | Invoke multiple affordances in one call |
@@ -111,10 +113,10 @@ Claude reads the current state tree from context, then constructs `app_action` o
 
 ```
 User: What apps are available?
-→ Claude sees the injected state and responds directly, no tool call needed
+→ Claude can answer from injected state, or call discover_apps when it needs a fresh discovery snapshot
 
 User: Connect to the kanban board
-→ Claude calls connected_apps("kanban")
+→ Claude calls connect_app("kanban")
 
 User: Add a card to the backlog (native)
 → Claude calls kanban__backlog__add_card({title: "..."}) directly

--- a/docs/guides/advanced/openclaw.md
+++ b/docs/guides/advanced/openclaw.md
@@ -1,8 +1,10 @@
 # OpenClaw Integration
 
-`@slop-ai/openclaw-plugin` lets OpenClaw discover SLOP-enabled apps on your machine and act on them through three tools:
+`@slop-ai/openclaw-plugin` lets OpenClaw discover SLOP-enabled apps on your machine and act on them through five tools:
 
-- `connected_apps`
+- `discover_apps`
+- `connect_app`
+- `disconnect_app`
 - `app_action`
 - `app_action_batch`
 
@@ -42,7 +44,7 @@ The plugin registers a `before_prompt_build` hook that injects connected provide
 ```
 ## SLOP Apps
 
-1 app(s) connected. Use app_action to act on apps.
+1 app(s) connected. Use app_action or app_action_batch to act on them. Call connect_app to refresh state or disconnect_app when you're done.
 
 ### Kanban Board (kanban-app)
 ```
@@ -61,7 +63,9 @@ The model knows what state exists and what actions are available without calling
 
 | Tool | Purpose |
 |---|---|
-| `connected_apps` | Connect to an app and see its full state tree, or list all discovered apps |
+| `discover_apps` | List all discovered apps and show which ones are already connected |
+| `connect_app` | Connect to an app and see its full state tree |
+| `disconnect_app` | Disconnect from an app and stop injecting its state |
 | `app_action` | Perform a single action: `app_action(app, path, action, params)` |
 | `app_action_batch` | Perform multiple actions in one call |
 
@@ -80,12 +84,14 @@ All three transport types (Unix socket, WebSocket, postMessage relay) are suppor
 ```text
 # Model sees kanban state in context via before_prompt_build injection
 
-connected_apps("kanban")        # Connect and get full state + actions
+discover_apps()                 # List available apps
+connect_app("kanban")           # Connect and get full state + actions
 app_action("kanban", "/columns/backlog", "add_card", { title: "Ship docs" })
 app_action_batch("kanban", [
   { path: "/columns/backlog", action: "add_card", params: { title: "Task 1" } },
   { path: "/columns/backlog", action: "add_card", params: { title: "Task 2" } },
 ])
+disconnect_app("kanban")       # Stop tracking the app when you're done
 ```
 
 ## Why meta-tools instead of dynamic tools
@@ -99,7 +105,7 @@ OpenClaw's plugin SDK does not support runtime tool registration. Tools must be:
 
 There is no `api.unregisterTool()` or `api.updateTools()` API. This means the plugin cannot add per-app tools when providers connect or remove them when providers disconnect.
 
-The workaround is the **meta-tool pattern**: three stable tools (`connected_apps`, `app_action`, `app_action_batch`) that resolve actions dynamically at runtime. The model knows the exact paths and action names from the state injection, so it gets the call right on the first try.
+The workaround is the **meta-tool pattern**: five stable tools (`discover_apps`, `connect_app`, `disconnect_app`, `app_action`, `app_action_batch`) that resolve actions dynamically at runtime. The model knows the exact paths and action names from the state injection, so it gets the call right on the first try.
 
 ### What would be needed for dynamic tools in OpenClaw
 
@@ -117,7 +123,9 @@ If OpenClaw adds a runtime tool registration API (e.g., `api.registerDynamicTool
 | Available apps in context | Yes (discovered + connected) | Yes (discovered + connected) |
 | Action tools | Dynamic per-app tools (`kanban__add_card`) | Meta-tools (`app_action`) |
 | Batch actions | `app_action_batch` | `app_action_batch` |
-| Connect tool | `connected_apps` | `connected_apps` |
+| Discover tool | `discover_apps` | `discover_apps` |
+| Connect tool | `connect_app` | `connect_app` |
+| Disconnect tool | `disconnect_app` | `disconnect_app` |
 | Discovery | `@slop-ai/discovery` | `@slop-ai/discovery` |
 | Bridge support | Yes | Yes |
 | Staleness protection | 30s timestamp check | Not needed (in-process) |
@@ -131,4 +139,4 @@ Both approaches give the model full context about available state and actions. T
 - [OpenClaw package API](../../api/openclaw-plugin.md)
 - [Consumer SDK](../../api/consumer.md)
 - [Discovery & Bridge](/sdk/discovery) — shared discovery layer
-- [Claude Code integration](./claude-code.md) — comparison integration
+- [Claude Code integration](/guides/advanced/claude-code) — comparison integration

--- a/docs/guides/advanced/openclaw.md
+++ b/docs/guides/advanced/openclaw.md
@@ -2,7 +2,7 @@
 
 `@slop-ai/openclaw-plugin` lets OpenClaw discover SLOP-enabled apps on your machine and act on them through five tools:
 
-- `discover_apps`
+- `list_apps`
 - `connect_app`
 - `disconnect_app`
 - `app_action`
@@ -63,7 +63,7 @@ The model knows what state exists and what actions are available without calling
 
 | Tool | Purpose |
 |---|---|
-| `discover_apps` | List all discovered apps and show which ones are already connected |
+| `list_apps` | List all available apps and show which ones are already connected |
 | `connect_app` | Connect to an app and see its full state tree |
 | `disconnect_app` | Disconnect from an app and stop injecting its state |
 | `app_action` | Perform a single action: `app_action(app, path, action, params)` |
@@ -84,7 +84,7 @@ All three transport types (Unix socket, WebSocket, postMessage relay) are suppor
 ```text
 # Model sees kanban state in context via before_prompt_build injection
 
-discover_apps()                 # List available apps
+list_apps()                     # List available apps
 connect_app("kanban")           # Connect and get full state + actions
 app_action("kanban", "/columns/backlog", "add_card", { title: "Ship docs" })
 app_action_batch("kanban", [
@@ -105,7 +105,7 @@ OpenClaw's plugin SDK does not support runtime tool registration. Tools must be:
 
 There is no `api.unregisterTool()` or `api.updateTools()` API. This means the plugin cannot add per-app tools when providers connect or remove them when providers disconnect.
 
-The workaround is the **meta-tool pattern**: five stable tools (`discover_apps`, `connect_app`, `disconnect_app`, `app_action`, `app_action_batch`) that resolve actions dynamically at runtime. The model knows the exact paths and action names from the state injection, so it gets the call right on the first try.
+The workaround is the **meta-tool pattern**: five stable tools (`list_apps`, `connect_app`, `disconnect_app`, `app_action`, `app_action_batch`) that resolve actions dynamically at runtime. The model knows the exact paths and action names from the state injection, so it gets the call right on the first try.
 
 ### What would be needed for dynamic tools in OpenClaw
 
@@ -123,7 +123,7 @@ If OpenClaw adds a runtime tool registration API (e.g., `api.registerDynamicTool
 | Available apps in context | Yes (discovered + connected) | Yes (discovered + connected) |
 | Action tools | Dynamic per-app tools (`kanban__add_card`) | Meta-tools (`app_action`) |
 | Batch actions | `app_action_batch` | `app_action_batch` |
-| Discover tool | `discover_apps` | `discover_apps` |
+| List tool | `list_apps` | `list_apps` |
 | Connect tool | `connect_app` | `connect_app` |
 | Disconnect tool | `disconnect_app` | `disconnect_app` |
 | Discovery | `@slop-ai/discovery` | `@slop-ai/discovery` |

--- a/docs/sdk/discovery.md
+++ b/docs/sdk/discovery.md
@@ -302,14 +302,14 @@ Hosts without dynamic tool support fall back to the **meta-tool pattern**: stabl
 
 | Variant | Purpose |
 |---|---|
-| **`claude-slop-native`** | Wraps `createDiscoveryService` + `createDynamicTools` from `@slop-ai/discovery`. Registers dynamic per-app tools via `tools/list_changed`. Static tools: `connected_apps`, `disconnect_app`. |
-| **`claude-slop-mcp-proxy`** | Wraps `createDiscoveryService` from `@slop-ai/discovery`, but keeps a fixed tool catalog: `connected_apps`, `disconnect_app`, `app_action`, `app_action_batch`. |
+| **`claude-slop-native`** | Wraps `createDiscoveryService` + `createDynamicTools` from `@slop-ai/discovery`. Registers dynamic per-app tools via `tools/list_changed`. Static tools: `discover_apps`, `connect_app`, `disconnect_app`. |
+| **`claude-slop-mcp-proxy`** | Wraps `createDiscoveryService` from `@slop-ai/discovery`, but keeps a fixed tool catalog: `discover_apps`, `connect_app`, `disconnect_app`, `app_action`, `app_action_batch`. |
 | **Shared hook** (`UserPromptSubmit`) | Reads a shared state file and injects connected providers' state trees into Claude's context on every user message — no MCP fetch needed. Also lists discovered-but-not-connected apps. |
 | **Shared skill** (`slop-connect`) | Teaches Claude the discover → connect → inspect → act workflow. |
 
 Design details:
 
-- **Native direct tools** — When `connected_apps("kanban")` connects a provider, `claude-slop-native` registers affordances as MCP tools (e.g., `kanban__add_card`). Claude calls them directly. When the provider disconnects, the tools are removed.
+- **Native direct tools** — When `connect_app("kanban")` connects a provider, `claude-slop-native` registers affordances as MCP tools (e.g., `kanban__add_card`). Claude calls them directly. When the provider disconnects, the tools are removed.
 - **MCP proxy fallback** — `claude-slop-mcp-proxy` does not register dynamic tools. Instead, Claude reads state from context and calls `app_action(app, path, action, params)` or `app_action_batch(...)`.
 - **Live state in context** — Both variants write provider state to `/tmp/claude-slop-plugin/state.json` on every state change. The hook reads this file and outputs markdown that Claude sees on every turn.
 - **Staleness protection** — The state file includes a `lastUpdated` timestamp. The hook skips injection if the file is older than 30 seconds.
@@ -321,7 +321,7 @@ See [Claude Code guide](/guides/advanced/claude-code) for setup and usage.
 
 | Component | Purpose |
 |---|---|
-| **Tools** | `connected_apps` (connect/list), `app_action` (single action), `app_action_batch` (bulk ops) — registered once during `register()` |
+| **Tools** | `discover_apps` (list), `connect_app` (connect/inspect), `disconnect_app`, `app_action` (single action), `app_action_batch` (bulk ops) — registered once during `register()` |
 | **Hook** (`before_prompt_build`) | Injects connected providers' state trees as `prependContext` on every inference turn |
 
 Design details:

--- a/docs/sdk/discovery.md
+++ b/docs/sdk/discovery.md
@@ -302,10 +302,10 @@ Hosts without dynamic tool support fall back to the **meta-tool pattern**: stabl
 
 | Variant | Purpose |
 |---|---|
-| **`claude-slop-native`** | Wraps `createDiscoveryService` + `createDynamicTools` from `@slop-ai/discovery`. Registers dynamic per-app tools via `tools/list_changed`. Static tools: `discover_apps`, `connect_app`, `disconnect_app`. |
-| **`claude-slop-mcp-proxy`** | Wraps `createDiscoveryService` from `@slop-ai/discovery`, but keeps a fixed tool catalog: `discover_apps`, `connect_app`, `disconnect_app`, `app_action`, `app_action_batch`. |
+| **`claude-slop-native`** | Wraps `createDiscoveryService` + `createDynamicTools` from `@slop-ai/discovery`. Registers dynamic per-app tools via `tools/list_changed`. Static tools: `list_apps`, `connect_app`, `disconnect_app`. |
+| **`claude-slop-mcp-proxy`** | Wraps `createDiscoveryService` from `@slop-ai/discovery`, but keeps a fixed tool catalog: `list_apps`, `connect_app`, `disconnect_app`, `app_action`, `app_action_batch`. |
 | **Shared hook** (`UserPromptSubmit`) | Reads a shared state file and injects connected providers' state trees into Claude's context on every user message — no MCP fetch needed. Also lists discovered-but-not-connected apps. |
-| **Shared skill** (`slop-connect`) | Teaches Claude the discover → connect → inspect → act workflow. |
+| **Shared skill** (`slop-connect`) | Teaches Claude the list → connect → inspect → act workflow. |
 
 Design details:
 
@@ -321,7 +321,7 @@ See [Claude Code guide](/guides/advanced/claude-code) for setup and usage.
 
 | Component | Purpose |
 |---|---|
-| **Tools** | `discover_apps` (list), `connect_app` (connect/inspect), `disconnect_app`, `app_action` (single action), `app_action_batch` (bulk ops) — registered once during `register()` |
+| **Tools** | `list_apps` (list), `connect_app` (connect/inspect), `disconnect_app`, `app_action` (single action), `app_action_batch` (bulk ops) — registered once during `register()` |
 | **Hook** (`before_prompt_build`) | Injects connected providers' state trees as `prependContext` on every inference turn |
 
 Design details:

--- a/packages/typescript/integrations/claude/slop-mcp-proxy/README.md
+++ b/packages/typescript/integrations/claude/slop-mcp-proxy/README.md
@@ -1,6 +1,6 @@
 # claude-slop-mcp-proxy
 
-Claude Code plugin for SLOP — generic-action variant. Connect Claude to SLOP-enabled apps while keeping a fixed four-tool MCP surface.
+Claude Code plugin for SLOP — generic-action variant. Connect Claude to SLOP-enabled apps while keeping a fixed five-tool MCP surface.
 
 ## What it does
 
@@ -36,7 +36,7 @@ bun install
 
 ### Auto-allow permissions
 
-To avoid approving the same four tools repeatedly, add this to your project's `.claude/settings.local.json`:
+To avoid approving the same five tools repeatedly, add this to your project's `.claude/settings.local.json`:
 
 ```json
 {
@@ -48,15 +48,16 @@ To avoid approving the same four tools repeatedly, add this to your project's `.
 }
 ```
 
-This allows the plugin's fixed tool set: `connected_apps`, `disconnect_app`, `app_action`, and `app_action_batch`.
+This allows the plugin's fixed tool set: `discover_apps`, `connect_app`, `disconnect_app`, `app_action`, and `app_action_batch`.
 
 ## Tools
 
-This plugin provides **4 static MCP tools**:
+This plugin provides **5 static MCP tools**:
 
 | Tool | Purpose |
 |------|---------|
-| `connected_apps` | Discover and connect to SLOP apps |
+| `discover_apps` | Discover SLOP apps and show which ones are already connected |
+| `connect_app` | Connect to a specific SLOP app |
 | `disconnect_app` | Disconnect from an app |
 | `app_action` | Perform a single action on an app node |
 | `app_action_batch` | Perform multiple actions in one call |
@@ -67,10 +68,10 @@ App state is injected into context on every user message via a `UserPromptSubmit
 
 | | **slop-mcp-proxy** (this) | **slop-native** |
 |---|---|---|
-| Tool count | Fixed (4 tools) | Grows with affordances |
+| Tool count | Fixed (5 tools) | Grows with affordances |
 | Affordance invocation | Generic `app_action(app, path, action, params)` | Per-affordance tool (e.g. `excalidraw__zoom_to_fit`) |
 | Schema validation | Model reads schemas from injected state | MCP validates per-tool JSON Schema |
-| Token cost | Low (4 tool definitions) | Higher (N tool definitions) |
+| Token cost | Low (5 tool definitions) | Higher (N tool definitions) |
 | Best fit | Lowest-overhead integration surface | Direct, ergonomic tool calling |
 
 ## Usage

--- a/packages/typescript/integrations/claude/slop-mcp-proxy/README.md
+++ b/packages/typescript/integrations/claude/slop-mcp-proxy/README.md
@@ -48,7 +48,7 @@ To avoid approving the same five tools repeatedly, add this to your project's `.
 }
 ```
 
-This allows the plugin's fixed tool set: `discover_apps`, `connect_app`, `disconnect_app`, `app_action`, and `app_action_batch`.
+This allows the plugin's fixed tool set: `list_apps`, `connect_app`, `disconnect_app`, `app_action`, and `app_action_batch`.
 
 ## Tools
 
@@ -56,7 +56,7 @@ This plugin provides **5 static MCP tools**:
 
 | Tool | Purpose |
 |------|---------|
-| `discover_apps` | Discover SLOP apps and show which ones are already connected |
+| `list_apps` | List available SLOP apps and show which ones are already connected |
 | `connect_app` | Connect to a specific SLOP app |
 | `disconnect_app` | Disconnect from an app |
 | `app_action` | Perform a single action on an app node |
@@ -78,7 +78,7 @@ App state is injected into context on every user message via a `UserPromptSubmit
 
 Ask Claude to interact with a SLOP-enabled app:
 
-- "What apps are available?" — discovers local + web providers
+- "What apps are available?" — lists local + web providers
 - "Connect to my kanban board" — connects and injects the current state tree
 - "Add three tasks to my todo list" — Claude uses `app_action_batch`
 - "Disconnect from the kanban board" — removes the app from injected context

--- a/packages/typescript/integrations/claude/slop-mcp-proxy/hooks/scripts/inject-state.mjs
+++ b/packages/typescript/integrations/claude/slop-mcp-proxy/hooks/scripts/inject-state.mjs
@@ -34,7 +34,7 @@ try {
   if (hasProviders) {
     output += `${data.providers.length} app(s) connected. `;
     output +=
-      "Use app_action or app_action_batch to act on apps. Call connected_apps with an app name to refresh full state and available actions.\n\n";
+      "Use app_action or app_action_batch to act on apps. Call connect_app to refresh full state and available actions.\n\n";
 
     for (const provider of data.providers) {
       output += `### ${provider.name} (${provider.id})\n\n`;
@@ -51,7 +51,7 @@ try {
     for (const app of data.available) {
       output += `- **${app.name}** (id: \`${app.id}\`, ${app.transport}, ${app.source})\n`;
     }
-    output += "\nCall connected_apps with an app name to connect.\n";
+    output += "\nCall connect_app with an app name to connect.\n";
   }
 
   process.stdout.write(output);

--- a/packages/typescript/integrations/claude/slop-mcp-proxy/servers/slop-bridge.mjs
+++ b/packages/typescript/integrations/claude/slop-mcp-proxy/servers/slop-bridge.mjs
@@ -3,8 +3,9 @@
 /**
  * slop-bridge (mcp-proxy) — MCP server that bridges SLOP providers to Claude.
  *
- * Four static tools:
- *   - connected_apps: discover and connect to SLOP providers
+ * Five static tools:
+ *   - discover_apps: list discovered SLOP providers
+ *   - connect_app: explicitly connect to a SLOP provider
  *   - disconnect_app: explicitly disconnect from a provider
  *   - app_action: perform a single action on an app node
  *   - app_action_batch: perform multiple actions in one call
@@ -107,11 +108,20 @@ discovery.onStateChange(() => {
 
 const TOOLS = [
   {
-    name: "connected_apps",
+    name: "discover_apps",
     description:
-      "Connect to an application to see its state and actions, or list all available apps. " +
-      "Once connected, the app's state tree is injected into context automatically on every message. " +
-      "Call with an app name to connect; call without arguments to list all.",
+      "List all discovered applications available for connection. " +
+      "Shows which apps are already connected and how many actions they expose.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "connect_app",
+    description:
+      "Connect to an application to see its state and actions. " +
+      "Once connected, the app's state tree is injected into context automatically on every message.",
     inputSchema: {
       type: "object",
       properties: {
@@ -150,7 +160,7 @@ const TOOLS = [
       properties: {
         app: {
           type: "string",
-          description: "App name or ID (from connected_apps or context)",
+          description: "App name or ID (from connect_app or context)",
         },
         path: {
           type: "string",
@@ -180,7 +190,7 @@ const TOOLS = [
       properties: {
         app: {
           type: "string",
-          description: "App name or ID (from connected_apps or context)",
+          description: "App name or ID (from connect_app or context)",
         },
         actions: {
           type: "array",
@@ -227,8 +237,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
   try {
     switch (name) {
-      case "connected_apps":
-        return await handlers.connectedApps(args);
+      case "discover_apps":
+        return await handlers.discoverApps();
+
+      case "connect_app":
+        return await handlers.connectApp(args);
 
       case "disconnect_app":
         return await handlers.disconnectApp(args);

--- a/packages/typescript/integrations/claude/slop-mcp-proxy/servers/slop-bridge.mjs
+++ b/packages/typescript/integrations/claude/slop-mcp-proxy/servers/slop-bridge.mjs
@@ -4,7 +4,7 @@
  * slop-bridge (mcp-proxy) — MCP server that bridges SLOP providers to Claude.
  *
  * Five static tools:
- *   - discover_apps: list discovered SLOP providers
+ *   - list_apps: list available SLOP providers
  *   - connect_app: explicitly connect to a SLOP provider
  *   - disconnect_app: explicitly disconnect from a provider
  *   - app_action: perform a single action on an app node
@@ -108,9 +108,9 @@ discovery.onStateChange(() => {
 
 const TOOLS = [
   {
-    name: "discover_apps",
+    name: "list_apps",
     description:
-      "List all discovered applications available for connection. " +
+      "List all available applications for connection. " +
       "Shows which apps are already connected and how many actions they expose.",
     inputSchema: {
       type: "object",
@@ -237,8 +237,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
   try {
     switch (name) {
-      case "discover_apps":
-        return await handlers.discoverApps();
+      case "list_apps":
+        return await handlers.listApps();
 
       case "connect_app":
         return await handlers.connectApp(args);

--- a/packages/typescript/integrations/claude/slop-mcp-proxy/skills/slop-connect/SKILL.md
+++ b/packages/typescript/integrations/claude/slop-mcp-proxy/skills/slop-connect/SKILL.md
@@ -17,11 +17,16 @@ you always see the latest state, available actions, paths, and parameter schemas
 
 ## Tools
 
-### `connected_apps`
+### `discover_apps`
 
-Lists all discovered applications, or connects to a specific app.
+Lists all discovered applications.
 
 - **No arguments** — lists all available apps (local native + web), their connection status, and action counts.
+
+### `connect_app`
+
+Connects to a specific app and returns its full state tree.
+
 - **`app: "name or id"`** — connects to the app (if not already connected) and returns its full state tree.
 
 ### `disconnect_app`
@@ -52,13 +57,13 @@ Use this for bulk operations: adding multiple items, making several edits, or an
 
 ### 1. Discover and list apps
 
-Call `connected_apps` (no arguments) to see what's available. Apps are auto-discovered from:
+Call `discover_apps` to see what's available. Apps are auto-discovered from:
 - `~/.slop/providers/` — local native apps
 - The SLOP browser extension bridge — web apps running in the browser
 
 ### 2. Connect
 
-Call `connected_apps` with an app name or ID. This connects and returns the full state tree.
+Call `connect_app` with an app name or ID. This connects and returns the full state tree.
 
 ### 3. Read state from context
 
@@ -145,7 +150,7 @@ Some actions take time (deploys, report generation). When you invoke one:
 
 - **Dangerous actions** — actions marked `[DANGEROUS]` require user confirmation. Always ask the user first.
 - **State is live** — the tree updates in real time via patches. What you see is current.
-- **Inspect before acting** — always call `connected_apps` with an app name before using `app_action` so you have the current state.
+- **Inspect before acting** — always call `connect_app` with an app name before using `app_action` so you have the current state.
 - **Batch for speed** — use `app_action_batch` for multiple actions instead of calling `app_action` sequentially.
 - **Summaries are valuable** — stub nodes with summaries often tell you enough without loading full details.
 

--- a/packages/typescript/integrations/claude/slop-mcp-proxy/skills/slop-connect/SKILL.md
+++ b/packages/typescript/integrations/claude/slop-mcp-proxy/skills/slop-connect/SKILL.md
@@ -5,7 +5,7 @@ description: >
   Use when the user asks to "connect to an app", "open an app", "interact with",
   "use", "control", or "check" a local application, or when the user mentions
   a specific app that might be SLOP-enabled (e.g., "check my kanban board",
-  "look at my editor", "what's in my inbox"). Also triggers on "discover apps",
+  "look at my editor", "what's in my inbox"). Also triggers on "list apps",
   "list providers", "available apps", or "SLOP".
 ---
 
@@ -17,9 +17,9 @@ you always see the latest state, available actions, paths, and parameter schemas
 
 ## Tools
 
-### `discover_apps`
+### `list_apps`
 
-Lists all discovered applications.
+Lists all available applications.
 
 - **No arguments** — lists all available apps (local native + web), their connection status, and action counts.
 
@@ -55,9 +55,9 @@ Use this for bulk operations: adding multiple items, making several edits, or an
 
 ## Workflow
 
-### 1. Discover and list apps
+### 1. List available apps
 
-Call `discover_apps` to see what's available. Apps are auto-discovered from:
+Call `list_apps` to see what's available. Apps are auto-discovered from:
 - `~/.slop/providers/` — local native apps
 - The SLOP browser extension bridge — web apps running in the browser
 

--- a/packages/typescript/integrations/claude/slop-native/README.md
+++ b/packages/typescript/integrations/claude/slop-native/README.md
@@ -35,7 +35,7 @@ This variant dynamically registers tools for each connected app. To avoid approv
 }
 ```
 
-This allows all tools from the plugin's MCP server — both the lifecycle tools (`discover_apps`, `connect_app`, `disconnect_app`) and every dynamic affordance tool from connected apps.
+This allows all tools from the plugin's MCP server — both the lifecycle tools (`list_apps`, `connect_app`, `disconnect_app`) and every dynamic affordance tool from connected apps.
 
 ## Comparison with `slop-mcp-proxy`
 
@@ -67,7 +67,7 @@ Both types appear seamlessly in discovery results and work identically once conn
 
 Ask Claude to interact with a SLOP-enabled app:
 
-- "What apps are available?" — discovers local + web providers
+- "What apps are available?" — lists local + web providers
 - "Connect to my kanban board" — connects, injects state, registers action tools
 - "Add three tasks to my todo list" — Claude calls the app's tools directly
 - "Disconnect from the kanban board" — removes tools and state
@@ -78,7 +78,7 @@ Ask Claude to interact with a SLOP-enabled app:
 
 | Tool | Purpose |
 |------|---------|
-| `discover_apps` | List all discovered apps and show which ones are already connected. |
+| `list_apps` | List all available apps and show which ones are already connected. |
 | `connect_app` | Connect to a specific app. Connecting triggers state injection and dynamic tool registration. |
 | `disconnect_app` | Explicitly disconnect from an app. Removes its tools and stops state updates. |
 
@@ -104,7 +104,7 @@ Claude calls these directly — no proxy through meta-tools needed. Tools are re
 | Component | Purpose |
 |-----------|---------|
 | **MCP Server** (`slop-bridge`) | Discovery + connection lifecycle. Registers dynamic affordance tools via `tools/list_changed`. |
-| **Skill** (`slop-connect`) | Teaches Claude the SLOP workflow: discover, connect, read state, act |
+| **Skill** (`slop-connect`) | Teaches Claude the SLOP workflow: list, connect, read state, act |
 | **Hook** (`UserPromptSubmit`) | Injects connected providers' state into Claude's context each turn |
 
 ## How it works

--- a/packages/typescript/integrations/claude/slop-native/README.md
+++ b/packages/typescript/integrations/claude/slop-native/README.md
@@ -35,16 +35,16 @@ This variant dynamically registers tools for each connected app. To avoid approv
 }
 ```
 
-This allows all tools from the plugin's MCP server — both the lifecycle tools (`connected_apps`, `disconnect_app`) and every dynamic affordance tool from connected apps.
+This allows all tools from the plugin's MCP server — both the lifecycle tools (`discover_apps`, `connect_app`, `disconnect_app`) and every dynamic affordance tool from connected apps.
 
 ## Comparison with `slop-mcp-proxy`
 
 | | **slop-native** (this) | **slop-mcp-proxy** |
 |---|---|---|
-| Tool count | Grows with connected affordances | Fixed (4 tools) |
+| Tool count | Grows with connected affordances | Fixed (5 tools) |
 | Affordance invocation | Per-affordance tool (e.g. `excalidraw__zoom_to_fit`) | Generic `app_action(app, path, action, params)` |
 | Schema validation | MCP validates per-tool JSON Schema | Model reads schemas from injected state |
-| Token cost | Higher (N tool definitions) | Lower (4 tool definitions) |
+| Token cost | Higher (N tool definitions) | Lower (5 tool definitions) |
 | Best fit | Direct, ergonomic tool calling | Lowest-overhead integration surface |
 
 ### Local apps
@@ -78,7 +78,8 @@ Ask Claude to interact with a SLOP-enabled app:
 
 | Tool | Purpose |
 |------|---------|
-| `connected_apps` | List all discovered apps, or connect to a specific app. Connecting triggers state injection and dynamic tool registration. |
+| `discover_apps` | List all discovered apps and show which ones are already connected. |
+| `connect_app` | Connect to a specific app. Connecting triggers state injection and dynamic tool registration. |
 | `disconnect_app` | Explicitly disconnect from an app. Removes its tools and stops state updates. |
 
 ### Dynamic affordance tools (per-app, after connecting)
@@ -109,7 +110,7 @@ Claude calls these directly — no proxy through meta-tools needed. Tools are re
 ## How it works
 
 1. The MCP server uses `createDiscoveryService` from `@slop-ai/discovery` to discover SLOP providers from the local filesystem and the browser extension bridge.
-2. When Claude calls `connected_apps` with an app name, the service lazy-connects via the appropriate transport (WebSocket, Unix socket, or extension relay) and subscribes to the state tree.
+2. When Claude calls `connect_app` with an app name, the service lazy-connects via the appropriate transport (WebSocket, Unix socket, or extension relay) and subscribes to the state tree.
 3. `createDynamicTools` from `@slop-ai/discovery` converts each connected app's affordances into namespaced MCP tools. The server notifies Claude via `tools/list_changed`.
 4. Claude calls affordance tools directly (e.g. `excalidraw__elements__add_rectangle`). The server resolves each tool name to a provider + path + action and invokes it.
 5. The `UserPromptSubmit` hook reads a shared state file (`/tmp/claude-slop-plugin/state.json`) that the MCP server updates whenever state changes, injecting live state into Claude's context.
@@ -138,7 +139,7 @@ Browser SPAs ──postMessage──Extension─────────┤
 
 All dynamic affordance tools remain registered for the lifetime of the connection. Apps with many distinct action+schema combinations can consume significant context tokens (~128 tokens per tool) even when Claude isn't actively interacting with the app.
 
-**Planned improvement: idle tool deregistration.** Track the last tool call per provider. After a configurable idle timeout (e.g. 60 seconds with no tool calls), deregister that provider's tools via `tools/list_changed` to free context. The connection and state subscription stay alive — the hook still injects the state tree each turn so Claude retains awareness of the app. When Claude needs to act again, a single `connected_apps("appname")` call re-registers the tools instantly from the cached state (no reconnection needed).
+**Planned improvement: idle tool deregistration.** Track the last tool call per provider. After a configurable idle timeout (e.g. 60 seconds with no tool calls), deregister that provider's tools via `tools/list_changed` to free context. The connection and state subscription stay alive — the hook still injects the state tree each turn so Claude retains awareness of the app. When Claude needs to act again, a single `connect_app("appname")` call re-registers the tools instantly from the cached state (no reconnection needed).
 
 This gives the best of both worlds: direct tool calls with zero overhead during active use, freed context when idle.
 

--- a/packages/typescript/integrations/claude/slop-native/hooks/scripts/inject-state.mjs
+++ b/packages/typescript/integrations/claude/slop-native/hooks/scripts/inject-state.mjs
@@ -34,7 +34,7 @@ try {
   if (hasProviders) {
     output += `${data.providers.length} app(s) connected. `;
     output +=
-      "Use the app-specific tools registered for each connected app to act on them directly. Call connected_apps with an app name to refresh state and tool registration if needed.\n\n";
+      "Use the app-specific tools registered for each connected app to act on them directly. Call connect_app to refresh state and tool registration if needed.\n\n";
 
     for (const provider of data.providers) {
       output += `### ${provider.name} (${provider.id})\n\n`;
@@ -51,7 +51,7 @@ try {
     for (const app of data.available) {
       output += `- **${app.name}** (id: \`${app.id}\`, ${app.transport}, ${app.source})\n`;
     }
-    output += "\nCall connected_apps with an app name to connect.\n";
+    output += "\nCall connect_app with an app name to connect.\n";
   }
 
   process.stdout.write(output);

--- a/packages/typescript/integrations/claude/slop-native/servers/slop-bridge.mjs
+++ b/packages/typescript/integrations/claude/slop-native/servers/slop-bridge.mjs
@@ -4,7 +4,7 @@
  * slop-bridge — MCP server that bridges SLOP providers to Claude.
  *
  * Three lifecycle tools:
- *   - discover_apps: list discovered SLOP providers
+ *   - list_apps: list available SLOP providers
  *   - connect_app: explicitly connect to a SLOP provider
  *   - disconnect_app: explicitly disconnect from a provider
  *
@@ -119,9 +119,9 @@ discovery.onStateChange(() => {
 
 const STATIC_TOOLS = [
   {
-    name: "discover_apps",
+    name: "list_apps",
     description:
-      "List all discovered applications available for connection. " +
+      "List all available applications for connection. " +
       "Shows which apps are already connected and how many actions they expose.",
     inputSchema: {
       type: "object",
@@ -194,8 +194,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   try {
     // Static tools
     switch (name) {
-      case "discover_apps": {
-        return await handlers.discoverApps();
+      case "list_apps": {
+        return await handlers.listApps();
       }
 
       case "connect_app": {

--- a/packages/typescript/integrations/claude/slop-native/servers/slop-bridge.mjs
+++ b/packages/typescript/integrations/claude/slop-native/servers/slop-bridge.mjs
@@ -3,8 +3,9 @@
 /**
  * slop-bridge — MCP server that bridges SLOP providers to Claude.
  *
- * Two meta-tools for lifecycle:
- *   - connected_apps: discover and connect to SLOP providers
+ * Three lifecycle tools:
+ *   - discover_apps: list discovered SLOP providers
+ *   - connect_app: explicitly connect to a SLOP provider
  *   - disconnect_app: explicitly disconnect from a provider
  *
  * All app actions are exposed as dynamic per-app tools via MCP tools/list_changed.
@@ -118,11 +119,20 @@ discovery.onStateChange(() => {
 
 const STATIC_TOOLS = [
   {
-    name: "connected_apps",
+    name: "discover_apps",
     description:
-      "Connect to an application to enable its tools, or list all available apps. " +
-      "Once connected, per-app action tools appear automatically (e.g. kanban__add_card). " +
-      "Call with an app name to connect; call without arguments to list all.",
+      "List all discovered applications available for connection. " +
+      "Shows which apps are already connected and how many actions they expose.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "connect_app",
+    description:
+      "Connect to an application to enable its tools and inspect its current state. " +
+      "Once connected, per-app action tools appear automatically (e.g. kanban__add_card).",
     inputSchema: {
       type: "object",
       properties: {
@@ -184,8 +194,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   try {
     // Static tools
     switch (name) {
-      case "connected_apps": {
-        const result = await handlers.connectedApps(args);
+      case "discover_apps": {
+        return await handlers.discoverApps();
+      }
+
+      case "connect_app": {
+        const result = await handlers.connectApp(args);
         // After connecting a new app, rebuild dynamic tools
         dynamicToolSet = createDynamicTools(discovery);
         server.sendToolListChanged().catch(() => {});
@@ -207,7 +221,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const provider = discovery.getProvider(resolved.providerId);
       if (!provider) {
         return {
-          content: [{ type: "text", text: `App disconnected. Call connected_apps to reconnect.` }],
+          content: [{ type: "text", text: `App disconnected. Call connect_app to reconnect.` }],
           isError: true,
         };
       }

--- a/packages/typescript/integrations/claude/slop-native/skills/slop-connect/SKILL.md
+++ b/packages/typescript/integrations/claude/slop-native/skills/slop-connect/SKILL.md
@@ -33,11 +33,16 @@ This auto-allows all tools from this plugin — lifecycle tools and dynamic app 
 
 ### Lifecycle tools (always available)
 
-#### `connected_apps`
+#### `discover_apps`
 
-Lists all discovered applications, or connects to a specific app.
+Lists all discovered applications.
 
 - **No arguments** — lists all available apps (local native + web), their connection status, and action counts.
+
+#### `connect_app`
+
+Connects to a specific app and returns its full state tree.
+
 - **`app: "name or id"`** — connects to the app (if not already connected) and returns its full state tree. **Connecting also registers all app affordances as dynamic tools.**
 
 #### `disconnect_app`
@@ -62,13 +67,13 @@ You can call multiple affordance tools **in parallel** in a single response for 
 
 ### 1. Discover and list apps
 
-Call `connected_apps` (no arguments) to see what's available. Apps are auto-discovered from:
+Call `discover_apps` to see what's available. Apps are auto-discovered from:
 - `~/.slop/providers/` — local native apps
 - The SLOP browser extension bridge — web apps running in the browser
 
 ### 2. Connect
 
-Call `connected_apps` with an app name or ID. This connects and returns the full state tree. Dynamic tools are registered automatically — you'll see them available for use.
+Call `connect_app` with an app name or ID. This connects and returns the full state tree. Dynamic tools are registered automatically — you'll see them available for use.
 
 ### 3. Act
 
@@ -113,7 +118,7 @@ Invoke the `read_content` action on that node to load the full content.
 
 ## Multi-App Workflows
 
-Connect to multiple apps simultaneously. Call `connected_apps` with each app name to connect. Each app's affordances are registered as separate namespaced tools, so there are no collisions.
+Connect to multiple apps simultaneously. Call `connect_app` with each app name to connect. Each app's affordances are registered as separate namespaced tools, so there are no collisions.
 
 Example: connect to both a kanban board and a chat app, then create a card from a chat message.
 
@@ -129,7 +134,7 @@ Some actions take time (deploys, report generation). When you invoke one:
 
 - **Dangerous actions** — actions marked `[DANGEROUS]` require user confirmation. Always ask the user first.
 - **State is live** — the tree updates in real time via patches. What you see is current.
-- **Inspect before acting** — always call `connected_apps` with an app name before using affordance tools so you have the current state and know which tools are available.
+- **Inspect before acting** — always call `connect_app` with an app name before using affordance tools so you have the current state and know which tools are available.
 - **Parallel calls** — use parallel tool calls for batch operations instead of calling sequentially.
 - **Summaries are valuable** — stub nodes with summaries often tell you enough without loading full details.
 

--- a/packages/typescript/integrations/claude/slop-native/skills/slop-connect/SKILL.md
+++ b/packages/typescript/integrations/claude/slop-native/skills/slop-connect/SKILL.md
@@ -5,7 +5,7 @@ description: >
   Use when the user asks to "connect to an app", "open an app", "interact with",
   "use", "control", or "check" a local application, or when the user mentions
   a specific app that might be SLOP-enabled (e.g., "check my kanban board",
-  "look at my editor", "what's in my inbox"). Also triggers on "discover apps",
+  "look at my editor", "what's in my inbox"). Also triggers on "list apps",
   "list providers", "available apps", or "SLOP".
 ---
 
@@ -33,9 +33,9 @@ This auto-allows all tools from this plugin — lifecycle tools and dynamic app 
 
 ### Lifecycle tools (always available)
 
-#### `discover_apps`
+#### `list_apps`
 
-Lists all discovered applications.
+Lists all available applications.
 
 - **No arguments** — lists all available apps (local native + web), their connection status, and action counts.
 
@@ -65,9 +65,9 @@ You can call multiple affordance tools **in parallel** in a single response for 
 
 ## Workflow
 
-### 1. Discover and list apps
+### 1. List available apps
 
-Call `discover_apps` to see what's available. Apps are auto-discovered from:
+Call `list_apps` to see what's available. Apps are auto-discovered from:
 - `~/.slop/providers/` — local native apps
 - The SLOP browser extension bridge — web apps running in the browser
 

--- a/packages/typescript/integrations/discovery/src/anthropic-agent-sdk.ts
+++ b/packages/typescript/integrations/discovery/src/anthropic-agent-sdk.ts
@@ -14,25 +14,30 @@ import { createToolHandlers } from "./tools";
 /**
  * Create Agent SDK tool definitions for use with `query()`.
  *
- * Returns lifecycle tools only (connected_apps, disconnect_app).
+ * Returns lifecycle tools only (discover_apps, connect_app, disconnect_app).
  * Dynamic affordance tools should be wired via MCP's tools/list_changed
  * using `createDynamicTools()` from the main export.
  */
 export function createSlopAgentTools(discovery: ReturnType<typeof createDiscoveryService>) {
   const handlers = createToolHandlers(discovery);
 
-  const connectedApps = tool(
-    "connected_apps",
+  const discoverApps = tool(
+    "discover_apps",
     "View applications running on this computer that you can observe and control. " +
-      "Call without arguments to list all available apps. " +
-      "Call with an app name or ID to connect (if needed) and see its full current state and every action you can perform.",
+      "Lists all available apps and shows which ones are already connected.",
+    {},
+    async () => handlers.discoverApps(),
+  );
+
+  const connectApp = tool(
+    "connect_app",
+    "Connect to an application running on this computer and see its full current state and every action you can perform.",
     {
       app: z
         .string()
-        .optional()
-        .describe("App name or ID to get detailed state for. Omit to list all apps."),
+        .describe("App name or ID to connect and inspect."),
     },
-    async (args) => handlers.connectedApps(args),
+    async (args) => handlers.connectApp(args),
   );
 
   const disconnectApp = tool(
@@ -45,7 +50,7 @@ export function createSlopAgentTools(discovery: ReturnType<typeof createDiscover
     async (args) => handlers.disconnectApp(args),
   );
 
-  return [connectedApps, disconnectApp];
+  return [discoverApps, connectApp, disconnectApp];
 }
 
 /**

--- a/packages/typescript/integrations/discovery/src/anthropic-agent-sdk.ts
+++ b/packages/typescript/integrations/discovery/src/anthropic-agent-sdk.ts
@@ -14,19 +14,19 @@ import { createToolHandlers } from "./tools";
 /**
  * Create Agent SDK tool definitions for use with `query()`.
  *
- * Returns lifecycle tools only (discover_apps, connect_app, disconnect_app).
+ * Returns lifecycle tools only (list_apps, connect_app, disconnect_app).
  * Dynamic affordance tools should be wired via MCP's tools/list_changed
  * using `createDynamicTools()` from the main export.
  */
 export function createSlopAgentTools(discovery: ReturnType<typeof createDiscoveryService>) {
   const handlers = createToolHandlers(discovery);
 
-  const discoverApps = tool(
-    "discover_apps",
+  const listApps = tool(
+    "list_apps",
     "View applications running on this computer that you can observe and control. " +
       "Lists all available apps and shows which ones are already connected.",
     {},
-    async () => handlers.discoverApps(),
+    async () => handlers.listApps(),
   );
 
   const connectApp = tool(
@@ -50,7 +50,7 @@ export function createSlopAgentTools(discovery: ReturnType<typeof createDiscover
     async (args) => handlers.disconnectApp(args),
   );
 
-  return [discoverApps, connectApp, disconnectApp];
+  return [listApps, connectApp, disconnectApp];
 }
 
 /**

--- a/packages/typescript/integrations/discovery/src/cli.ts
+++ b/packages/typescript/integrations/discovery/src/cli.ts
@@ -25,11 +25,11 @@ const server = new McpServer({
 });
 
 server.tool(
-  "discover_apps",
+  "list_apps",
   "View applications running on this computer that you can observe and control. " +
-    "Lists all discovered apps and shows which ones are already connected.",
+    "Lists all available apps and shows which ones are already connected.",
   {},
-  async () => handlers.discoverApps(),
+  async () => handlers.listApps(),
 );
 
 // @ts-expect-error — MCP SDK's server.tool() has excessively deep type instantiation with Zod

--- a/packages/typescript/integrations/discovery/src/cli.ts
+++ b/packages/typescript/integrations/discovery/src/cli.ts
@@ -24,22 +24,27 @@ const server = new McpServer({
   version: "0.1.0",
 });
 
+server.tool(
+  "discover_apps",
+  "View applications running on this computer that you can observe and control. " +
+    "Lists all discovered apps and shows which ones are already connected.",
+  {},
+  async () => handlers.discoverApps(),
+);
+
 // @ts-expect-error — MCP SDK's server.tool() has excessively deep type instantiation with Zod
 server.tool(
-  "connected_apps",
+  "connect_app",
   isPluginMode
-    ? "View applications running on this computer. Usually state is already in context — " +
-      "use this only to refresh state or connect to a newly discovered app."
-    : "View applications running on this computer that you can observe and control. " +
-      "Call without arguments to list all available apps. " +
-      "Call with an app name or ID to connect (if needed) and see its full current state and every action you can perform.",
+    ? "Connect to a discovered application and refresh its full current state. " +
+      "Use this when you need to inspect a newly discovered app or refresh the active app state."
+    : "Connect to an application running on this computer and see its full current state and every action you can perform.",
   {
     app: z
       .string()
-      .optional()
-      .describe("App name or ID to get detailed state for. Omit to list all apps."),
+      .describe("App name or ID to connect and inspect."),
   },
-  async (args) => handlers.connectedApps(args),
+  async (args) => handlers.connectApp(args),
 );
 
 server.tool(

--- a/packages/typescript/integrations/discovery/src/tools.ts
+++ b/packages/typescript/integrations/discovery/src/tools.ts
@@ -98,49 +98,48 @@ export function createDynamicTools(discovery: DiscoveryService): DynamicToolSet 
 }
 
 export function createToolHandlers(discovery: DiscoveryService) {
-  async function connectedApps(args: { app?: string }): Promise<ToolResult> {
-    const { app } = args;
-
-    // --- List all discovered apps ---
-    if (!app) {
-      const discovered = discovery.getDiscovered();
-      if (discovered.length === 0) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: "No applications found. Desktop and web apps that support external control will appear here automatically when they're running.",
-            },
-          ],
-        };
-      }
-
-      const connected = discovery.getProviders();
-      const connectedIds = new Set(connected.map((p) => p.id));
-
-      const lines = discovered.map((desc) => {
-        const isConnected = connectedIds.has(desc.id);
-        const provider = isConnected
-          ? connected.find((p) => p.id === desc.id)
-          : null;
-        const tree = provider?.consumer.getTree(provider.subscriptionId);
-        const actionCount = tree ? affordancesToTools(tree).tools.length : 0;
-        const label = (tree?.properties?.label as string) ?? desc.name;
-        const status = isConnected
-          ? `connected, ${actionCount} actions`
-          : "available";
-        return `- **${label}** (id: \`${desc.id}\`, ${desc.transport.type}) — ${status}`;
-      });
-
+  async function discoverApps(): Promise<ToolResult> {
+    const discovered = discovery.getDiscovered();
+    if (discovered.length === 0) {
       return {
         content: [
           {
             type: "text",
-            text: `Applications on this computer:\n${lines.join("\n")}\n\nUse connected_apps with an app name to see full state and available actions.`,
+            text: "No applications found. Desktop and web apps that support external control will appear here automatically when they're running.",
           },
         ],
       };
     }
+
+    const connected = discovery.getProviders();
+    const connectedIds = new Set(connected.map((p) => p.id));
+
+    const lines = discovered.map((desc) => {
+      const isConnected = connectedIds.has(desc.id);
+      const provider = isConnected
+        ? connected.find((p) => p.id === desc.id)
+        : null;
+      const tree = provider?.consumer.getTree(provider.subscriptionId);
+      const actionCount = tree ? affordancesToTools(tree).tools.length : 0;
+      const label = (tree?.properties?.label as string) ?? desc.name;
+      const status = isConnected
+        ? `connected, ${actionCount} actions`
+        : "available";
+      return `- **${label}** (id: \`${desc.id}\`, ${desc.transport.type}) — ${status}`;
+    });
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Applications on this computer:\n${lines.join("\n")}\n\nUse connect_app with an app name or ID to connect and inspect it.`,
+        },
+      ],
+    };
+  }
+
+  async function connectApp(args: { app: string }): Promise<ToolResult> {
+    const { app } = args;
 
     // --- Show specific app (lazy connect) ---
     const p = await discovery.ensureConnected(app);
@@ -204,7 +203,7 @@ export function createToolHandlers(discovery: DiscoveryService) {
         content: [
           {
             type: "text",
-            text: `App "${app}" is not connected. Use connected_apps to see available apps.`,
+            text: `App "${app}" is not connected. Use discover_apps to see available apps.`,
           },
         ],
       };
@@ -219,5 +218,5 @@ export function createToolHandlers(discovery: DiscoveryService) {
     };
   }
 
-  return { connectedApps, disconnectApp };
+  return { discoverApps, connectApp, disconnectApp };
 }

--- a/packages/typescript/integrations/discovery/src/tools.ts
+++ b/packages/typescript/integrations/discovery/src/tools.ts
@@ -98,7 +98,7 @@ export function createDynamicTools(discovery: DiscoveryService): DynamicToolSet 
 }
 
 export function createToolHandlers(discovery: DiscoveryService) {
-  async function discoverApps(): Promise<ToolResult> {
+  async function listApps(): Promise<ToolResult> {
     const discovered = discovery.getDiscovered();
     if (discovered.length === 0) {
       return {
@@ -203,7 +203,7 @@ export function createToolHandlers(discovery: DiscoveryService) {
         content: [
           {
             type: "text",
-            text: `App "${app}" is not connected. Use discover_apps to see available apps.`,
+            text: `App "${app}" is not connected. Use list_apps to see available apps.`,
           },
         ],
       };
@@ -218,5 +218,5 @@ export function createToolHandlers(discovery: DiscoveryService) {
     };
   }
 
-  return { discoverApps, connectApp, disconnectApp };
+  return { listApps, connectApp, disconnectApp };
 }

--- a/packages/typescript/integrations/openclaw-plugin/README.md
+++ b/packages/typescript/integrations/openclaw-plugin/README.md
@@ -4,7 +4,7 @@ OpenClaw plugin for discovering and controlling SLOP-enabled apps.
 
 The plugin watches SLOP providers, subscribes to their trees, injects live state into the prompt, and exposes five OpenClaw tools:
 
-- `discover_apps` to list discoverable providers
+- `list_apps` to list available providers
 - `connect_app` to inspect a provider's current state and actions
 - `disconnect_app` to stop tracking an app
 - `app_action` to invoke a single affordance on a provider
@@ -54,7 +54,7 @@ The plugin connects to Unix socket, WebSocket, and browser-relayed providers aut
 ## Example
 
 ```text
-discover_apps()
+list_apps()
 connect_app("kanban")
 app_action("kanban", "/columns/backlog", "add_card", { title: "Ship docs" })
 app_action_batch("kanban", [

--- a/packages/typescript/integrations/openclaw-plugin/README.md
+++ b/packages/typescript/integrations/openclaw-plugin/README.md
@@ -2,15 +2,18 @@
 
 OpenClaw plugin for discovering and controlling SLOP-enabled apps.
 
-The plugin watches local SLOP providers, subscribes to their trees, and exposes two OpenClaw tools:
+The plugin watches SLOP providers, subscribes to their trees, injects live state into the prompt, and exposes five OpenClaw tools:
 
-- `connected_apps` to inspect connected providers and their available actions
-- `app_action` to invoke an affordance on a provider
+- `discover_apps` to list discoverable providers
+- `connect_app` to inspect a provider's current state and actions
+- `disconnect_app` to stop tracking an app
+- `app_action` to invoke a single affordance on a provider
+- `app_action_batch` to invoke multiple affordances in one call
 
 ## Install
 
 ```bash
-openclaw plugins install --link /path/to/slop/packages/typescript/openclaw-plugin
+openclaw plugins install --link /path/to/slop/packages/typescript/integrations/openclaw-plugin
 ```
 
 If your OpenClaw setup supports registry installation, use the package name:
@@ -18,6 +21,10 @@ If your OpenClaw setup supports registry installation, use the package name:
 ```bash
 openclaw plugins install @slop-ai/openclaw-plugin
 ```
+
+## How it works
+
+The plugin uses `@slop-ai/discovery` for provider discovery and connection management, and injects provider state into the prompt via OpenClaw's `before_prompt_build` hook. The model sees live app state before every inference turn, then uses `app_action` or `app_action_batch` with the exact paths and action names shown in context.
 
 ## How provider discovery works
 
@@ -36,17 +43,29 @@ Providers register themselves in `~/.slop/providers/` with a descriptor like:
 }
 ```
 
-The plugin connects to Unix socket and WebSocket providers automatically.
+The plugin discovers providers from:
+
+- `~/.slop/providers/` for persistent local providers
+- `/tmp/slop/providers/` for session-scoped providers
+- the browser extension bridge for web apps
+
+The plugin connects to Unix socket, WebSocket, and browser-relayed providers automatically.
 
 ## Example
 
 ```text
-connected_apps("kanban")
-app_action("kanban", "/", "add_card", { column: "backlog", title: "Ship docs" })
+discover_apps()
+connect_app("kanban")
+app_action("kanban", "/columns/backlog", "add_card", { title: "Ship docs" })
+app_action_batch("kanban", [
+  { path: "/columns/backlog", action: "add_card", params: { title: "Task 1" } },
+  { path: "/columns/backlog", action: "add_card", params: { title: "Task 2" } }
+])
+disconnect_app("kanban")
 ```
 
 ## Documentation
 
 - API reference: https://docs.slopai.dev/api/openclaw-plugin
-- OpenClaw guide: https://docs.slopai.dev/guides-advanced/openclaw
+- OpenClaw guide: https://docs.slopai.dev/guides/advanced/openclaw
 - Consumer SDK: https://docs.slopai.dev/api/consumer

--- a/packages/typescript/integrations/openclaw-plugin/openclaw.plugin.json
+++ b/packages/typescript/integrations/openclaw-plugin/openclaw.plugin.json
@@ -8,6 +8,6 @@
     "properties": {}
   },
   "contracts": {
-    "tools": ["discover_apps", "connect_app", "disconnect_app", "app_action", "app_action_batch"]
+    "tools": ["list_apps", "connect_app", "disconnect_app", "app_action", "app_action_batch"]
   }
 }

--- a/packages/typescript/integrations/openclaw-plugin/openclaw.plugin.json
+++ b/packages/typescript/integrations/openclaw-plugin/openclaw.plugin.json
@@ -8,6 +8,6 @@
     "properties": {}
   },
   "contracts": {
-    "tools": ["connected_apps", "app_action", "app_action_batch"]
+    "tools": ["discover_apps", "connect_app", "disconnect_app", "app_action", "app_action_batch"]
   }
 }

--- a/packages/typescript/integrations/openclaw-plugin/src/index.ts
+++ b/packages/typescript/integrations/openclaw-plugin/src/index.ts
@@ -18,7 +18,7 @@ function buildStateContext(discovery: DiscoveryService): string | null {
   if (connected.length > 0) {
     output += `${connected.length} app(s) connected. `;
     output +=
-      "Use app_action to act on them. Call connected_apps with an app name to see full state and actions.\n\n";
+      "Use app_action or app_action_batch to act on them. Call connect_app to refresh detailed state or disconnect_app when you're done.\n\n";
 
     for (const p of connected) {
       const tree = p.consumer.getTree(p.subscriptionId);
@@ -34,9 +34,9 @@ function buildStateContext(discovery: DiscoveryService): string | null {
   if (available.length > 0) {
     output += "### Available (not connected)\n\n";
     for (const app of available) {
-      output += `- **${app.name}** (id: \`${app.id}\`, ${app.transport.type})\n`;
+      output += `- **${app.name}** (id: \`${app.id}\`, ${app.transport.type}, ${app.source ?? "local"})\n`;
     }
-    output += "\nCall connected_apps with an app name to connect.\n";
+    output += "\nCall connect_app with an app name to connect.\n";
   }
 
   return output;
@@ -48,7 +48,7 @@ export default definePluginEntry({
   description:
     "Observe and control desktop and web applications running on this computer. " +
     "Applications that support external control are discovered automatically and " +
-    "become available through connected_apps, app_action, app_action_batch, and disconnect_app tools.",
+    "become available through discover_apps, connect_app, app_action, app_action_batch, and disconnect_app tools.",
   register(api) {
     const discovery = createDiscoveryService({ logger: api.logger });
     const handlers = createToolHandlers(discovery);

--- a/packages/typescript/integrations/openclaw-plugin/src/index.ts
+++ b/packages/typescript/integrations/openclaw-plugin/src/index.ts
@@ -48,7 +48,7 @@ export default definePluginEntry({
   description:
     "Observe and control desktop and web applications running on this computer. " +
     "Applications that support external control are discovered automatically and " +
-    "become available through discover_apps, connect_app, app_action, app_action_batch, and disconnect_app tools.",
+    "become available through list_apps, connect_app, app_action, app_action_batch, and disconnect_app tools.",
   register(api) {
     const discovery = createDiscoveryService({ logger: api.logger });
     const handlers = createToolHandlers(discovery);

--- a/packages/typescript/integrations/openclaw-plugin/src/tools.ts
+++ b/packages/typescript/integrations/openclaw-plugin/src/tools.ts
@@ -3,26 +3,35 @@ import type { DiscoveryService } from "@slop-ai/discovery";
 import type { ToolResult } from "@slop-ai/discovery";
 
 interface ToolHandlers {
-  connectedApps(args: { app?: string }): Promise<ToolResult>;
+  discoverApps(): Promise<ToolResult>;
+  connectApp(args: { app: string }): Promise<ToolResult>;
   disconnectApp(args: { app: string }): Promise<ToolResult>;
 }
 
 export function registerSlopTools(api: any, discovery: DiscoveryService, handlers: ToolHandlers) {
   api.registerTool({
-    name: "connected_apps",
+    name: "discover_apps",
+    description:
+      "List the applications currently discoverable on this computer and whether they are already connected.",
+    parameters: Type.Object({}),
+    async execute(_id: string) {
+      return handlers.discoverApps();
+    },
+  });
+
+  api.registerTool({
+    name: "connect_app",
     description:
       "Connect to an application and see its full state tree and every action you can perform. " +
       "State for already-connected apps is injected into context automatically — " +
-      "use this only to connect new apps or refresh state.",
+      "use this to connect a new app or refresh detailed state.",
     parameters: Type.Object({
-      app: Type.Optional(
-        Type.String({
-          description: "App name or ID to connect and inspect. Omit to list all apps.",
-        }),
-      ),
+      app: Type.String({
+        description: "App name or ID to connect and inspect.",
+      }),
     }),
-    async execute(_id: string, args: { app?: string }) {
-      return handlers.connectedApps(args);
+    async execute(_id: string, args: { app: string }) {
+      return handlers.connectApp(args);
     },
   });
 
@@ -49,7 +58,7 @@ export function registerSlopTools(api: any, discovery: DiscoveryService, handler
       "Use the exact paths, action names, and parameter values from the application state shown in context.",
     parameters: Type.Object({
       app: Type.String({
-        description: "App name or ID (from connected_apps or context)",
+        description: "App name or ID (from connect_app or context)",
       }),
       path: Type.String({
         description: "Path to the item to act on, e.g. '/' for root, '/todos/todo-1'",
@@ -109,7 +118,7 @@ export function registerSlopTools(api: any, discovery: DiscoveryService, handler
       "sequence of actions.",
     parameters: Type.Object({
       app: Type.String({
-        description: "App name or ID (from connected_apps or context)",
+        description: "App name or ID (from connect_app or context)",
       }),
       actions: Type.Array(
         Type.Object({

--- a/packages/typescript/integrations/openclaw-plugin/src/tools.ts
+++ b/packages/typescript/integrations/openclaw-plugin/src/tools.ts
@@ -3,19 +3,19 @@ import type { DiscoveryService } from "@slop-ai/discovery";
 import type { ToolResult } from "@slop-ai/discovery";
 
 interface ToolHandlers {
-  discoverApps(): Promise<ToolResult>;
+  listApps(): Promise<ToolResult>;
   connectApp(args: { app: string }): Promise<ToolResult>;
   disconnectApp(args: { app: string }): Promise<ToolResult>;
 }
 
 export function registerSlopTools(api: any, discovery: DiscoveryService, handlers: ToolHandlers) {
   api.registerTool({
-    name: "discover_apps",
+    name: "list_apps",
     description:
-      "List the applications currently discoverable on this computer and whether they are already connected.",
+      "List the applications currently available on this computer and whether they are already connected.",
     parameters: Type.Object({}),
     async execute(_id: string) {
-      return handlers.discoverApps();
+      return handlers.listApps();
     },
   });
 

--- a/website/docs/src/content/docs/api/openclaw-plugin.md
+++ b/website/docs/src/content/docs/api/openclaw-plugin.md
@@ -2,9 +2,11 @@
 title: "@slop-ai/openclaw-plugin"
 description: "OpenClaw plugin for discovering and controlling SLOP-enabled applications"
 ---
-The OpenClaw plugin discovers SLOP providers, injects their state into the prompt, and exposes three tools for interaction:
+The OpenClaw plugin discovers SLOP providers, injects their state into the prompt, and exposes five tools for interaction:
 
-- `connected_apps` — connect and inspect apps
+- `discover_apps` — list discoverable apps
+- `connect_app` — connect and inspect an app
+- `disconnect_app` — stop tracking an app
 - `app_action` — perform a single action
 - `app_action_batch` — perform multiple actions in one call
 
@@ -26,7 +28,7 @@ The plugin uses `@slop-ai/discovery` for provider discovery (local dirs, bridge,
 
 ### State injection
 
-A `before_prompt_build` hook injects connected providers' state trees as `prependContext` on every inference turn. The model sees live app state and available actions without calling any tool.
+A `before_prompt_build` hook injects connected providers' state trees as `prependContext` on every inference turn. The model sees live app state and available actions without calling any tool, and it can act using `app_action`, `app_action_batch`, or `disconnect_app`.
 
 ### Discovery
 

--- a/website/docs/src/content/docs/api/openclaw-plugin.md
+++ b/website/docs/src/content/docs/api/openclaw-plugin.md
@@ -4,7 +4,7 @@ description: "OpenClaw plugin for discovering and controlling SLOP-enabled appli
 ---
 The OpenClaw plugin discovers SLOP providers, injects their state into the prompt, and exposes five tools for interaction:
 
-- `discover_apps` — list discoverable apps
+- `list_apps` — list available apps
 - `connect_app` — connect and inspect an app
 - `disconnect_app` — stop tracking an app
 - `app_action` — perform a single action

--- a/website/docs/src/content/docs/guides/advanced/claude-code.md
+++ b/website/docs/src/content/docs/guides/advanced/claude-code.md
@@ -5,7 +5,7 @@ description: "Connect Claude Code to SLOP-enabled applications with dynamic or g
 SLOP ships two Claude Code integrations:
 
 - `claude-slop-native` — direct-tool variant. Connected app affordances become first-class MCP tools, so Claude calls app-specific tools directly.
-- `claude-slop-mcp-proxy` — generic-action variant. Claude reads the injected state tree and uses five stable tools: `discover_apps`, `connect_app`, `disconnect_app`, `app_action`, and `app_action_batch`.
+- `claude-slop-mcp-proxy` — generic-action variant. Claude reads the injected state tree and uses five stable tools: `list_apps`, `connect_app`, `disconnect_app`, `app_action`, and `app_action_batch`.
 
 Use `claude-slop-native` by default for the best Claude Code UX. Use `claude-slop-mcp-proxy` when you want a fixed, low-overhead tool catalog.
 
@@ -85,7 +85,7 @@ Three lifecycle tools remain static and always available:
 
 | Tool | When to use |
 |---|---|
-| `discover_apps` | List all discovered apps and show which ones are already connected |
+| `list_apps` | List all available apps and show which ones are already connected |
 | `connect_app` | Connect to an app and trigger dynamic tool registration |
 | `disconnect_app` | Remove an app and its dynamic tools when you're done |
 
@@ -95,7 +95,7 @@ This variant keeps a stable five-tool surface:
 
 | Tool | When to use |
 |---|---|
-| `discover_apps` | List all discovered apps and show which ones are already connected |
+| `list_apps` | List all available apps and show which ones are already connected |
 | `connect_app` | Connect to an app and inject its current state |
 | `disconnect_app` | Remove an app from injected context |
 | `app_action` | Invoke one affordance by `app`, `path`, `action`, and `params` |
@@ -115,7 +115,7 @@ Claude reads the current state tree from context, then constructs `app_action` o
 
 ```
 User: What apps are available?
-→ Claude can answer from injected state, or call discover_apps when it needs a fresh discovery snapshot
+→ Claude can answer from injected state, or call list_apps when it needs a fresh availability snapshot
 
 User: Connect to the kanban board
 → Claude calls connect_app("kanban")

--- a/website/docs/src/content/docs/guides/advanced/claude-code.md
+++ b/website/docs/src/content/docs/guides/advanced/claude-code.md
@@ -5,7 +5,7 @@ description: "Connect Claude Code to SLOP-enabled applications with dynamic or g
 SLOP ships two Claude Code integrations:
 
 - `claude-slop-native` — direct-tool variant. Connected app affordances become first-class MCP tools, so Claude calls app-specific tools directly.
-- `claude-slop-mcp-proxy` — generic-action variant. Claude reads the injected state tree and uses four stable tools: `connected_apps`, `disconnect_app`, `app_action`, and `app_action_batch`.
+- `claude-slop-mcp-proxy` — generic-action variant. Claude reads the injected state tree and uses five stable tools: `discover_apps`, `connect_app`, `disconnect_app`, `app_action`, and `app_action_batch`.
 
 Use `claude-slop-native` by default for the best Claude Code UX. Use `claude-slop-mcp-proxy` when you want a fixed, low-overhead tool catalog.
 
@@ -81,20 +81,22 @@ Each dynamic tool has proper parameter schemas from the provider's affordance de
 
 Dynamic tools are rebuilt on every state change. When affordances appear or disappear (e.g., a node gains a new action, or a provider disconnects), the tool list updates automatically.
 
-Two tools remain static and always available:
+Three lifecycle tools remain static and always available:
 
 | Tool | When to use |
 |---|---|
-| `connected_apps` | Connect to an app or list all discovered apps |
+| `discover_apps` | List all discovered apps and show which ones are already connected |
+| `connect_app` | Connect to an app and trigger dynamic tool registration |
 | `disconnect_app` | Remove an app and its dynamic tools when you're done |
 
 ### `claude-slop-mcp-proxy`: fixed generic tools
 
-This variant keeps a stable four-tool surface:
+This variant keeps a stable five-tool surface:
 
 | Tool | When to use |
 |---|---|
-| `connected_apps` | Connect to an app or list all discovered apps |
+| `discover_apps` | List all discovered apps and show which ones are already connected |
+| `connect_app` | Connect to an app and inject its current state |
 | `disconnect_app` | Remove an app from injected context |
 | `app_action` | Invoke one affordance by `app`, `path`, `action`, and `params` |
 | `app_action_batch` | Invoke multiple affordances in one call |
@@ -113,10 +115,10 @@ Claude reads the current state tree from context, then constructs `app_action` o
 
 ```
 User: What apps are available?
-→ Claude sees the injected state and responds directly, no tool call needed
+→ Claude can answer from injected state, or call discover_apps when it needs a fresh discovery snapshot
 
 User: Connect to the kanban board
-→ Claude calls connected_apps("kanban")
+→ Claude calls connect_app("kanban")
 
 User: Add a card to the backlog (native)
 → Claude calls kanban__backlog__add_card({title: "..."}) directly

--- a/website/docs/src/content/docs/guides/advanced/openclaw.md
+++ b/website/docs/src/content/docs/guides/advanced/openclaw.md
@@ -4,7 +4,7 @@ description: "Control SLOP-enabled applications through OpenClaw"
 ---
 `@slop-ai/openclaw-plugin` lets OpenClaw discover SLOP-enabled apps on your machine and act on them through five tools:
 
-- `discover_apps`
+- `list_apps`
 - `connect_app`
 - `disconnect_app`
 - `app_action`
@@ -65,7 +65,7 @@ The model knows what state exists and what actions are available without calling
 
 | Tool | Purpose |
 |---|---|
-| `discover_apps` | List all discovered apps and show which ones are already connected |
+| `list_apps` | List all available apps and show which ones are already connected |
 | `connect_app` | Connect to an app and see its full state tree |
 | `disconnect_app` | Disconnect from an app and stop injecting its state |
 | `app_action` | Perform a single action: `app_action(app, path, action, params)` |
@@ -86,7 +86,7 @@ All three transport types (Unix socket, WebSocket, postMessage relay) are suppor
 ```text
 # Model sees kanban state in context via before_prompt_build injection
 
-discover_apps()                 # List available apps
+list_apps()                     # List available apps
 connect_app("kanban")           # Connect and get full state + actions
 app_action("kanban", "/columns/backlog", "add_card", { title: "Ship docs" })
 app_action_batch("kanban", [
@@ -107,7 +107,7 @@ OpenClaw's plugin SDK does not support runtime tool registration. Tools must be:
 
 There is no `api.unregisterTool()` or `api.updateTools()` API. This means the plugin cannot add per-app tools when providers connect or remove them when providers disconnect.
 
-The workaround is the **meta-tool pattern**: five stable tools (`discover_apps`, `connect_app`, `disconnect_app`, `app_action`, `app_action_batch`) that resolve actions dynamically at runtime. The model knows the exact paths and action names from the state injection, so it gets the call right on the first try.
+The workaround is the **meta-tool pattern**: five stable tools (`list_apps`, `connect_app`, `disconnect_app`, `app_action`, `app_action_batch`) that resolve actions dynamically at runtime. The model knows the exact paths and action names from the state injection, so it gets the call right on the first try.
 
 ### What would be needed for dynamic tools in OpenClaw
 
@@ -125,7 +125,7 @@ If OpenClaw adds a runtime tool registration API (e.g., `api.registerDynamicTool
 | Available apps in context | Yes (discovered + connected) | Yes (discovered + connected) |
 | Action tools | Dynamic per-app tools (`kanban__add_card`) | Meta-tools (`app_action`) |
 | Batch actions | `app_action_batch` | `app_action_batch` |
-| Discover tool | `discover_apps` | `discover_apps` |
+| List tool | `list_apps` | `list_apps` |
 | Connect tool | `connect_app` | `connect_app` |
 | Disconnect tool | `disconnect_app` | `disconnect_app` |
 | Discovery | `@slop-ai/discovery` | `@slop-ai/discovery` |

--- a/website/docs/src/content/docs/guides/advanced/openclaw.md
+++ b/website/docs/src/content/docs/guides/advanced/openclaw.md
@@ -2,9 +2,11 @@
 title: "OpenClaw Integration"
 description: "Control SLOP-enabled applications through OpenClaw"
 ---
-`@slop-ai/openclaw-plugin` lets OpenClaw discover SLOP-enabled apps on your machine and act on them through three tools:
+`@slop-ai/openclaw-plugin` lets OpenClaw discover SLOP-enabled apps on your machine and act on them through five tools:
 
-- `connected_apps`
+- `discover_apps`
+- `connect_app`
+- `disconnect_app`
 - `app_action`
 - `app_action_batch`
 
@@ -44,7 +46,7 @@ The plugin registers a `before_prompt_build` hook that injects connected provide
 ```
 ## SLOP Apps
 
-1 app(s) connected. Use app_action to act on apps.
+1 app(s) connected. Use app_action or app_action_batch to act on them. Call connect_app to refresh state or disconnect_app when you're done.
 
 ### Kanban Board (kanban-app)
 ```
@@ -63,7 +65,9 @@ The model knows what state exists and what actions are available without calling
 
 | Tool | Purpose |
 |---|---|
-| `connected_apps` | Connect to an app and see its full state tree, or list all discovered apps |
+| `discover_apps` | List all discovered apps and show which ones are already connected |
+| `connect_app` | Connect to an app and see its full state tree |
+| `disconnect_app` | Disconnect from an app and stop injecting its state |
 | `app_action` | Perform a single action: `app_action(app, path, action, params)` |
 | `app_action_batch` | Perform multiple actions in one call |
 
@@ -82,12 +86,14 @@ All three transport types (Unix socket, WebSocket, postMessage relay) are suppor
 ```text
 # Model sees kanban state in context via before_prompt_build injection
 
-connected_apps("kanban")        # Connect and get full state + actions
+discover_apps()                 # List available apps
+connect_app("kanban")           # Connect and get full state + actions
 app_action("kanban", "/columns/backlog", "add_card", { title: "Ship docs" })
 app_action_batch("kanban", [
   { path: "/columns/backlog", action: "add_card", params: { title: "Task 1" } },
   { path: "/columns/backlog", action: "add_card", params: { title: "Task 2" } },
 ])
+disconnect_app("kanban")       # Stop tracking the app when you're done
 ```
 
 ## Why meta-tools instead of dynamic tools
@@ -101,7 +107,7 @@ OpenClaw's plugin SDK does not support runtime tool registration. Tools must be:
 
 There is no `api.unregisterTool()` or `api.updateTools()` API. This means the plugin cannot add per-app tools when providers connect or remove them when providers disconnect.
 
-The workaround is the **meta-tool pattern**: three stable tools (`connected_apps`, `app_action`, `app_action_batch`) that resolve actions dynamically at runtime. The model knows the exact paths and action names from the state injection, so it gets the call right on the first try.
+The workaround is the **meta-tool pattern**: five stable tools (`discover_apps`, `connect_app`, `disconnect_app`, `app_action`, `app_action_batch`) that resolve actions dynamically at runtime. The model knows the exact paths and action names from the state injection, so it gets the call right on the first try.
 
 ### What would be needed for dynamic tools in OpenClaw
 
@@ -119,7 +125,9 @@ If OpenClaw adds a runtime tool registration API (e.g., `api.registerDynamicTool
 | Available apps in context | Yes (discovered + connected) | Yes (discovered + connected) |
 | Action tools | Dynamic per-app tools (`kanban__add_card`) | Meta-tools (`app_action`) |
 | Batch actions | `app_action_batch` | `app_action_batch` |
-| Connect tool | `connected_apps` | `connected_apps` |
+| Discover tool | `discover_apps` | `discover_apps` |
+| Connect tool | `connect_app` | `connect_app` |
+| Disconnect tool | `disconnect_app` | `disconnect_app` |
 | Discovery | `@slop-ai/discovery` | `@slop-ai/discovery` |
 | Bridge support | Yes | Yes |
 | Staleness protection | 30s timestamp check | Not needed (in-process) |

--- a/website/docs/src/content/docs/sdk/discovery.md
+++ b/website/docs/src/content/docs/sdk/discovery.md
@@ -304,10 +304,10 @@ Hosts without dynamic tool support fall back to the **meta-tool pattern**: stabl
 
 | Variant | Purpose |
 |---|---|
-| **`claude-slop-native`** | Wraps `createDiscoveryService` + `createDynamicTools` from `@slop-ai/discovery`. Registers dynamic per-app tools via `tools/list_changed`. Static tools: `discover_apps`, `connect_app`, `disconnect_app`. |
-| **`claude-slop-mcp-proxy`** | Wraps `createDiscoveryService` from `@slop-ai/discovery`, but keeps a fixed tool catalog: `discover_apps`, `connect_app`, `disconnect_app`, `app_action`, `app_action_batch`. |
+| **`claude-slop-native`** | Wraps `createDiscoveryService` + `createDynamicTools` from `@slop-ai/discovery`. Registers dynamic per-app tools via `tools/list_changed`. Static tools: `list_apps`, `connect_app`, `disconnect_app`. |
+| **`claude-slop-mcp-proxy`** | Wraps `createDiscoveryService` from `@slop-ai/discovery`, but keeps a fixed tool catalog: `list_apps`, `connect_app`, `disconnect_app`, `app_action`, `app_action_batch`. |
 | **Shared hook** (`UserPromptSubmit`) | Reads a shared state file and injects connected providers' state trees into Claude's context on every user message — no MCP fetch needed. Also lists discovered-but-not-connected apps. |
-| **Shared skill** (`slop-connect`) | Teaches Claude the discover → connect → inspect → act workflow. |
+| **Shared skill** (`slop-connect`) | Teaches Claude the list → connect → inspect → act workflow. |
 
 Design details:
 
@@ -323,7 +323,7 @@ See [Claude Code guide](/guides/advanced/claude-code) for setup and usage.
 
 | Component | Purpose |
 |---|---|
-| **Tools** | `discover_apps` (list), `connect_app` (connect/inspect), `disconnect_app`, `app_action` (single action), `app_action_batch` (bulk ops) — registered once during `register()` |
+| **Tools** | `list_apps` (list), `connect_app` (connect/inspect), `disconnect_app`, `app_action` (single action), `app_action_batch` (bulk ops) — registered once during `register()` |
 | **Hook** (`before_prompt_build`) | Injects connected providers' state trees as `prependContext` on every inference turn |
 
 Design details:

--- a/website/docs/src/content/docs/sdk/discovery.md
+++ b/website/docs/src/content/docs/sdk/discovery.md
@@ -304,14 +304,14 @@ Hosts without dynamic tool support fall back to the **meta-tool pattern**: stabl
 
 | Variant | Purpose |
 |---|---|
-| **`claude-slop-native`** | Wraps `createDiscoveryService` + `createDynamicTools` from `@slop-ai/discovery`. Registers dynamic per-app tools via `tools/list_changed`. Static tools: `connected_apps`, `disconnect_app`. |
-| **`claude-slop-mcp-proxy`** | Wraps `createDiscoveryService` from `@slop-ai/discovery`, but keeps a fixed tool catalog: `connected_apps`, `disconnect_app`, `app_action`, `app_action_batch`. |
+| **`claude-slop-native`** | Wraps `createDiscoveryService` + `createDynamicTools` from `@slop-ai/discovery`. Registers dynamic per-app tools via `tools/list_changed`. Static tools: `discover_apps`, `connect_app`, `disconnect_app`. |
+| **`claude-slop-mcp-proxy`** | Wraps `createDiscoveryService` from `@slop-ai/discovery`, but keeps a fixed tool catalog: `discover_apps`, `connect_app`, `disconnect_app`, `app_action`, `app_action_batch`. |
 | **Shared hook** (`UserPromptSubmit`) | Reads a shared state file and injects connected providers' state trees into Claude's context on every user message — no MCP fetch needed. Also lists discovered-but-not-connected apps. |
 | **Shared skill** (`slop-connect`) | Teaches Claude the discover → connect → inspect → act workflow. |
 
 Design details:
 
-- **Native direct tools** — When `connected_apps("kanban")` connects a provider, `claude-slop-native` registers affordances as MCP tools (e.g., `kanban__add_card`). Claude calls them directly. When the provider disconnects, the tools are removed.
+- **Native direct tools** — When `connect_app("kanban")` connects a provider, `claude-slop-native` registers affordances as MCP tools (e.g., `kanban__add_card`). Claude calls them directly. When the provider disconnects, the tools are removed.
 - **MCP proxy fallback** — `claude-slop-mcp-proxy` does not register dynamic tools. Instead, Claude reads state from context and calls `app_action(app, path, action, params)` or `app_action_batch(...)`.
 - **Live state in context** — Both variants write provider state to `/tmp/claude-slop-plugin/state.json` on every state change. The hook reads this file and outputs markdown that Claude sees on every turn.
 - **Staleness protection** — The state file includes a `lastUpdated` timestamp. The hook skips injection if the file is older than 30 seconds.
@@ -323,7 +323,7 @@ See [Claude Code guide](/guides/advanced/claude-code) for setup and usage.
 
 | Component | Purpose |
 |---|---|
-| **Tools** | `connected_apps` (connect/list), `app_action` (single action), `app_action_batch` (bulk ops) — registered once during `register()` |
+| **Tools** | `discover_apps` (list), `connect_app` (connect/inspect), `disconnect_app`, `app_action` (single action), `app_action_batch` (bulk ops) — registered once during `register()` |
 | **Hook** (`before_prompt_build`) | Injects connected providers' state trees as `prependContext` on every inference turn |
 
 Design details:


### PR DESCRIPTION
## Summary

This PR moves the recent Claude/OpenClaw integration work off `main` and into a feature branch, including both the lifecycle split and the follow-up naming cleanup.

It:
- splits app lifecycle actions across integrations into explicit `connect_app` and `disconnect_app` flows instead of overloading a single tool
- renames the listing tool consistently from `discover_apps` to `list_apps` across the shared discovery layer, Claude integrations, OpenClaw, and docs
- regenerates the published docs content so the website matches the canonical docs and package READMEs

## Why

The previous tool shape mixed listing and connection semantics in a way that made the lifecycle harder to reason about for both users and models. The follow-up rename makes the tool verbs consistent: `list_apps`, `connect_app`, and `disconnect_app`.

## Impact

- clearer lifecycle semantics in the shared discovery APIs
- consistent tool names across Claude native, Claude MCP proxy, and OpenClaw
- updated prompts, skills, manifests, and docs so examples match the runtime behavior

## Validation

- `bun run generate:content`
- `bun run check:content`
- `bun run build` in `packages/typescript/integrations/discovery`
- `bun run build` in `packages/typescript/integrations/openclaw-plugin`
- `bun run build` in `packages/typescript/integrations/claude/slop-native/servers`
- `bun run build` in `packages/typescript/integrations/claude/slop-mcp-proxy/servers`
