### PR TITLE
[codex] Add Codex SLOP integration with state injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__/
 target/
 .claude/
 examples/spa/angular/.angular/
+.agents/plugins/marketplace.json

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Full results and methodology: [Benchmarks: MCP vs SLOP](https://docs.slopai.dev/
 | TanStack Start | [`@slop-ai/tanstack-start`](./packages/typescript/adapters/tanstack-start) | `bun add @slop-ai/tanstack-start` |
 | Discovery | [`@slop-ai/discovery`](./packages/typescript/integrations/discovery) | `bun add @slop-ai/discovery` |
 | OpenClaw | [`@slop-ai/openclaw-plugin`](./packages/typescript/integrations/openclaw-plugin) | `bun add @slop-ai/openclaw-plugin` |
+| Codex | [`slop` plugin](./packages/typescript/integrations/codex/slop) | `cp -r packages/typescript/integrations/codex/slop ~/.codex/plugins/slop` |
 | Python | [`slop-ai`](./packages/python/slop-ai) | `pip install slop-ai` |
 | Rust | [`slop-ai`](./packages/rust/slop-ai) | `cargo add slop-ai` |
 | Go | [`slop-ai`](./packages/go/slop-ai) | `go get github.com/devteapot/slop/packages/go/slop-ai` |
@@ -162,7 +163,8 @@ slop/
 │   │   │   └── tanstack-start/     # @slop-ai/tanstack-start — SSR adapter
 │   │   └── integrations/
 │   │       ├── discovery/          # @slop-ai/discovery — provider discovery + agent tool helpers
-│   │       ├── claude-slop-plugin/ # Claude Code plugin (MCP bridge, hooks, skills)
+│   │       ├── claude/             # Claude Code plugins (native + MCP proxy)
+│   │       ├── codex/              # Codex plugin (MCP bridge + skill)
 │   │       └── openclaw-plugin/    # @slop-ai/openclaw-plugin — OpenClaw integration
 │   ├── python/slop-ai/             # Python SDK
 │   ├── rust/slop-ai/               # Rust SDK

--- a/bun.lock
+++ b/bun.lock
@@ -298,6 +298,15 @@
         "@slop-ai/discovery": "workspace:*",
       },
     },
+    "packages/typescript/integrations/codex/slop/servers": {
+      "name": "codex-slop-bridge",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.1",
+        "@slop-ai/consumer": "workspace:*",
+        "@slop-ai/discovery": "workspace:*",
+      },
+    },
     "packages/typescript/integrations/discovery": {
       "name": "@slop-ai/discovery",
       "version": "0.1.0",
@@ -1606,6 +1615,8 @@
     "clone-response": ["clone-response@1.0.3", "", { "dependencies": { "mimic-response": "^1.0.0" } }, "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "codex-slop-bridge": ["codex-slop-bridge@workspace:packages/typescript/integrations/codex/slop/servers"],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 

--- a/docs/guides/advanced/claude-code.md
+++ b/docs/guides/advanced/claude-code.md
@@ -163,4 +163,5 @@ All three integrations share the same underlying `@slop-ai/discovery` package. `
 
 - [Discovery & Bridge](/sdk/discovery) — the discovery layer this plugin builds on
 - [Consumer guide](/guides/consumer) — other SLOP consumers (CLI, Desktop, Extension)
+- [Codex integration](/guides/advanced/codex) — fixed-tool Codex plugin for SLOP app discovery and control
 - [OpenClaw integration](/guides/advanced/openclaw) — similar integration for OpenClaw

--- a/docs/guides/advanced/codex.md
+++ b/docs/guides/advanced/codex.md
@@ -1,0 +1,132 @@
+# Codex Integration
+
+SLOP ships a Codex plugin at `packages/typescript/integrations/codex/slop`.
+
+It gives Codex five stable MCP tools for discovering and controlling SLOP-enabled applications:
+
+- `list_apps`
+- `connect_app`
+- `disconnect_app`
+- `app_action`
+- `app_action_batch`
+
+## What it does
+
+- **Discovers** SLOP apps from local provider descriptors and the browser extension bridge
+- **Connects** to Unix socket, WebSocket, and relay-backed providers through `@slop-ai/discovery`
+- **Injects live state** for connected apps on each future user prompt through a Codex hook
+- **Returns an immediate snapshot** through `connect_app`, including the current state tree and available actions
+- **Acts through stable meta-tools** so Codex has a predictable tool surface
+- **Supports multiple apps** connected simultaneously
+
+## Install
+
+Copy or symlink the plugin into your Codex plugins directory:
+
+```bash
+# From the repo root
+cp -r packages/typescript/integrations/codex/slop ~/.codex/plugins/slop
+```
+
+The plugin includes a bundled MCP bridge in `servers/dist/slop-bridge.bundle.mjs`, so the copied plugin can run as-is. To rebuild the bundle from source:
+
+```bash
+cd ~/.codex/plugins/slop/servers
+bun install
+bun run build
+```
+
+## How it works
+
+### MCP bridge
+
+The plugin's `.mcp.json` starts a local stdio MCP server:
+
+- command: `node`
+- cwd: `./servers`
+- entrypoint: `./dist/slop-bridge.bundle.mjs`
+
+That bridge wraps `@slop-ai/discovery` and exposes a fixed five-tool surface to Codex.
+
+### Hook-based state injection
+
+The bridge writes connected-provider state to `/tmp/codex-slop-plugin/state.json` whenever provider state changes. A bundled `UserPromptSubmit` hook reads that file and injects markdown into future Codex turns:
+
+````text
+## SLOP Apps
+
+1 app(s) connected. Read the state trees below before acting...
+
+### Kanban (kanban)
+
+```
+[collection] board: Sprint Board (...)
+  [collection] backlog: Backlog (...)  actions: {add_card(title: string)}
+```
+````
+
+The hook skips injection if the state file is older than 30 seconds, which prevents stale state from a dead MCP process from lingering in context.
+
+### Skill-guided workflow
+
+The bundled `slop-connect` skill teaches Codex the intended control loop:
+
+1. `list_apps`
+2. `connect_app("target-app")`
+3. inspect the returned same-turn state tree
+4. on later turns, read the injected `## SLOP Apps` context
+5. `app_action(...)` or `app_action_batch(...)`
+6. `disconnect_app(...)` when done
+
+Codex does not need to call `connect_app` before every action. `connect_app` is for establishing or refreshing a connection; once connected, the hook keeps the current state in context on future user turns.
+
+## Tools
+
+| Tool | Purpose |
+| --- | --- |
+| `list_apps` | List all discovered SLOP-enabled apps and show which are already connected |
+| `connect_app` | Connect to an app, return its current state tree plus action summary, and enroll it in injected context |
+| `disconnect_app` | Disconnect from an app |
+| `app_action` | Invoke one affordance on a node |
+| `app_action_batch` | Invoke multiple affordances in a single call |
+
+## Discovery sources
+
+| Source | Transport | How it's found |
+| --- | --- | --- |
+| `~/.slop/providers/*.json` | Unix socket or WebSocket | File watcher + periodic scan |
+| `/tmp/slop/providers/*.json` | Unix socket or WebSocket | File watcher + periodic scan |
+| Browser extension bridge | WebSocket or postMessage relay | Bridge client at `ws://127.0.0.1:9339/slop-bridge` |
+
+## Why the Codex plugin uses meta-tools
+
+The Codex integration currently chooses the same fixed-tool model as the OpenClaw plugin:
+
+- Codex gets a stable, predictable MCP tool catalog
+- the hook can inject live state without rebuilding tools on every patch
+- the skill can reliably teach the connect-once, inspect, then act workflow
+
+When Codex support for dynamic per-affordance tool flows becomes desirable, the same `@slop-ai/discovery` layer can be extended in that direction.
+
+## Example interaction
+
+```text
+User: What apps are available?
+→ Codex calls list_apps
+
+User: Connect to the kanban board
+→ Codex calls connect_app("kanban")
+
+User: Add three cards to the backlog
+→ Codex reads the injected Kanban tree from context, then calls app_action_batch with three add_card actions
+
+User: Disconnect from the kanban board
+→ Codex calls disconnect_app("kanban")
+```
+
+## Related
+
+- [Discovery & Bridge](/sdk/discovery) — shared discovery layer used by the plugin
+- [Consumer guide](/guides/consumer) — direct consumer usage patterns
+- [Claude Code integration](/guides/advanced/claude-code) — dynamic-tool and proxy variants for Claude
+- [OpenClaw integration](/guides/advanced/openclaw) — comparison integration using the same meta-tool pattern

--- a/docs/guides/advanced/openclaw.md
+++ b/docs/guides/advanced/openclaw.md
@@ -139,4 +139,5 @@ Both approaches give the model full context about available state and actions. T
 - [OpenClaw package API](../../api/openclaw-plugin.md)
 - [Consumer SDK](../../api/consumer.md)
 - [Discovery & Bridge](/sdk/discovery) — shared discovery layer
+- [Codex integration](/guides/advanced/codex) — fixed-tool Codex plugin using the same meta-tool pattern
 - [Claude Code integration](/guides/advanced/claude-code) — comparison integration

--- a/docs/guides/consumer.md
+++ b/docs/guides/consumer.md
@@ -309,6 +309,7 @@ The same pattern works well for a headless regression check: connect, subscribe 
 
 - [Consumer package API](/api/consumer)
 - [Discovery & Bridge](/sdk/discovery) — auto-discovery, extension bridge, relay transport, and state formatting for AI integrations
+- [Codex integration](/guides/advanced/codex) — Codex plugin for SLOP app discovery and control
 - [Claude Code integration](/guides/advanced/claude-code) — Claude Code plugin for SLOP app discovery and control
 - [Desktop app docs](/desktop/install)
 - [Chrome extension docs](../extension/install.md)

--- a/docs/sdk/discovery.md
+++ b/docs/sdk/discovery.md
@@ -293,10 +293,29 @@ Dynamic tools have proper parameter schemas from the provider's affordance defin
 
 | Host | Dynamic tools | Mechanism | Limitation |
 |---|---|---|---|
+| Codex | No (current plugin) | Stable MCP tools + `UserPromptSubmit` hook-based state injection | No runtime tool registration; actions still go through meta-tools |
 | Claude Code (MCP) | Yes | `notifications/tools/list_changed` — server notifies client when tool list changes | None |
 | OpenClaw | No | `api.registerTool()` is one-time during `register()` | No runtime tool registration API; tools must be declared in the plugin manifest |
 
-Hosts without dynamic tool support fall back to the **meta-tool pattern**: stable tools (`app_action`, `app_action_batch`) that resolve actions at runtime. The model knows exact paths and action names from state injection, so it gets the call right without guessing.
+Hosts without dynamic tool support fall back to the **meta-tool pattern**: stable tools (`app_action`, `app_action_batch`) that resolve actions at runtime. Depending on the host, the model learns the exact paths and action names from prompt-time state injection or from an explicit `connect_app` inspection step.
+
+### Codex plugin (`packages/typescript/integrations/codex/slop`)
+
+| Component | Purpose |
+|---|---|
+| **Tools** | `list_apps`, `connect_app`, `disconnect_app`, `app_action`, `app_action_batch` |
+| **Hook** (`UserPromptSubmit`) | Reads a shared state file and injects connected providers' trees into Codex on every user message |
+| **Skill** (`slop-connect`) | Teaches Codex the connect-once → inspect → act workflow |
+
+Design details:
+
+- **Fixed tool surface** — The Codex plugin exposes the same stable five-tool catalog as the OpenClaw plugin.
+- **Hook-based state injection** — The bridge writes provider state to `/tmp/codex-slop-plugin/state.json` on every state change. The `UserPromptSubmit` hook reads that file and injects fresh markdown into future turns.
+- **Immediate snapshot on connect** — `connect_app` still returns the current tree and actions right away, so Codex can act in the same turn it first connects.
+- **Discovery** — Uses `@slop-ai/discovery` with local descriptor watching plus browser bridge support.
+- **Multi-app** — Multiple providers can remain connected concurrently; `app_action` and `app_action_batch` resolve against the requested app ID.
+
+See [Codex guide](/guides/advanced/codex) for setup and usage.
 
 ### Claude Code integrations (`claude-slop-native`, `claude-slop-mcp-proxy`)
 
@@ -338,4 +357,5 @@ See [OpenClaw guide](/guides/advanced/openclaw) for setup and usage.
 - [Transport spec](../../spec/core/transport.md) — wire protocol and discovery mechanisms
 - [Adapters spec](../../spec/integrations/adapters.md) — bridging non-SLOP apps
 - [Consumer guide](/guides/consumer) — usage patterns and example workflows
+- [Codex guide](/guides/advanced/codex) — Codex plugin setup and usage
 - [Claude Code guide](/guides/advanced/claude-code) — Claude Code plugin setup and usage

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "packages/typescript/sdk/*",
     "packages/typescript/adapters/*",
     "packages/typescript/integrations/*",
+    "packages/typescript/integrations/codex/*/servers",
     "packages/typescript/integrations/claude/*/servers",
     "website/demo",
     "examples/cli/*",

--- a/packages/typescript/integrations/codex/slop/.codex-plugin/plugin.json
+++ b/packages/typescript/integrations/codex/slop/.codex-plugin/plugin.json
@@ -1,0 +1,46 @@
+{
+  "name": "slop",
+  "version": "0.1.0",
+  "description": "Codex plugin for discovering and controlling SLOP-enabled desktop and web applications through MCP.",
+  "author": {
+    "name": "Diego"
+  },
+  "homepage": "https://docs.slopai.dev/guides/advanced/codex",
+  "repository": "https://github.com/devteapot/slop",
+  "license": "MIT",
+  "keywords": [
+    "slop",
+    "codex",
+    "integration",
+    "state",
+    "affordances",
+    "real-time"
+  ],
+  "skills": "./skills/",
+  "hooks": "./hooks/hooks.json",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "SLOP",
+    "shortDescription": "Observe and control local apps through Codex",
+    "longDescription": "Connect Codex to SLOP-enabled desktop and web applications. Discover available providers, inject their live semantic state into Codex, and act through five stable MCP tools backed by the shared discovery layer.",
+    "developerName": "Diego",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://docs.slopai.dev/guides/advanced/codex",
+    "privacyPolicyURL": "https://github.com/devteapot/slop",
+    "termsOfServiceURL": "https://github.com/devteapot/slop/blob/main/LICENSE",
+    "defaultPrompt": [
+      "List the SLOP-enabled apps available on this computer",
+      "Connect to my kanban board and inspect its current state",
+      "Use the visible app actions to update several items in one batch"
+    ],
+    "brandColor": "#2563EB",
+    "composerIcon": "./assets/slop-small.svg",
+    "logo": "./assets/slop-logo.svg",
+    "screenshots": []
+  }
+}

--- a/packages/typescript/integrations/codex/slop/.mcp.json
+++ b/packages/typescript/integrations/codex/slop/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "slop-bridge": {
+      "command": "node",
+      "args": [
+        "./dist/slop-bridge.bundle.mjs"
+      ],
+      "cwd": "./servers",
+      "note": "Local MCP bridge for discovering SLOP providers and invoking their affordances through Codex."
+    }
+  }
+}

--- a/packages/typescript/integrations/codex/slop/README.md
+++ b/packages/typescript/integrations/codex/slop/README.md
@@ -1,0 +1,70 @@
+# codex-slop
+
+Codex plugin for SLOP. It lets Codex discover SLOP-enabled desktop and web apps on the current machine, inspect their semantic state trees, and invoke affordances through five stable MCP tools:
+
+- `list_apps`
+- `connect_app`
+- `disconnect_app`
+- `app_action`
+- `app_action_batch`
+
+## What it does
+
+- Discovers SLOP apps from local provider descriptors and the browser extension bridge
+- Connects to Unix socket, WebSocket, and browser-relayed providers through `@slop-ai/discovery`
+- Injects connected apps' live state into future user turns through a `UserPromptSubmit` hook
+- Gives Codex a fixed MCP surface that works well with Codex skills and tool calling
+- Supports multiple connected apps at once for cross-app workflows
+
+## Install
+
+Copy or symlink the plugin into your Codex plugins directory:
+
+```bash
+# From the repo root
+cp -r packages/typescript/integrations/codex/slop ~/.codex/plugins/slop
+```
+
+The plugin ships with a bundled MCP bridge at `servers/dist/slop-bridge.bundle.mjs`, so the copied plugin can run without workspace installs. If you want to rebuild that bundle from source:
+
+```bash
+cd ~/.codex/plugins/slop/servers
+bun install
+bun run build
+```
+
+## How it works
+
+Codex loads the plugin-local MCP server from `.mcp.json`. That server uses `@slop-ai/discovery` to:
+
+1. discover local and browser-announced SLOP providers
+2. connect to a provider on demand with `connect_app`
+3. write connected-provider state to `/tmp/codex-slop-plugin/state.json`
+4. let the bundled `UserPromptSubmit` hook inject that state into future Codex turns
+5. execute actions through `app_action` or `app_action_batch`
+
+`connect_app` still returns the current formatted state tree immediately, so Codex can inspect and act in the same turn it establishes a connection. After that, future user turns get live injected state automatically.
+
+## Workflow
+
+1. Call `list_apps` to see what's available.
+2. Call `connect_app("app-name")` once to connect and get the first state snapshot.
+3. Use `app_action` or `app_action_batch` with the exact path and action names from that snapshot.
+4. On later user turns, read the injected `## SLOP Apps` context instead of reconnecting every time.
+5. Leave the app connected while you work, or call `disconnect_app` when you're done.
+
+## Components
+
+| Component | Purpose |
+| --- | --- |
+| `.codex-plugin/plugin.json` | Codex plugin manifest |
+| `.mcp.json` | Plugin-local MCP server wiring |
+| `hooks/hooks.json` | `UserPromptSubmit` hook wiring for state injection |
+| `skills/slop-connect` | Codex-native workflow guidance for app discovery and control |
+| `servers/slop-bridge.mjs` | Fixed-tool MCP bridge backed by `@slop-ai/discovery` |
+
+## Documentation
+
+- Codex guide: https://docs.slopai.dev/guides/advanced/codex
+- Discovery layer: https://docs.slopai.dev/sdk/discovery
+- Consumer SDK: https://docs.slopai.dev/api/consumer

--- a/packages/typescript/integrations/codex/slop/assets/slop-logo.svg
+++ b/packages/typescript/integrations/codex/slop/assets/slop-logo.svg
@@ -1,0 +1,8 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="256" height="256" rx="56" fill="#2563EB"/>
+  <path d="M72 96C72 76.1178 88.1177 60 108 60H148C167.882 60 184 76.1178 184 96V120C184 139.882 167.882 156 148 156H124L92 188V156H108C88.1177 156 72 139.882 72 120V96Z" fill="white"/>
+  <circle cx="112" cy="108" r="10" fill="#2563EB"/>
+  <circle cx="128" cy="108" r="10" fill="#2563EB"/>
+  <circle cx="144" cy="108" r="10" fill="#2563EB"/>
+  <path d="M84 188H172" stroke="white" stroke-width="16" stroke-linecap="round"/>
+</svg>

--- a/packages/typescript/integrations/codex/slop/assets/slop-small.svg
+++ b/packages/typescript/integrations/codex/slop/assets/slop-small.svg
@@ -1,0 +1,8 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" rx="16" fill="#2563EB"/>
+  <path d="M20 24C20 20.6863 22.6863 18 26 18H38C41.3137 18 44 20.6863 44 24V28C44 31.3137 41.3137 34 38 34H31L25 40V34H26C22.6863 34 20 31.3137 20 28V24Z" fill="white"/>
+  <circle cx="28" cy="26" r="2.5" fill="#2563EB"/>
+  <circle cx="32" cy="26" r="2.5" fill="#2563EB"/>
+  <circle cx="36" cy="26" r="2.5" fill="#2563EB"/>
+  <path d="M22 44H42" stroke="white" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/packages/typescript/integrations/codex/slop/hooks/hooks.json
+++ b/packages/typescript/integrations/codex/slop/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ./hooks/scripts/inject-state.mjs",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/typescript/integrations/codex/slop/hooks/scripts/inject-state.mjs
+++ b/packages/typescript/integrations/codex/slop/hooks/scripts/inject-state.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+/**
+ * Hook script: reads the shared state file written by slop-bridge
+ * and outputs connected providers' state trees for context injection.
+ *
+ * Called by the UserPromptSubmit hook on every user message.
+ * Outputs nothing if no providers are connected/discovered or if the state is stale.
+ */
+
+import fs from "node:fs";
+
+const STATE_FILE = "/tmp/codex-slop-plugin/state.json";
+const STALE_THRESHOLD = 30_000; // 30 seconds
+
+try {
+  if (!fs.existsSync(STATE_FILE)) process.exit(0);
+
+  const raw = fs.readFileSync(STATE_FILE, "utf-8");
+  const data = JSON.parse(raw);
+
+  if (data.lastUpdated && Date.now() - data.lastUpdated > STALE_THRESHOLD) {
+    process.exit(0);
+  }
+
+  const hasProviders = data.providers && data.providers.length > 0;
+  const hasAvailable = data.available && data.available.length > 0;
+
+  if (!hasProviders && !hasAvailable) process.exit(0);
+
+  let output = "## SLOP Apps\n\n";
+
+  if (hasProviders) {
+    output += `${data.providers.length} app(s) connected. `;
+    output +=
+      "Read the state trees below before acting. Use app_action or app_action_batch to invoke affordances, and call connect_app only when you need to connect a new app or force a refresh.\n\n";
+
+    for (const provider of data.providers) {
+      output += `### ${provider.name} (${provider.id})\n\n`;
+      if (provider.state && provider.state !== "(no state yet)") {
+        output += "```\n" + provider.state + "\n```\n\n";
+      } else {
+        output += "(awaiting state snapshot)\n\n";
+      }
+    }
+  }
+
+  if (hasAvailable) {
+    output += "### Available (not connected)\n\n";
+    for (const app of data.available) {
+      output += `- **${app.name}** (id: \`${app.id}\`, ${app.transport}, ${app.source})\n`;
+    }
+    output += "\nCall connect_app with an app name to connect it.\n";
+  }
+
+  process.stdout.write(output);
+} catch {
+  process.exit(0);
+}

--- a/packages/typescript/integrations/codex/slop/servers/package.json
+++ b/packages/typescript/integrations/codex/slop/servers/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "codex-slop-bridge",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "bun build slop-bridge.mjs --outfile dist/slop-bridge.bundle.mjs --format esm --target node",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "@slop-ai/consumer": "workspace:*",
+    "@slop-ai/discovery": "workspace:*"
+  }
+}

--- a/packages/typescript/integrations/codex/slop/servers/slop-bridge.mjs
+++ b/packages/typescript/integrations/codex/slop/servers/slop-bridge.mjs
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+
+/**
+ * slop-bridge — fixed-tool MCP server for the Codex plugin.
+ *
+ * Codex keeps a stable five-tool surface, but connected providers' state is also
+ * written to a shared file for UserPromptSubmit hook-based context injection.
+ * connect_app still returns an immediate snapshot so Codex can act in the same
+ * turn it establishes a new connection.
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { createDiscoveryService, createToolHandlers } from "@slop-ai/discovery";
+import { formatTree } from "@slop-ai/consumer";
+import fs from "node:fs";
+import path from "node:path";
+
+const STATE_DIR = "/tmp/codex-slop-plugin";
+const STATE_FILE = path.join(STATE_DIR, "state.json");
+
+const log = {
+  info: (...args) => console.error("[codex-slop]", ...args),
+  error: (...args) => console.error("[codex-slop] ERROR:", ...args),
+};
+
+const discovery = createDiscoveryService({ logger: log, autoConnect: false });
+const handlers = createToolHandlers(discovery);
+
+function writeStateFile() {
+  try {
+    fs.mkdirSync(STATE_DIR, { recursive: true });
+
+    const connected = discovery.getProviders();
+    const discovered = discovery.getDiscovered();
+    const connectedIds = new Set(connected.map((provider) => provider.id));
+
+    const available = discovered
+      .filter((descriptor) => !connectedIds.has(descriptor.id))
+      .map((descriptor) => ({
+        id: descriptor.id,
+        name: descriptor.name,
+        transport: descriptor.transport.type,
+        source: descriptor.source ?? "local",
+      }));
+
+    if (connected.length === 0 && available.length === 0) {
+      if (fs.existsSync(STATE_FILE)) fs.unlinkSync(STATE_FILE);
+      return;
+    }
+
+    const providers = connected.map((provider) => {
+      const tree = provider.consumer.getTree(provider.subscriptionId);
+      return {
+        id: provider.id,
+        name: provider.name,
+        state: tree ? formatTree(tree) : "(no state yet)",
+      };
+    });
+
+    fs.writeFileSync(
+      STATE_FILE,
+      JSON.stringify({ lastUpdated: Date.now(), providers, available }, null, 2),
+    );
+  } catch (err) {
+    log.error("Failed to write state file:", err.message);
+  }
+}
+
+discovery.onStateChange(() => {
+  writeStateFile();
+});
+
+const TOOLS = [
+  {
+    name: "list_apps",
+    description:
+      "List SLOP-enabled applications currently available on this computer and whether they are already connected.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "connect_app",
+    description:
+      "Connect to an application and return its current state tree and available actions. " +
+      "Once connected, future user messages also receive the app's live state through Codex hook-based context injection.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        app: {
+          type: "string",
+          description: "App name or ID to connect and inspect.",
+        },
+      },
+      required: ["app"],
+    },
+  },
+  {
+    name: "disconnect_app",
+    description:
+      "Disconnect from an application when you're done interacting with it.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        app: {
+          type: "string",
+          description: "App name or ID to disconnect from.",
+        },
+      },
+      required: ["app"],
+    },
+  },
+  {
+    name: "app_action",
+    description:
+      "Perform a single affordance on an application. Use the exact path, action, and parameter names shown by connect_app or in the injected SLOP Apps context.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        app: {
+          type: "string",
+          description: "App name or ID.",
+        },
+        path: {
+          type: "string",
+          description: "Path to the node to act on, for example '/' or '/todos/todo-1'.",
+        },
+        action: {
+          type: "string",
+          description: "Action to perform, for example 'add_card', 'toggle', or 'delete'.",
+        },
+        params: {
+          type: "object",
+          description: "Optional action parameters.",
+          additionalProperties: true,
+        },
+      },
+      required: ["app", "path", "action"],
+    },
+  },
+  {
+    name: "app_action_batch",
+    description:
+      "Perform multiple affordances on an application in one call. Prefer this for repeated or bulk operations, using the exact paths and action names from connect_app or injected context.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        app: {
+          type: "string",
+          description: "App name or ID.",
+        },
+        actions: {
+          type: "array",
+          description: "Actions to perform sequentially.",
+          items: {
+            type: "object",
+            properties: {
+              path: {
+                type: "string",
+                description: "Path to the node to act on.",
+              },
+              action: {
+                type: "string",
+                description: "Action name.",
+              },
+              params: {
+                type: "object",
+                description: "Optional action parameters.",
+                additionalProperties: true,
+              },
+            },
+            required: ["path", "action"],
+          },
+        },
+      },
+      required: ["app", "actions"],
+    },
+  },
+];
+
+const server = new Server(
+  { name: "slop-bridge", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args = {} } = request.params;
+
+  try {
+    switch (name) {
+      case "list_apps":
+        return await handlers.listApps();
+
+      case "connect_app":
+        return await handlers.connectApp(args);
+
+      case "disconnect_app":
+        return await handlers.disconnectApp(args);
+
+      case "app_action": {
+        const provider = await discovery.ensureConnected(args.app);
+        if (!provider) {
+          return {
+            content: [{ type: "text", text: `App "${args.app}" not found or could not connect.` }],
+            isError: true,
+          };
+        }
+
+        try {
+          const result = await provider.consumer.invoke(
+            args.path,
+            args.action,
+            args.params ?? {},
+          );
+
+          if (result.status === "ok") {
+            return {
+              content: [{
+                type: "text",
+                text:
+                  `Done. ${args.action} on ${args.path} succeeded.` +
+                  (result.data ? ` Result: ${JSON.stringify(result.data)}` : ""),
+              }],
+            };
+          }
+
+          return {
+            content: [{
+              type: "text",
+              text: `Action failed: [${result.error?.code}] ${result.error?.message}`,
+            }],
+            isError: true,
+          };
+        } catch (err) {
+          return {
+            content: [{ type: "text", text: `Error: ${err.message}` }],
+            isError: true,
+          };
+        }
+      }
+
+      case "app_action_batch": {
+        const provider = await discovery.ensureConnected(args.app);
+        if (!provider) {
+          return {
+            content: [{ type: "text", text: `App "${args.app}" not found or could not connect.` }],
+            isError: true,
+          };
+        }
+
+        const results = [];
+        let failed = 0;
+
+        for (const { path, action, params } of args.actions) {
+          try {
+            const result = await provider.consumer.invoke(path, action, params ?? {});
+            if (result.status === "ok") {
+              results.push(`OK: ${action} on ${path}`);
+            } else {
+              failed++;
+              results.push(`FAIL: ${action} on ${path} — [${result.error?.code}] ${result.error?.message}`);
+            }
+          } catch (err) {
+            failed++;
+            results.push(`ERROR: ${action} on ${path} — ${err.message}`);
+          }
+        }
+
+        return {
+          content: [{
+            type: "text",
+            text:
+              `Batch complete: ${args.actions.length - failed}/${args.actions.length} succeeded.\n` +
+              results.join("\n"),
+          }],
+          isError: failed > 0,
+        };
+      }
+
+      default:
+        return {
+          content: [{ type: "text", text: `Unknown tool: ${name}` }],
+          isError: true,
+        };
+    }
+  } catch (err) {
+    return {
+      content: [{ type: "text", text: `Error: ${err.message}` }],
+      isError: true,
+    };
+  }
+});
+
+async function main() {
+  discovery.start();
+  log.info("Discovery started (local + bridge)");
+  writeStateFile();
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  log.info("MCP server running on stdio");
+
+  process.on("SIGINT", () => {
+    discovery.stop();
+    process.exit(0);
+  });
+  process.on("SIGTERM", () => {
+    discovery.stop();
+    process.exit(0);
+  });
+}
+
+main().catch((err) => {
+  log.error("Fatal:", err);
+  process.exit(1);
+});

--- a/packages/typescript/integrations/codex/slop/skills/slop-connect/SKILL.md
+++ b/packages/typescript/integrations/codex/slop/skills/slop-connect/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: slop-connect
+description: Connect Codex to SLOP-enabled applications and interact with them in real time. Use when the user asks to list apps, connect to an app, inspect a local or browser app, or control software that exposes SLOP state and actions.
+metadata:
+  priority: 8
+  pathPatterns:
+    - '.mcp.json'
+    - 'packages/typescript/integrations/codex/slop/**'
+  bashPatterns:
+    - '\blist_apps\b'
+    - '\bconnect_app\b'
+    - '\bdisconnect_app\b'
+    - '\bapp_action(_batch)?\b'
+retrieval:
+  aliases:
+    - slop
+    - slop app control
+    - connect to app
+    - list available apps
+    - control local app
+  intents:
+    - connect to an app
+    - inspect app state
+    - control a desktop app
+    - control a browser app
+  entities:
+    - SLOP
+    - list_apps
+    - connect_app
+    - disconnect_app
+    - app_action
+    - app_action_batch
+---
+
+# Connecting Codex to SLOP Apps
+
+SLOP (Semantic Live Observable Protocol) lets apps expose their live semantic state and actions to AI systems.
+This Codex plugin gives you five stable MCP tools for discovering apps, connecting them once, and invoking affordances while live state stays injected into future user turns.
+
+## Tools
+
+### `list_apps`
+
+Lists SLOP-enabled apps currently available on this computer, including:
+
+- local native apps discovered from `~/.slop/providers/`
+- session-scoped apps discovered from `/tmp/slop/providers/`
+- browser-announced apps discovered through the SLOP extension bridge
+
+### `connect_app`
+
+Connects to an app and returns:
+
+- the current formatted state tree
+- a summarized list of available actions
+
+This is the connection step. After an app is connected, the plugin injects its live state into future user prompts automatically. Call `connect_app` when you want to connect a new app, reconnect a dropped app, or force an immediate same-turn snapshot.
+
+### `disconnect_app`
+
+Disconnects from an app when you're done. Connections may also time out when idle.
+
+### `app_action`
+
+Performs one affordance on an app using:
+
+- `app`
+- `path`
+- `action`
+- optional `params`
+
+Use the exact path and action names that `connect_app` showed you or that the injected `## SLOP Apps` context shows on later turns.
+
+### `app_action_batch`
+
+Performs multiple affordances in one call. Prefer this when you need to add or update several things because it is faster and more reliable than issuing many single-action calls.
+
+## Workflow
+
+1. Call `list_apps` to discover what's available.
+2. Call `connect_app("name-or-id")` once to connect the target app and get an immediate snapshot.
+3. In the same turn, read the returned state tree carefully.
+4. On later turns, read the injected `## SLOP Apps` context before acting.
+5. Call `app_action` or `app_action_batch` with the exact paths and actions from the current tree.
+6. Re-run `connect_app` only when the app is not connected yet, looks stale, or needs to be reconnected.
+7. Call `disconnect_app` only when explicitly asked or when the task is clearly complete.
+
+## Reading the state tree
+
+The tree uses the canonical SLOP text format:
+
+```
+[type] id: Label (key=value, ...)  — "summary"  salience=0.90  actions: {action1(param: type), action2}
+  [type] child-id: Child Label (...)
+```
+
+Focus on:
+
+- node labels and IDs
+- high-salience nodes
+- affordances shown in `actions: {...}`
+- summaries on collapsed or windowed content
+
+## Important guidance
+
+- Inspect before acting. Do not guess action names or paths.
+- Treat injected `## SLOP Apps` context as the default source of truth on later turns.
+- Use the `connect_app` tool output as the source of truth in the same turn you first connect.
+- Use `app_action_batch` for repeated or bulk edits.
+- If an action is marked dangerous, ask the user before calling it.
+- Multiple apps can stay connected at once for cross-app workflows.
+- If a connection has gone stale, disappeared from injected context, or the app changed significantly, refresh with `connect_app`.

--- a/website/docs/content-manifest.mjs
+++ b/website/docs/content-manifest.mjs
@@ -74,6 +74,11 @@ export const docsPages = [
 		description: 'Connect Claude Code to SLOP-enabled applications with dynamic or generic action tools',
 		redirects: ['/guides-advanced/claude-code'],
 	}),
+	page('docs/guides/advanced/codex.md', 'guides/advanced/codex.md', {
+		label: 'Codex Integration',
+		description: 'Connect Codex to SLOP-enabled applications with injected live state and a fixed MCP tool surface',
+		redirects: ['/guides-advanced/codex'],
+	}),
 	page('docs/guides/advanced/openclaw.md', 'guides/advanced/openclaw.md', {
 		label: 'OpenClaw Integration',
 		description: 'Control SLOP-enabled applications through OpenClaw',
@@ -269,6 +274,7 @@ export const docsSidebar = [
 		items: [
 			pageItem('guides/advanced/agent-scaffolding', 'Agent-Assisted Integration'),
 			pageItem('guides/advanced/claude-code', 'Claude Code Integration'),
+			pageItem('guides/advanced/codex', 'Codex Integration'),
 			pageItem('guides/advanced/openclaw', 'OpenClaw Integration'),
 			pageItem('guides/advanced/benchmarks', 'Benchmarks: MCP vs SLOP'),
 		],

--- a/website/docs/src/content/docs/guides/advanced/claude-code.md
+++ b/website/docs/src/content/docs/guides/advanced/claude-code.md
@@ -165,4 +165,5 @@ All three integrations share the same underlying `@slop-ai/discovery` package. `
 
 - [Discovery & Bridge](/sdk/discovery) — the discovery layer this plugin builds on
 - [Consumer guide](/guides/consumer) — other SLOP consumers (CLI, Desktop, Extension)
+- [Codex integration](/guides/advanced/codex) — fixed-tool Codex plugin for SLOP app discovery and control
 - [OpenClaw integration](/guides/advanced/openclaw) — similar integration for OpenClaw

--- a/website/docs/src/content/docs/guides/advanced/codex.md
+++ b/website/docs/src/content/docs/guides/advanced/codex.md
@@ -1,0 +1,134 @@
+---
+title: "Codex Integration"
+description: "Connect Codex to SLOP-enabled applications with injected live state and a fixed MCP tool surface"
+---
+SLOP ships a Codex plugin at `packages/typescript/integrations/codex/slop`.
+
+It gives Codex five stable MCP tools for discovering and controlling SLOP-enabled applications:
+
+- `list_apps`
+- `connect_app`
+- `disconnect_app`
+- `app_action`
+- `app_action_batch`
+
+## What it does
+
+- **Discovers** SLOP apps from local provider descriptors and the browser extension bridge
+- **Connects** to Unix socket, WebSocket, and relay-backed providers through `@slop-ai/discovery`
+- **Injects live state** for connected apps on each future user prompt through a Codex hook
+- **Returns an immediate snapshot** through `connect_app`, including the current state tree and available actions
+- **Acts through stable meta-tools** so Codex has a predictable tool surface
+- **Supports multiple apps** connected simultaneously
+
+## Install
+
+Copy or symlink the plugin into your Codex plugins directory:
+
+```bash
+# From the repo root
+cp -r packages/typescript/integrations/codex/slop ~/.codex/plugins/slop
+```
+
+The plugin includes a bundled MCP bridge in `servers/dist/slop-bridge.bundle.mjs`, so the copied plugin can run as-is. To rebuild the bundle from source:
+
+```bash
+cd ~/.codex/plugins/slop/servers
+bun install
+bun run build
+```
+
+## How it works
+
+### MCP bridge
+
+The plugin's `.mcp.json` starts a local stdio MCP server:
+
+- command: `node`
+- cwd: `./servers`
+- entrypoint: `./dist/slop-bridge.bundle.mjs`
+
+That bridge wraps `@slop-ai/discovery` and exposes a fixed five-tool surface to Codex.
+
+### Hook-based state injection
+
+The bridge writes connected-provider state to `/tmp/codex-slop-plugin/state.json` whenever provider state changes. A bundled `UserPromptSubmit` hook reads that file and injects markdown into future Codex turns:
+
+````text
+## SLOP Apps
+
+1 app(s) connected. Read the state trees below before acting...
+
+### Kanban (kanban)
+
+```
+[collection] board: Sprint Board (...)
+  [collection] backlog: Backlog (...)  actions: {add_card(title: string)}
+```
+````
+
+The hook skips injection if the state file is older than 30 seconds, which prevents stale state from a dead MCP process from lingering in context.
+
+### Skill-guided workflow
+
+The bundled `slop-connect` skill teaches Codex the intended control loop:
+
+1. `list_apps`
+2. `connect_app("target-app")`
+3. inspect the returned same-turn state tree
+4. on later turns, read the injected `## SLOP Apps` context
+5. `app_action(...)` or `app_action_batch(...)`
+6. `disconnect_app(...)` when done
+
+Codex does not need to call `connect_app` before every action. `connect_app` is for establishing or refreshing a connection; once connected, the hook keeps the current state in context on future user turns.
+
+## Tools
+
+| Tool | Purpose |
+| --- | --- |
+| `list_apps` | List all discovered SLOP-enabled apps and show which are already connected |
+| `connect_app` | Connect to an app, return its current state tree plus action summary, and enroll it in injected context |
+| `disconnect_app` | Disconnect from an app |
+| `app_action` | Invoke one affordance on a node |
+| `app_action_batch` | Invoke multiple affordances in a single call |
+
+## Discovery sources
+
+| Source | Transport | How it's found |
+| --- | --- | --- |
+| `~/.slop/providers/*.json` | Unix socket or WebSocket | File watcher + periodic scan |
+| `/tmp/slop/providers/*.json` | Unix socket or WebSocket | File watcher + periodic scan |
+| Browser extension bridge | WebSocket or postMessage relay | Bridge client at `ws://127.0.0.1:9339/slop-bridge` |
+
+## Why the Codex plugin uses meta-tools
+
+The Codex integration currently chooses the same fixed-tool model as the OpenClaw plugin:
+
+- Codex gets a stable, predictable MCP tool catalog
+- the hook can inject live state without rebuilding tools on every patch
+- the skill can reliably teach the connect-once, inspect, then act workflow
+
+When Codex support for dynamic per-affordance tool flows becomes desirable, the same `@slop-ai/discovery` layer can be extended in that direction.
+
+## Example interaction
+
+```text
+User: What apps are available?
+→ Codex calls list_apps
+
+User: Connect to the kanban board
+→ Codex calls connect_app("kanban")
+
+User: Add three cards to the backlog
+→ Codex reads the injected Kanban tree from context, then calls app_action_batch with three add_card actions
+
+User: Disconnect from the kanban board
+→ Codex calls disconnect_app("kanban")
+```
+
+## Related
+
+- [Discovery & Bridge](/sdk/discovery) — shared discovery layer used by the plugin
+- [Consumer guide](/guides/consumer) — direct consumer usage patterns
+- [Claude Code integration](/guides/advanced/claude-code) — dynamic-tool and proxy variants for Claude
+- [OpenClaw integration](/guides/advanced/openclaw) — comparison integration using the same meta-tool pattern

--- a/website/docs/src/content/docs/guides/advanced/openclaw.md
+++ b/website/docs/src/content/docs/guides/advanced/openclaw.md
@@ -141,4 +141,5 @@ Both approaches give the model full context about available state and actions. T
 - [OpenClaw package API](/api/openclaw-plugin)
 - [Consumer SDK](/api/consumer)
 - [Discovery & Bridge](/sdk/discovery) — shared discovery layer
+- [Codex integration](/guides/advanced/codex) — fixed-tool Codex plugin using the same meta-tool pattern
 - [Claude Code integration](/guides/advanced/claude-code) — comparison integration

--- a/website/docs/src/content/docs/guides/consumer.md
+++ b/website/docs/src/content/docs/guides/consumer.md
@@ -311,6 +311,7 @@ The same pattern works well for a headless regression check: connect, subscribe 
 
 - [Consumer package API](/api/consumer)
 - [Discovery & Bridge](/sdk/discovery) — auto-discovery, extension bridge, relay transport, and state formatting for AI integrations
+- [Codex integration](/guides/advanced/codex) — Codex plugin for SLOP app discovery and control
 - [Claude Code integration](/guides/advanced/claude-code) — Claude Code plugin for SLOP app discovery and control
 - [Desktop app docs](/desktop/install)
 - [Chrome extension docs](/extension/install)

--- a/website/docs/src/content/docs/sdk/discovery.md
+++ b/website/docs/src/content/docs/sdk/discovery.md
@@ -295,10 +295,29 @@ Dynamic tools have proper parameter schemas from the provider's affordance defin
 
 | Host | Dynamic tools | Mechanism | Limitation |
 |---|---|---|---|
+| Codex | No (current plugin) | Stable MCP tools + `UserPromptSubmit` hook-based state injection | No runtime tool registration; actions still go through meta-tools |
 | Claude Code (MCP) | Yes | `notifications/tools/list_changed` — server notifies client when tool list changes | None |
 | OpenClaw | No | `api.registerTool()` is one-time during `register()` | No runtime tool registration API; tools must be declared in the plugin manifest |
 
-Hosts without dynamic tool support fall back to the **meta-tool pattern**: stable tools (`app_action`, `app_action_batch`) that resolve actions at runtime. The model knows exact paths and action names from state injection, so it gets the call right without guessing.
+Hosts without dynamic tool support fall back to the **meta-tool pattern**: stable tools (`app_action`, `app_action_batch`) that resolve actions at runtime. Depending on the host, the model learns the exact paths and action names from prompt-time state injection or from an explicit `connect_app` inspection step.
+
+### Codex plugin (`packages/typescript/integrations/codex/slop`)
+
+| Component | Purpose |
+|---|---|
+| **Tools** | `list_apps`, `connect_app`, `disconnect_app`, `app_action`, `app_action_batch` |
+| **Hook** (`UserPromptSubmit`) | Reads a shared state file and injects connected providers' trees into Codex on every user message |
+| **Skill** (`slop-connect`) | Teaches Codex the connect-once → inspect → act workflow |
+
+Design details:
+
+- **Fixed tool surface** — The Codex plugin exposes the same stable five-tool catalog as the OpenClaw plugin.
+- **Hook-based state injection** — The bridge writes provider state to `/tmp/codex-slop-plugin/state.json` on every state change. The `UserPromptSubmit` hook reads that file and injects fresh markdown into future turns.
+- **Immediate snapshot on connect** — `connect_app` still returns the current tree and actions right away, so Codex can act in the same turn it first connects.
+- **Discovery** — Uses `@slop-ai/discovery` with local descriptor watching plus browser bridge support.
+- **Multi-app** — Multiple providers can remain connected concurrently; `app_action` and `app_action_batch` resolve against the requested app ID.
+
+See [Codex guide](/guides/advanced/codex) for setup and usage.
 
 ### Claude Code integrations (`claude-slop-native`, `claude-slop-mcp-proxy`)
 
@@ -340,4 +359,5 @@ See [OpenClaw guide](/guides/advanced/openclaw) for setup and usage.
 - [Transport spec](/spec/core/transport) — wire protocol and discovery mechanisms
 - [Adapters spec](/spec/integrations/adapters) — bridging non-SLOP apps
 - [Consumer guide](/guides/consumer) — usage patterns and example workflows
+- [Codex guide](/guides/advanced/codex) — Codex plugin setup and usage
 - [Claude Code guide](/guides/advanced/claude-code) — Claude Code plugin setup and usage


### PR DESCRIPTION
## Summary

Adds a first-class Codex integration for SLOP under `packages/typescript/integrations/codex/slop`.

This bundle includes:

- a Codex plugin manifest and MCP wiring
- a fixed-tool SLOP bridge backed by `@slop-ai/discovery`
- hook-based state injection via `UserPromptSubmit`
- a Codex-native skill describing the connect-once and act workflow
- docs for the new Codex integration and updated discovery comparisons
- a `.gitignore` rule to keep local Codex marketplace test setup out of git

## Why

The previous Codex version was pull-based. This change aligns Codex with the preferred SLOP host pattern by keeping app state in context after connection, while still using stable meta-tools for action dispatch.

## User Impact

Codex can now:

- connect to SLOP-enabled apps once with `connect_app`
- read live app state from injected `## SLOP Apps` context on later turns
- act through `app_action` and `app_action_batch` without repeatedly re-fetching state

## Validation

- `bun run build` in `packages/typescript/integrations/codex/slop/servers`
- installed and verified the plugin locally in Codex
- confirmed the state-injection flow works in practice after `connect_app`
