### PR TITLE
Add core discovery parity across SDKs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,163 @@
+# Agent Guide
+
+- This repository is a multi-language monorepo for the SLOP protocol and SDKs.
+- Primary stacks are TypeScript/Bun, Go, Rust, Python, plus app/example code.
+- Prefer the smallest correct change and keep behavior aligned across SDKs when touching protocol logic.
+- `spec/` and `website/docs` are important source-of-truth areas, not just marketing content.
+
+## Repo-Specific Agent Rules
+
+- No repo-local Cursor rules were found in `.cursor/rules/` or `.cursorrules`.
+- No repo-local Copilot instructions were found in `.github/copilot-instructions.md`.
+- Do not assume ESLint, Prettier, Biome, Ruff, or golangci-lint are enforced here unless you add them intentionally.
+- Existing enforcement is mostly build, typecheck, generated-content checks, and tests.
+
+## Workspace Basics
+
+- Use `bun` for root workspace installs and most TypeScript tasks.
+- Root workspace packages live under `packages/typescript/`, plus apps, websites, examples, and benchmarks.
+- Python SDK lives in `packages/python/slop-ai`.
+- Go SDK lives in `packages/go/slop-ai`.
+- Rust SDK lives in `packages/rust/slop-ai`.
+- Desktop app frontend is in `apps/desktop`; native Tauri code is in `apps/desktop/src-tauri`.
+- Chrome extension is in `apps/extension`.
+- CLI inspector is Go code in `apps/cli`.
+
+## Core Commands
+
+- Install workspace JS dependencies: `bun install --frozen-lockfile`
+- Root TypeScript build: `bun run build`
+- Root TypeScript tests: `bun run test`
+- List scoped checks for current changes: `bun run preflight --list`
+- Run scoped checks for current worktree: `bun run preflight`
+- Run scoped checks since a base ref: `bun run preflight --since origin/main`
+- Run scoped checks for explicit paths: `bun run preflight --files path/to/file another/path`
+- There is no repo-wide `lint` script or repo-wide TS `typecheck` script.
+
+## Single-Test Recipes
+
+- Single Bun test file: `cd packages/typescript/sdk/core && bun test __tests__/tree-assembler.test.ts`
+- Another Bun single file example: `cd packages/typescript/adapters/react && bun test __tests__/use-slop.test.tsx`
+- TanStack Start single test file: `cd examples/full-stack/tanstack-start && bunx vitest run path/to/test-file.test.ts`
+- One Python test file: `cd packages/python/slop-ai && python -m pytest tests/test_server.py`
+- One Python test case: `cd packages/python/slop-ai && python -m pytest tests/test_server.py -k test_invoke`
+- One Go test: `cd packages/go/slop-ai && go test ./... -run '^TestInvoke$'`
+- One Rust test: `cd packages/rust/slop-ai && cargo test test_register_static`
+- Root `bun run test` is a loop over publishable TS packages; it is not the right command for a single test.
+- If you need a single test case, run the package-local runner and narrow further with Bun test-name filtering if needed.
+
+## App And Site Commands
+
+- Extension typecheck: `cd apps/extension && bun run typecheck`
+- Extension build: `cd apps/extension && bun run build`
+- Desktop frontend typecheck: `cd apps/desktop && bun run typecheck`
+- Desktop web bundle build: `cd apps/desktop && bun run vite:build`
+- Desktop full Tauri dev app: `cd apps/desktop && bun run dev`
+- Desktop full Tauri build: `cd apps/desktop && bun run build`
+- Docs generated-content check: `cd website/docs && bun run check:content`
+- Docs build: `cd website/docs && bun run build`
+- Landing/demo/playground build pattern: `cd website/<site> && bun run build`
+- TanStack Start example build/test: `cd examples/full-stack/tanstack-start && bun run build` and `bun run test`
+- Benchmarks: `cd benchmarks/mcp-vs-slop && bun run bench`
+
+## Python Commands
+
+- Install Python SDK in editable mode with test extras: `python -m pip install -e "packages/python/slop-ai[all]"`
+- Run Python SDK tests from repo root: `python -m pytest packages/python/slop-ai/tests`
+- Run Python SDK tests from package dir: `cd packages/python/slop-ai && python -m pytest tests`
+- There is no checked-in Ruff or Black config here.
+
+## Go Commands
+
+- Build Go CLI inspector: `cd apps/cli && go build -o slop-inspect .`
+- Run Go CLI inspector: `cd apps/cli && go run .`
+- Run Go SDK tests: `cd packages/go/slop-ai && go test ./...`
+- Use `go test` as both test and basic compile validation.
+- There is no checked-in golangci-lint config.
+
+## Rust Commands
+
+- Run Rust SDK tests: `cd packages/rust/slop-ai && cargo test`
+- Build Rust SDK: `cd packages/rust/slop-ai && cargo build`
+- Build desktop native side directly if needed: `cd apps/desktop/src-tauri && cargo build`
+- CI mainly validates Rust with `cargo test` in `packages/rust/slop-ai` and Tauri build via `apps/desktop`.
+
+## Change-Validation Expectations
+
+- Run the narrowest commands that cover the files you changed.
+- If you touch a publishable TS package, at minimum run that package's `bun run build` and relevant `bun test` commands.
+- Package-local TS command pattern: `cd packages/typescript/<group>/<pkg> && bun run build` and `bun test`
+- If you touch shared protocol behavior, inspect sibling SDKs and update tests/docs as needed.
+- If you touch `spec/` or docs generation inputs, run `cd website/docs && bun run check:content`.
+- If you touch desktop frontend code, run `cd apps/desktop && bun run typecheck`.
+- If you touch extension code, run `cd apps/extension && bun run typecheck`.
+- If you touch Python, Go, or Rust SDK code, run that language's package-local tests.
+- CI mainly enforces root TS build/test, extension typecheck/build, docs check/build, desktop typecheck plus unsigned Tauri build, and Python/Rust/Go SDK tests.
+
+## TypeScript Style
+
+- Use ESM imports and exports.
+- Use `import type` for type-only imports; this pattern is common across the TS packages.
+- Node built-ins should use the `node:` prefix.
+- Prefer named exports over default exports in library code, and re-export public API from package entrypoints.
+- Keep React component files in PascalCase like `TopBar.tsx` and module files in kebab-case like `tree-assembler.ts`.
+- Use 2-space indentation.
+- Use semicolons, double quotes, and trailing commas in multiline structures when nearby code does.
+- Favor explicit public types for package APIs.
+- `tsconfig` is strict in the TS packages and desktop app; preserve strict typing.
+- Avoid `any` unless the boundary is truly dynamic protocol data, and narrow unknown wire data at the boundary.
+- In tests, use Bun's `bun:test` APIs in publishable TS packages.
+- Do not add runtime dependencies to `@slop-ai/core` without a strong reason; it is treated as the low-level browser-safe core.
+
+## React And Frontend Style
+
+- Match the established style in each app instead of introducing a new design system.
+- Keep side-effect CSS imports separate and obvious.
+- Follow existing Zustand store patterns in desktop app code.
+- Prefer small components and state transitions over heavy abstractions; avoid premature memoization unless the surrounding code already relies on it.
+
+## Python Style
+
+- Use Python 3.10+ typing syntax throughout.
+- Keep `from __future__ import annotations` at the top when needed, use 4-space indentation, and keep stdlib imports before local imports.
+- Prefer module, class, and function docstrings for public surfaces.
+- Use `dict[str, Any]`, `list[T]`, and `Protocol` patterns rather than untyped containers.
+- Keep the runtime dependency surface minimal; the core package intentionally has zero required runtime dependencies.
+- Raise specific errors when possible; broad exception handling is acceptable only around connection fan-out, cleanup, or optional dependency boundaries.
+
+## Go Style
+
+- Let `gofmt` decide formatting.
+- Follow normal Go naming: exported identifiers in PascalCase, internal helpers in lowerCamelCase.
+- Keep `context.Context` as the first parameter in handler-style functions.
+- Return `error` values instead of panicking in library code, and use `fmt.Errorf` or structured logging for operational failures.
+- Preserve the existing `Handler` and `HandlerFunc` style that mirrors `net/http` patterns.
+- Use `map[string]any` only at JSON/wire boundaries.
+
+## Rust Style
+
+- Let `rustfmt` style drive formatting.
+- Use `snake_case` for modules and functions and `PascalCase` for types.
+- Prefer the crate's `Result<T>` alias and `SlopError` for fallible APIs.
+- Use `thiserror`-based typed errors, keep transport-specific code behind feature flags, and avoid new `unwrap()` calls in user-facing fallible paths.
+- Re-export stable public surface from `src/lib.rs`.
+
+## Error-Handling Conventions
+
+- Preserve structured protocol errors with codes and messages at transport boundaries.
+- Do not crash the whole server because one client connection failed to send.
+- Cleanup paths may warn/log and continue.
+- User-facing library APIs should prefer returning errors over printing directly.
+- When behavior changes, add or update tests that exercise both happy paths and protocol-error paths.
+
+## Cross-Language Consistency
+
+- The same protocol concepts exist in TS, Python, Go, and Rust implementations.
+- When changing descriptors, tree assembly, diffing, scaling, consumers, or affordance formatting, check whether the equivalent code exists in the other SDKs.
+- Do not update one SDK's protocol semantics casually if the others will drift.
+- If semantics intentionally change, update docs in `spec/` and relevant READMEs.
+
+## Generated And Special Files
+
+- `examples/full-stack/tanstack-start/src/routeTree.gen.ts` is generated by TanStack Router; avoid hand-editing it unless the generator workflow requires it.
+- `website/docs` content is partially generated; use `bun run check:content` to detect stale generated files.

--- a/docs/guides/go.md
+++ b/docs/guides/go.md
@@ -87,6 +87,31 @@ _, _ = consumer.Invoke(context.Background(), "/status", "restart", nil)
 fmt.Println(hello["provider"], subID, snapshot.ID)
 ```
 
+## Discovery layer
+
+The Go SDK also includes the core discovery layer in the `discovery` subpackage:
+
+```go
+import (
+	"context"
+	"fmt"
+
+	"github.com/devteapot/slop/packages/go/slop-ai/discovery"
+)
+
+svc := discovery.NewService(discovery.ServiceOptions{})
+svc.Start(context.Background())
+defer svc.Stop()
+
+provider, err := svc.EnsureConnected(context.Background(), "my-app")
+if err != nil {
+	panic(err)
+}
+if provider != nil {
+	fmt.Println(provider.Name)
+}
+```
+
 ## Next Steps
 
 - [Go package API](/api/go)

--- a/docs/guides/python.md
+++ b/docs/guides/python.md
@@ -95,6 +95,32 @@ asyncio.run(main())
 
 Unix consumer connections are available via `slop_ai.transports.unix_client.UnixClientTransport`.
 
+## Discovery layer
+
+The Python SDK also includes the core discovery layer in `slop_ai.discovery`:
+
+```python
+import asyncio
+
+from slop_ai.discovery import DiscoveryOptions, create_discovery_service
+
+
+async def main() -> None:
+    service = create_discovery_service(DiscoveryOptions())
+    await service.start()
+    try:
+        provider = await service.ensure_connected("my-app")
+        if provider is not None:
+            print(provider.name)
+    finally:
+        await service.stop()
+
+
+asyncio.run(main())
+```
+
+Install `slop-ai[websocket]` when discovery needs browser bridge support or direct WebSocket providers.
+
 ## Utilities
 
 The package also exports:

--- a/docs/guides/rust.md
+++ b/docs/guides/rust.md
@@ -254,6 +254,26 @@ let node = consumer.query("/todos", 1).await?;
 consumer.disconnect();
 ```
 
+## Discovery layer
+
+The Rust SDK also includes the core discovery layer in `slop_ai::discovery` under the default `native` feature set:
+
+```rust
+use slop_ai::discovery::{DiscoveryService, DiscoveryServiceOptions};
+
+#[tokio::main]
+async fn main() {
+    let service = DiscoveryService::new(DiscoveryServiceOptions::default());
+    service.start().await;
+
+    if let Ok(Some(provider)) = service.ensure_connected("my-app").await {
+        println!("{}", provider.name);
+    }
+
+    service.stop().await;
+}
+```
+
 ## Scaling
 
 Prepare trees for output with depth truncation, salience filtering, and node-budget compaction:

--- a/docs/sdk/discovery.md
+++ b/docs/sdk/discovery.md
@@ -287,32 +287,32 @@ Consumers can use this to maintain a cache, update a UI, or trigger context inje
 | Language | Consumer SDK | Core discovery module | Current status |
 |---|---|---|---|
 | TypeScript | `@slop-ai/consumer` | `@slop-ai/discovery` | Reference implementation for phase 1, plus host-specific helpers outside the shared contract |
-| Python | `slop-ai` | `slop_ai.discovery` | Planned |
+| Python | `slop-ai` | `slop_ai.discovery` | Initial phase-1 implementation shipped in the SDK and normalized to the shared contract |
 | Go | `slop-ai` | `github.com/devteapot/slop/packages/go/slop-ai/discovery` | Initial phase-1 implementation shipped in the SDK and normalized to the shared contract |
-| Rust | `slop-ai` | `slop_ai::discovery` | Planned extraction from `apps/desktop`, then normalization to the TypeScript contract |
+| Rust | `slop-ai` | `slop_ai::discovery` | Initial phase-1 implementation shipped in the SDK and normalized to the shared contract |
 
 ### Phase 1 capability matrix
 
 | Capability | TypeScript | Python | Go | Rust |
 |---|---|---|---|---|
-| Local provider scanning | Shipped | Planned | Shipped | Partial |
-| Descriptor validation and pruning | Shipped | Planned | Shipped | Partial |
-| Directory watch + 15s fallback scan | Shipped | Planned | Shipped | Partial |
-| Bridge client | Shipped | Planned | Shipped | Planned |
-| Bridge server | Shipped | Planned | Shipped | Partial |
-| Client-first / server-fallback startup | Shipped | Planned | Shipped | Planned |
-| Relay transport | Shipped | Planned | Shipped | Partial |
-| Discovery service / connection orchestration | Shipped | Planned | Shipped | Partial |
-| Lazy connect + `ensureConnected()` | Shipped | Planned | Shipped | Partial |
-| Auto-connect mode | Shipped | Planned | Shipped | Planned |
-| Idle timeout | Shipped | Planned | Shipped | Planned |
-| Reconnect backoff | Shipped | Planned | Shipped | Planned |
-| Connection timeout | Shipped | Planned | Shipped | Partial |
-| State change callback | Shipped | Planned | Shipped | Partial |
+| Local provider scanning | Shipped | Shipped | Shipped | Shipped |
+| Descriptor validation and pruning | Shipped | Shipped | Shipped | Shipped |
+| Directory watch + 15s fallback scan | Shipped | Shipped | Shipped | Shipped |
+| Bridge client | Shipped | Shipped | Shipped | Shipped |
+| Bridge server | Shipped | Shipped | Shipped | Shipped |
+| Client-first / server-fallback startup | Shipped | Shipped | Shipped | Shipped |
+| Relay transport | Shipped | Shipped | Shipped | Shipped |
+| Discovery service / connection orchestration | Shipped | Shipped | Shipped | Shipped |
+| Lazy connect + `ensureConnected()` | Shipped | Shipped | Shipped | Shipped |
+| Auto-connect mode | Shipped | Shipped | Shipped | Shipped |
+| Idle timeout | Shipped | Shipped | Shipped | Shipped |
+| Reconnect backoff | Shipped | Shipped | Shipped | Shipped |
+| Connection timeout | Shipped | Shipped | Shipped | Shipped |
+| State change callback | Shipped | Shipped | Shipped | Shipped |
 | `formatTree()` | Shipped | Shipped | Shipped | Shipped |
 | `affordancesToTools()` | Shipped | Shipped | Shipped | Shipped |
-| `createToolHandlers()` | Shipped | Planned | Shipped | Planned |
-| `createDynamicTools()` | Shipped | Planned | Shipped | Planned |
+| `createToolHandlers()` | Shipped | Shipped | Shipped | Shipped |
+| `createDynamicTools()` | Shipped | Shipped | Shipped | Shipped |
 | Host wrappers and prompt injection glue | Shipped | Out of scope | Out of scope | Out of scope |
 | State cache / shared file helpers | Shipped | Out of scope | Out of scope | Out of scope |
 

--- a/docs/sdk/discovery.md
+++ b/docs/sdk/discovery.md
@@ -38,6 +38,55 @@ Integrations (Claude Code plugin, OpenClaw plugin, VS Code extension, custom age
 
 Integrations that only need discovery + MCP (e.g. `slop-bridge` with the MCP SDK) import from the **default** export and do not need `anthropic-agent-sdk`.
 
+## Phase 1: Core Discovery Layer
+
+The current cross-SDK parity target is the **core discovery layer**. The TypeScript implementation is the behavioral reference, but other SDKs do **not** need to copy its package topology.
+
+- TypeScript reference files: `packages/typescript/integrations/discovery/src/discovery.ts`, `bridge-client.ts`, `bridge-server.ts`, `relay-transport.ts`, and `tools.ts`
+- Python target module: `slop_ai.discovery`
+- Go target package: `github.com/devteapot/slop/packages/go/slop-ai/discovery`
+- Rust target module: `slop_ai::discovery`
+
+Python, Go, and Rust keep discovery inside their existing SDK artifact. Only TypeScript publishes discovery as a separate package.
+
+### Phase 1 scope
+
+Phase 1 includes:
+
+- Local provider scanning (`~/.slop/providers/` + `/tmp/slop/providers/`)
+- Descriptor validation and pruning when descriptors disappear
+- Directory watching with periodic fallback scan
+- Bridge client
+- Bridge server
+- "Try client first, fall back to server" bridge startup
+- Relay transport for `postmessage` providers
+- Discovery service / connection orchestration
+- Lazy connect with `ensureConnected()`
+- Auto-connect mode
+- Idle timeout (5 minutes default)
+- Exponential backoff reconnection
+- Connection timeout (10 seconds)
+- State change callback
+- `formatTree()`
+- `affordancesToTools()`
+- `createToolHandlers()`
+- `createDynamicTools()`
+
+Phase 1 explicitly excludes:
+
+- Host-specific wrappers such as `cli.ts` and `anthropic-agent-sdk.ts`
+- Prompt/hook integration glue for Claude Code, Codex, OpenClaw, or other hosts
+- File-cache helpers such as `createStateCache()`
+
+### Status labels
+
+| Label | Meaning |
+|---|---|
+| `Shipped` | Implemented in the SDK artifact with the current contract |
+| `Partial` | Code exists, but only in app code or with behavior drift from the contract |
+| `Planned` | Not implemented yet |
+| `Out of scope` | Intentionally excluded from phase 1 |
+
 ## Provider Discovery
 
 ### Local providers
@@ -235,16 +284,62 @@ Consumers can use this to maintain a cache, update a UI, or trigger context inje
 
 ## SDK Implementations
 
-| Language | Consumer SDK | Discovery Layer | Status |
+| Language | Consumer SDK | Core discovery module | Current status |
 |---|---|---|---|
-| TypeScript | `@slop-ai/consumer` | `@slop-ai/discovery` | Bridge client + server, relay, auto-connect, state cache |
-| Python | `slop-ai` | — | Planned |
-| Go | `slop-ai` | `apps/cli/bridge` + `apps/cli/provider` (to be extracted) | Bridge client + server exist in CLI, not packaged as library |
-| Rust | `slop-ai` | `apps/desktop/src-tauri/src/bridge` (to be extracted) | Bridge server exists in Desktop, not packaged as library |
+| TypeScript | `@slop-ai/consumer` | `@slop-ai/discovery` | Reference implementation for phase 1, plus host-specific helpers outside the shared contract |
+| Python | `slop-ai` | `slop_ai.discovery` | Planned |
+| Go | `slop-ai` | `github.com/devteapot/slop/packages/go/slop-ai/discovery` | Initial phase-1 implementation shipped in the SDK and normalized to the shared contract |
+| Rust | `slop-ai` | `slop_ai::discovery` | Planned extraction from `apps/desktop`, then normalization to the TypeScript contract |
+
+### Phase 1 capability matrix
+
+| Capability | TypeScript | Python | Go | Rust |
+|---|---|---|---|---|
+| Local provider scanning | Shipped | Planned | Shipped | Partial |
+| Descriptor validation and pruning | Shipped | Planned | Shipped | Partial |
+| Directory watch + 15s fallback scan | Shipped | Planned | Shipped | Partial |
+| Bridge client | Shipped | Planned | Shipped | Planned |
+| Bridge server | Shipped | Planned | Shipped | Partial |
+| Client-first / server-fallback startup | Shipped | Planned | Shipped | Planned |
+| Relay transport | Shipped | Planned | Shipped | Partial |
+| Discovery service / connection orchestration | Shipped | Planned | Shipped | Partial |
+| Lazy connect + `ensureConnected()` | Shipped | Planned | Shipped | Partial |
+| Auto-connect mode | Shipped | Planned | Shipped | Planned |
+| Idle timeout | Shipped | Planned | Shipped | Planned |
+| Reconnect backoff | Shipped | Planned | Shipped | Planned |
+| Connection timeout | Shipped | Planned | Shipped | Partial |
+| State change callback | Shipped | Planned | Shipped | Partial |
+| `formatTree()` | Shipped | Shipped | Shipped | Shipped |
+| `affordancesToTools()` | Shipped | Shipped | Shipped | Shipped |
+| `createToolHandlers()` | Shipped | Planned | Shipped | Planned |
+| `createDynamicTools()` | Shipped | Planned | Shipped | Planned |
+| Host wrappers and prompt injection glue | Shipped | Out of scope | Out of scope | Out of scope |
+| State cache / shared file helpers | Shipped | Out of scope | Out of scope | Out of scope |
+
+### Known donor-code drift
+
+The Go CLI and Rust Desktop codebases are useful donor implementations, but they are **not** the behavioral contract. New SDK modules should match the TypeScript phase-1 semantics above, even when that means changing extracted code.
+
+#### Go donor drift (`apps/cli`)
+
+- `apps/cli/bridge/server.go` forwards `provider-available`, `provider-unavailable`, and `slop-relay`, but does not yet forward `relay-open` and `relay-close`
+- `apps/cli/bridge/client.go` does not maintain a reconnect loop after bridge disconnects
+- `apps/cli/main.go` tries client first, but on bind failure it disables the bridge instead of retrying as a client after a port race
+- `apps/cli/bridge/relay.go` opens the relay and returns immediately; it does not yet match the TypeScript relay handshake retry and early-message buffering behavior
+- `apps/cli/tui/discovery.go` refreshes via TUI polling instead of a reusable discovery service with directory watchers, pruning, idle timeout, and reconnect backoff
+- `apps/cli/provider/discovery.go` filters dead PIDs today; extraction should keep only behavior that is explicitly part of the shared contract
+
+#### Rust donor drift (`apps/desktop/src-tauri`)
+
+- `apps/desktop/src-tauri/src/bridge/mod.rs` is coupled to `tauri::AppHandle`, app events, and desktop registry state, so it cannot be extracted as-is into the SDK
+- `apps/desktop/src-tauri/src/provider/mod.rs` sends `relay-open` and a single `connect`, but does not yet match the TypeScript relay handshake retry and early-message buffering behavior
+- `apps/desktop/src-tauri/src/provider/discovery.rs` only scans descriptor files; it does not yet implement the full watcher, fallback-rescan, validation, and pruning behavior
+- `apps/desktop/src-tauri/src/provider/mod.rs` ingests discovered and bridge providers additively; extraction should also handle descriptor disappearance and bridge provider removal using the shared contract
+- The desktop app currently hosts a bridge server, but it does not provide a reusable bridge client or the full client-first / server-fallback startup flow
 
 ### Implementation checklist for new SDKs
 
-A complete discovery layer implementation provides:
+A complete phase-1 discovery layer implementation provides:
 
 - [ ] Local provider scanning (`~/.slop/providers/` + `/tmp/slop/providers/`)
 - [ ] Directory watching with periodic fallback scan
@@ -261,7 +356,8 @@ A complete discovery layer implementation provides:
 - [ ] Connection timeout (10 seconds)
 - [ ] State change callback
 - [ ] Dynamic tool generation (`createDynamicTools()` equivalent)
-- [ ] State injection for host context (hook or prompt prepend)
+
+Host-specific wrappers and prompt injection are intentionally outside phase 1.
 
 ## Integrations
 

--- a/packages/go/slop-ai/README.md
+++ b/packages/go/slop-ai/README.md
@@ -47,8 +47,33 @@ That mounts:
 
 - `Server`, `ScopedServer`, and `RegisterFunc` for providers
 - `Consumer` plus WebSocket and Unix client transports
+- `discovery` subpackage for provider scanning, bridge relay, lazy/auto-connect, and AI-facing tool helpers
 - stdio and Unix transports for local tools
 - scaling helpers and LLM tool formatting helpers
+
+## Discovery layer
+
+The Go SDK now includes the core discovery layer in the `discovery` subpackage:
+
+```go
+import (
+	"context"
+
+	"github.com/devteapot/slop/packages/go/slop-ai/discovery"
+)
+
+svc := discovery.NewService(discovery.ServiceOptions{})
+svc.Start(context.Background())
+defer svc.Stop()
+
+provider, err := svc.EnsureConnected(context.Background(), "my-app")
+if err != nil {
+	panic(err)
+}
+if provider != nil {
+	println(provider.Name)
+}
+```
 
 ## Documentation
 

--- a/packages/go/slop-ai/discovery/bridge.go
+++ b/packages/go/slop-ai/discovery/bridge.go
@@ -1,0 +1,81 @@
+package discovery
+
+// BridgeProvider represents a provider announced through the extension bridge.
+type BridgeProvider struct {
+	ProviderKey string
+	TabID       int
+	ID          string
+	Name        string
+	Transport   string
+	URL         string
+}
+
+// Bridge is the common interface shared by the bridge client and server.
+type Bridge interface {
+	Running() bool
+	Providers() []BridgeProvider
+	OnProviderChange(fn func())
+	SubscribeRelay(providerKey string) chan map[string]any
+	UnsubscribeRelay(providerKey string, ch chan map[string]any)
+	Send(msg map[string]any) error
+	Stop()
+}
+
+func parseBridgeProvider(msg map[string]any) (BridgeProvider, bool) {
+	providerKey, _ := msg["providerKey"].(string)
+	if providerKey == "" {
+		return BridgeProvider{}, false
+	}
+
+	tabID := 0
+	switch value := msg["tabId"].(type) {
+	case float64:
+		tabID = int(value)
+	case int:
+		tabID = value
+	case int64:
+		tabID = int(value)
+	}
+
+	provider, _ := msg["provider"].(map[string]any)
+	transport, _ := provider["transport"].(string)
+	if transport == "" {
+		transport = "postmessage"
+	}
+
+	id, _ := provider["id"].(string)
+	if id == "" {
+		id = providerKey
+	}
+	name, _ := provider["name"].(string)
+	if name == "" {
+		name = "Tab"
+	}
+	url, _ := provider["url"].(string)
+
+	return BridgeProvider{
+		ProviderKey: providerKey,
+		TabID:       tabID,
+		ID:          id,
+		Name:        name,
+		Transport:   transport,
+		URL:         url,
+	}, true
+}
+
+func bridgeProviderToDescriptor(provider BridgeProvider) ProviderDescriptor {
+	transport := TransportDescriptor{Type: "relay"}
+	if provider.Transport == "ws" && provider.URL != "" {
+		transport = TransportDescriptor{Type: "ws", URL: provider.URL}
+	}
+
+	return ProviderDescriptor{
+		ID:           provider.ProviderKey,
+		Name:         provider.Name,
+		SlopVersion:  "1.0",
+		Transport:    transport,
+		Capabilities: []string{},
+		ProviderKey:  provider.ProviderKey,
+		Source:       SourceBridge,
+	}
+}

--- a/packages/go/slop-ai/discovery/bridge_client.go
+++ b/packages/go/slop-ai/discovery/bridge_client.go
@@ -1,0 +1,338 @@
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"nhooyr.io/websocket"
+)
+
+// BridgeClient connects to an existing bridge server and mirrors provider announcements.
+type BridgeClient struct {
+	url            string
+	logger         Logger
+	reconnectDelay time.Duration
+
+	mu               sync.RWMutex
+	conn             *websocket.Conn
+	connCtx          context.Context
+	connCancel       context.CancelFunc
+	providers        map[string]BridgeProvider
+	relaySubscribers map[string][]chan map[string]any
+	running          bool
+	started          bool
+	onProviderChange func()
+	ctx              context.Context
+	cancel           context.CancelFunc
+	reconnectTimer   *time.Timer
+}
+
+// NewBridgeClient creates a bridge client for the given URL.
+func NewBridgeClient(url string, logger Logger) *BridgeClient {
+	return &BridgeClient{
+		url:              url,
+		logger:           logger,
+		reconnectDelay:   defaultBridgeReconnectWait,
+		providers:        map[string]BridgeProvider{},
+		relaySubscribers: map[string][]chan map[string]any{},
+	}
+}
+
+// ConnectOnce attempts a single connection to the bridge.
+func (c *BridgeClient) ConnectOnce(ctx context.Context) error {
+	return c.connect(ctx)
+}
+
+// Start enables the reconnect loop and keeps the bridge client running until ctx is cancelled.
+func (c *BridgeClient) Start(ctx context.Context) {
+	c.mu.Lock()
+	if c.started {
+		c.mu.Unlock()
+		return
+	}
+	c.ctx, c.cancel = context.WithCancel(ctx)
+	c.started = true
+	alreadyConnected := c.conn != nil
+	c.mu.Unlock()
+
+	if alreadyConnected {
+		return
+	}
+
+	go c.tryConnect()
+}
+
+// Stop closes the bridge client and clears mirrored state.
+func (c *BridgeClient) Stop() {
+	c.mu.Lock()
+	if c.reconnectTimer != nil {
+		c.reconnectTimer.Stop()
+		c.reconnectTimer = nil
+	}
+	if c.cancel != nil {
+		c.cancel()
+		c.cancel = nil
+	}
+	conn := c.conn
+	connCancel := c.connCancel
+	providersChanged := len(c.providers) > 0
+	for key, subs := range c.relaySubscribers {
+		for _, ch := range subs {
+			close(ch)
+		}
+		delete(c.relaySubscribers, key)
+	}
+	c.providers = map[string]BridgeProvider{}
+	c.conn = nil
+	c.connCtx = nil
+	c.connCancel = nil
+	c.running = false
+	c.started = false
+	onChange := c.onProviderChange
+	c.mu.Unlock()
+
+	if connCancel != nil {
+		connCancel()
+	}
+	if conn != nil {
+		_ = conn.Close(websocket.StatusNormalClosure, "")
+	}
+	if providersChanged && onChange != nil {
+		onChange()
+	}
+}
+
+func (c *BridgeClient) Running() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.running
+}
+
+func (c *BridgeClient) Providers() []BridgeProvider {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	providers := make([]BridgeProvider, 0, len(c.providers))
+	for _, provider := range c.providers {
+		providers = append(providers, provider)
+	}
+	return providers
+}
+
+func (c *BridgeClient) OnProviderChange(fn func()) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onProviderChange = fn
+}
+
+func (c *BridgeClient) SubscribeRelay(providerKey string) chan map[string]any {
+	ch := make(chan map[string]any, 64)
+	c.mu.Lock()
+	c.relaySubscribers[providerKey] = append(c.relaySubscribers[providerKey], ch)
+	c.mu.Unlock()
+	return ch
+}
+
+func (c *BridgeClient) UnsubscribeRelay(providerKey string, ch chan map[string]any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	subs := c.relaySubscribers[providerKey]
+	for index, sub := range subs {
+		if sub == ch {
+			c.relaySubscribers[providerKey] = append(subs[:index], subs[index+1:]...)
+			break
+		}
+	}
+	if len(c.relaySubscribers[providerKey]) == 0 {
+		delete(c.relaySubscribers, providerKey)
+	}
+	close(ch)
+}
+
+func (c *BridgeClient) Send(msg map[string]any) error {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+
+	c.mu.RLock()
+	conn := c.conn
+	connCtx := c.connCtx
+	c.mu.RUnlock()
+	if conn == nil || connCtx == nil {
+		return fmt.Errorf("bridge client is not connected")
+	}
+
+	return conn.Write(connCtx, websocket.MessageText, data)
+}
+
+func (c *BridgeClient) connect(ctx context.Context) error {
+	c.mu.Lock()
+	if c.conn != nil {
+		c.mu.Unlock()
+		return nil
+	}
+	c.mu.Unlock()
+
+	conn, _, err := websocket.Dial(ctx, c.url, nil)
+	if err != nil {
+		return err
+	}
+
+	connCtx, connCancel := context.WithCancel(context.Background())
+
+	c.mu.Lock()
+	if c.conn != nil {
+		c.mu.Unlock()
+		connCancel()
+		_ = conn.Close(websocket.StatusNormalClosure, "")
+		return nil
+	}
+	c.conn = conn
+	c.connCtx = connCtx
+	c.connCancel = connCancel
+	c.running = true
+	c.mu.Unlock()
+
+	c.logger.infof("[slop-bridge] Connected to existing bridge at %s", c.url)
+	go c.readLoop(conn, connCtx, connCancel)
+	return nil
+}
+
+func (c *BridgeClient) tryConnect() {
+	c.mu.RLock()
+	ctx := c.ctx
+	started := c.started
+	c.mu.RUnlock()
+	if !started || ctx == nil {
+		return
+	}
+
+	dialCtx, cancel := context.WithTimeout(ctx, defaultBridgeDialTimeout)
+	err := c.connect(dialCtx)
+	cancel()
+	if err != nil {
+		c.scheduleReconnect()
+	}
+}
+
+func (c *BridgeClient) scheduleReconnect() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.started || c.ctx == nil || c.ctx.Err() != nil || c.reconnectTimer != nil {
+		return
+	}
+	c.reconnectTimer = time.AfterFunc(c.reconnectDelay, func() {
+		c.mu.Lock()
+		c.reconnectTimer = nil
+		c.mu.Unlock()
+		c.tryConnect()
+	})
+}
+
+func (c *BridgeClient) readLoop(conn *websocket.Conn, connCtx context.Context, connCancel context.CancelFunc) {
+	defer connCancel()
+	for {
+		_, data, err := conn.Read(connCtx)
+		if err != nil {
+			c.handleDisconnect(conn)
+			return
+		}
+		var msg map[string]any
+		if err := json.Unmarshal(data, &msg); err != nil {
+			continue
+		}
+		c.handleMessage(msg)
+	}
+}
+
+func (c *BridgeClient) handleDisconnect(conn *websocket.Conn) {
+	c.mu.Lock()
+	if c.conn != conn {
+		c.mu.Unlock()
+		return
+	}
+	c.conn = nil
+	c.connCtx = nil
+	c.connCancel = nil
+	providersChanged := len(c.providers) > 0
+	c.providers = map[string]BridgeProvider{}
+	for key, subs := range c.relaySubscribers {
+		for _, ch := range subs {
+			close(ch)
+		}
+		delete(c.relaySubscribers, key)
+	}
+	c.running = false
+	started := c.started
+	onChange := c.onProviderChange
+	c.mu.Unlock()
+
+	if providersChanged && onChange != nil {
+		onChange()
+	}
+	if started {
+		c.scheduleReconnect()
+	}
+}
+
+func (c *BridgeClient) handleMessage(msg map[string]any) {
+	msgType, _ := msg["type"].(string)
+
+	switch msgType {
+	case "provider-available":
+		provider, ok := parseBridgeProvider(msg)
+		if !ok {
+			return
+		}
+		c.mu.Lock()
+		c.providers[provider.ProviderKey] = provider
+		onChange := c.onProviderChange
+		c.mu.Unlock()
+		if onChange != nil {
+			onChange()
+		}
+
+	case "provider-unavailable":
+		providerKey, _ := msg["providerKey"].(string)
+		if providerKey == "" {
+			return
+		}
+		c.mu.Lock()
+		delete(c.providers, providerKey)
+		if subs, ok := c.relaySubscribers[providerKey]; ok {
+			for _, ch := range subs {
+				close(ch)
+			}
+			delete(c.relaySubscribers, providerKey)
+		}
+		onChange := c.onProviderChange
+		c.mu.Unlock()
+		if onChange != nil {
+			onChange()
+		}
+
+	case "slop-relay":
+		providerKey, _ := msg["providerKey"].(string)
+		message, _ := msg["message"].(map[string]any)
+		if providerKey == "" || message == nil {
+			return
+		}
+		c.dispatchRelay(providerKey, message)
+	}
+}
+
+func (c *BridgeClient) dispatchRelay(providerKey string, message map[string]any) {
+	c.mu.RLock()
+	subs := append([]chan map[string]any(nil), c.relaySubscribers[providerKey]...)
+	c.mu.RUnlock()
+
+	for _, ch := range subs {
+		select {
+		case ch <- message:
+		default:
+		}
+	}
+}

--- a/packages/go/slop-ai/discovery/bridge_server.go
+++ b/packages/go/slop-ai/discovery/bridge_server.go
@@ -1,0 +1,380 @@
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+
+	"nhooyr.io/websocket"
+)
+
+type wsSink struct {
+	conn *websocket.Conn
+	mu   sync.Mutex
+}
+
+func (s *wsSink) write(ctx context.Context, payload []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.conn.Write(ctx, websocket.MessageText, payload)
+}
+
+// BridgeServer hosts the extension bridge and mirrors bridge providers for local consumers.
+type BridgeServer struct {
+	addr   string
+	path   string
+	logger Logger
+
+	mu               sync.RWMutex
+	providers        map[string]BridgeProvider
+	relaySubscribers map[string][]chan map[string]any
+	sinks            map[*wsSink]struct{}
+	httpServer       *http.Server
+	listener         net.Listener
+	actualAddr       string
+	running          bool
+	onProviderChange func()
+	cancel           context.CancelFunc
+	ctx              context.Context
+}
+
+// NewBridgeServer creates a new bridge server.
+func NewBridgeServer(addr, path string, logger Logger) *BridgeServer {
+	return &BridgeServer{
+		addr:             addr,
+		path:             path,
+		logger:           logger,
+		providers:        map[string]BridgeProvider{},
+		relaySubscribers: map[string][]chan map[string]any{},
+		sinks:            map[*wsSink]struct{}{},
+	}
+}
+
+// Start binds the bridge server and begins serving in the background.
+func (s *BridgeServer) Start(ctx context.Context) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc(s.path, s.handleUpgrade)
+
+	listener, err := net.Listen("tcp", s.addr)
+	if err != nil {
+		return err
+	}
+
+	serverCtx, cancel := context.WithCancel(ctx)
+	httpServer := &http.Server{Handler: mux}
+
+	s.mu.Lock()
+	s.listener = listener
+	s.actualAddr = listener.Addr().String()
+	s.ctx = serverCtx
+	s.cancel = cancel
+	s.httpServer = httpServer
+	s.running = true
+	s.mu.Unlock()
+
+	go func() {
+		<-serverCtx.Done()
+		_ = httpServer.Close()
+	}()
+
+	go func() {
+		err := httpServer.Serve(listener)
+		if err != nil && err != http.ErrServerClosed {
+			s.logger.errorf("[slop-bridge] Server error: %v", err)
+		}
+	}()
+
+	s.logger.infof("[slop-bridge] Bridge server running on %s", s.URL())
+	return nil
+}
+
+// URL returns the current bridge URL.
+func (s *BridgeServer) URL() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	addr := s.actualAddr
+	if addr == "" {
+		addr = s.addr
+	}
+	return fmt.Sprintf("ws://%s%s", addr, s.path)
+}
+
+func (s *BridgeServer) Stop() {
+	s.mu.Lock()
+	if s.cancel != nil {
+		s.cancel()
+	}
+	listener := s.listener
+	httpServer := s.httpServer
+	s.running = false
+	s.listener = nil
+	s.httpServer = nil
+	providersChanged := len(s.providers) > 0
+	for key, subs := range s.relaySubscribers {
+		for _, ch := range subs {
+			close(ch)
+		}
+		delete(s.relaySubscribers, key)
+	}
+	s.providers = map[string]BridgeProvider{}
+	sinks := make([]*wsSink, 0, len(s.sinks))
+	for sink := range s.sinks {
+		sinks = append(sinks, sink)
+		delete(s.sinks, sink)
+	}
+	onChange := s.onProviderChange
+	s.mu.Unlock()
+
+	if listener != nil {
+		_ = listener.Close()
+	}
+	if httpServer != nil {
+		_ = httpServer.Close()
+	}
+	for _, sink := range sinks {
+		_ = sink.conn.Close(websocket.StatusNormalClosure, "")
+	}
+	if providersChanged && onChange != nil {
+		onChange()
+	}
+}
+
+func (s *BridgeServer) Running() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.running
+}
+
+func (s *BridgeServer) Providers() []BridgeProvider {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	providers := make([]BridgeProvider, 0, len(s.providers))
+	for _, provider := range s.providers {
+		providers = append(providers, provider)
+	}
+	return providers
+}
+
+func (s *BridgeServer) OnProviderChange(fn func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.onProviderChange = fn
+}
+
+func (s *BridgeServer) SubscribeRelay(providerKey string) chan map[string]any {
+	ch := make(chan map[string]any, 64)
+	s.mu.Lock()
+	s.relaySubscribers[providerKey] = append(s.relaySubscribers[providerKey], ch)
+	s.mu.Unlock()
+	return ch
+}
+
+func (s *BridgeServer) UnsubscribeRelay(providerKey string, ch chan map[string]any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	subs := s.relaySubscribers[providerKey]
+	for index, sub := range subs {
+		if sub == ch {
+			s.relaySubscribers[providerKey] = append(subs[:index], subs[index+1:]...)
+			break
+		}
+	}
+	if len(s.relaySubscribers[providerKey]) == 0 {
+		delete(s.relaySubscribers, providerKey)
+	}
+	close(ch)
+}
+
+func (s *BridgeServer) Send(msg map[string]any) error {
+	return s.broadcast(msg)
+}
+
+func (s *BridgeServer) broadcast(msg map[string]any) error {
+	payload, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+
+	s.mu.RLock()
+	ctx := s.ctx
+	sinks := make([]*wsSink, 0, len(s.sinks))
+	for sink := range s.sinks {
+		sinks = append(sinks, sink)
+	}
+	s.mu.RUnlock()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	for _, sink := range sinks {
+		if err := sink.write(ctx, payload); err != nil {
+			s.logger.errorf("[slop-bridge] Broadcast failed: %v", err)
+		}
+	}
+	return nil
+}
+
+func (s *BridgeServer) handleUpgrade(w http.ResponseWriter, r *http.Request) {
+	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+	if err != nil {
+		return
+	}
+
+	sink := &wsSink{conn: conn}
+	s.addConn(sink)
+	defer s.removeConn(sink)
+
+	s.readLoop(sink)
+}
+
+func (s *BridgeServer) addConn(sink *wsSink) {
+	s.mu.Lock()
+	s.sinks[sink] = struct{}{}
+	providers := make([]BridgeProvider, 0, len(s.providers))
+	for _, provider := range s.providers {
+		providers = append(providers, provider)
+	}
+	ctx := s.ctx
+	s.mu.Unlock()
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	for _, provider := range providers {
+		message := map[string]any{
+			"type":        "provider-available",
+			"tabId":       provider.TabID,
+			"providerKey": provider.ProviderKey,
+			"provider": map[string]any{
+				"id":        provider.ID,
+				"name":      provider.Name,
+				"transport": provider.Transport,
+			},
+		}
+		if provider.URL != "" {
+			message["provider"].(map[string]any)["url"] = provider.URL
+		}
+		payload, err := json.Marshal(message)
+		if err != nil {
+			continue
+		}
+		_ = sink.write(ctx, payload)
+	}
+}
+
+func (s *BridgeServer) removeConn(sink *wsSink) {
+	s.mu.Lock()
+	delete(s.sinks, sink)
+	noSinks := len(s.sinks) == 0
+	providersChanged := false
+	if noSinks {
+		if len(s.providers) > 0 {
+			providersChanged = true
+		}
+		for key, subs := range s.relaySubscribers {
+			for _, ch := range subs {
+				close(ch)
+			}
+			delete(s.relaySubscribers, key)
+		}
+		s.providers = map[string]BridgeProvider{}
+	}
+	onChange := s.onProviderChange
+	s.mu.Unlock()
+
+	_ = sink.conn.Close(websocket.StatusNormalClosure, "")
+	if providersChanged && onChange != nil {
+		onChange()
+	}
+}
+
+func (s *BridgeServer) readLoop(sink *wsSink) {
+	for {
+		s.mu.RLock()
+		ctx := s.ctx
+		s.mu.RUnlock()
+		if ctx == nil {
+			ctx = context.Background()
+		}
+
+		_, data, err := sink.conn.Read(ctx)
+		if err != nil {
+			return
+		}
+
+		var msg map[string]any
+		if err := json.Unmarshal(data, &msg); err != nil {
+			continue
+		}
+		s.handleMessage(msg)
+	}
+}
+
+func (s *BridgeServer) handleMessage(msg map[string]any) {
+	msgType, _ := msg["type"].(string)
+
+	switch msgType {
+	case "provider-available":
+		provider, ok := parseBridgeProvider(msg)
+		if !ok {
+			return
+		}
+		s.mu.Lock()
+		s.providers[provider.ProviderKey] = provider
+		onChange := s.onProviderChange
+		s.mu.Unlock()
+		_ = s.broadcast(msg)
+		if onChange != nil {
+			onChange()
+		}
+
+	case "provider-unavailable":
+		providerKey, _ := msg["providerKey"].(string)
+		if providerKey == "" {
+			return
+		}
+		s.mu.Lock()
+		delete(s.providers, providerKey)
+		if subs, ok := s.relaySubscribers[providerKey]; ok {
+			for _, ch := range subs {
+				close(ch)
+			}
+			delete(s.relaySubscribers, providerKey)
+		}
+		onChange := s.onProviderChange
+		s.mu.Unlock()
+		_ = s.broadcast(msg)
+		if onChange != nil {
+			onChange()
+		}
+
+	case "slop-relay":
+		providerKey, _ := msg["providerKey"].(string)
+		message, _ := msg["message"].(map[string]any)
+		if providerKey == "" || message == nil {
+			return
+		}
+		s.dispatchRelay(providerKey, message)
+		_ = s.broadcast(msg)
+
+	case "relay-open", "relay-close":
+		_ = s.broadcast(msg)
+	}
+}
+
+func (s *BridgeServer) dispatchRelay(providerKey string, message map[string]any) {
+	s.mu.RLock()
+	subs := append([]chan map[string]any(nil), s.relaySubscribers[providerKey]...)
+	s.mu.RUnlock()
+
+	for _, ch := range subs {
+		select {
+		case ch <- message:
+		default:
+		}
+	}
+}

--- a/packages/go/slop-ai/discovery/discovery_test.go
+++ b/packages/go/slop-ai/discovery/discovery_test.go
@@ -1,0 +1,220 @@
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+)
+
+func TestServiceScansAndPrunesDescriptors(t *testing.T) {
+	t.Parallel()
+
+	providersDir := t.TempDir()
+	descriptorPath := filepath.Join(providersDir, "test-app.json")
+	descriptor := `{
+		"id": "test-app",
+		"name": "Test App",
+		"slop_version": "0.1",
+		"transport": {"type": "unix", "path": "/tmp/slop/test-app.sock"},
+		"capabilities": ["state"]
+	}`
+	if err := os.WriteFile(descriptorPath, []byte(descriptor), 0o644); err != nil {
+		t.Fatalf("write descriptor: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	service := NewService(ServiceOptions{
+		ProvidersDirs:     []string{providersDir},
+		BridgeURL:         "ws://127.0.0.1:1/slop-bridge",
+		BridgeAddr:        "127.0.0.1:0",
+		BridgePath:        "/slop-bridge",
+		BridgeDialTimeout: 20 * time.Millisecond,
+		ScanInterval:      20 * time.Millisecond,
+		WatchDebounce:     10 * time.Millisecond,
+	})
+	service.Start(ctx)
+	defer service.Stop()
+
+	waitUntil(t, time.Second, func() bool {
+		return len(service.GetDiscovered()) == 1
+	})
+
+	if err := os.Remove(descriptorPath); err != nil {
+		t.Fatalf("remove descriptor: %v", err)
+	}
+
+	waitUntil(t, time.Second, func() bool {
+		return len(service.GetDiscovered()) == 0
+	})
+}
+
+func TestBridgeServerForwardsRelayControlMessages(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server := NewBridgeServer("127.0.0.1:0", "/slop-bridge", Logger{})
+	if err := server.Start(ctx); err != nil {
+		t.Fatalf("start bridge server: %v", err)
+	}
+	defer server.Stop()
+
+	clientOne, _, err := websocket.Dial(ctx, server.URL(), nil)
+	if err != nil {
+		t.Fatalf("dial client one: %v", err)
+	}
+	defer clientOne.Close(websocket.StatusNormalClosure, "")
+
+	clientTwo, _, err := websocket.Dial(ctx, server.URL(), nil)
+	if err != nil {
+		t.Fatalf("dial client two: %v", err)
+	}
+	defer clientTwo.Close(websocket.StatusNormalClosure, "")
+
+	openMessage := map[string]any{"type": "relay-open", "providerKey": "browser-tab"}
+	if err := writeWSJSON(ctx, clientOne, openMessage); err != nil {
+		t.Fatalf("write relay-open: %v", err)
+	}
+
+	message := readWSJSON(t, ctx, clientTwo)
+	if message["type"] != "relay-open" {
+		t.Fatalf("expected relay-open broadcast, got %#v", message)
+	}
+
+	closeMessage := map[string]any{"type": "relay-close", "providerKey": "browser-tab"}
+	if err := writeWSJSON(ctx, clientOne, closeMessage); err != nil {
+		t.Fatalf("write relay-close: %v", err)
+	}
+
+	message = readWSJSON(t, ctx, clientTwo)
+	if message["type"] != "relay-close" {
+		t.Fatalf("expected relay-close broadcast, got %#v", message)
+	}
+}
+
+func TestRelayTransportBuffersEarlyMessages(t *testing.T) {
+	t.Parallel()
+
+	bridge := &fakeBridge{}
+	transport := &BridgeRelayTransport{Bridge: bridge, ProviderKey: "tab-1"}
+
+	conn, err := transport.Connect(context.Background())
+	if err != nil {
+		t.Fatalf("connect relay transport: %v", err)
+	}
+	defer conn.Close()
+
+	got := make(chan map[string]any, 1)
+	conn.OnMessage(func(msg map[string]any) {
+		got <- msg
+	})
+
+	select {
+	case msg := <-got:
+		if msg["type"] != "hello" {
+			t.Fatalf("expected buffered hello message, got %#v", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for buffered relay message")
+	}
+}
+
+func waitUntil(t *testing.T, timeout time.Duration, fn func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("condition not met before timeout")
+}
+
+func writeWSJSON(ctx context.Context, conn *websocket.Conn, value map[string]any) error {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return conn.Write(ctx, websocket.MessageText, payload)
+}
+
+func readWSJSON(t *testing.T, ctx context.Context, conn *websocket.Conn) map[string]any {
+	t.Helper()
+	readCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	_, payload, err := conn.Read(readCtx)
+	if err != nil {
+		t.Fatalf("read websocket message: %v", err)
+	}
+	var message map[string]any
+	if err := json.Unmarshal(payload, &message); err != nil {
+		t.Fatalf("decode websocket message: %v", err)
+	}
+	return message
+}
+
+type fakeBridge struct {
+	mu   sync.Mutex
+	subs map[string][]chan map[string]any
+	msgs []map[string]any
+}
+
+func (b *fakeBridge) Running() bool { return true }
+
+func (b *fakeBridge) Providers() []BridgeProvider { return nil }
+
+func (b *fakeBridge) OnProviderChange(func()) {}
+
+func (b *fakeBridge) SubscribeRelay(providerKey string) chan map[string]any {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.subs == nil {
+		b.subs = map[string][]chan map[string]any{}
+	}
+	ch := make(chan map[string]any, 8)
+	b.subs[providerKey] = append(b.subs[providerKey], ch)
+	return ch
+}
+
+func (b *fakeBridge) UnsubscribeRelay(providerKey string, ch chan map[string]any) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	subs := b.subs[providerKey]
+	for index, sub := range subs {
+		if sub == ch {
+			b.subs[providerKey] = append(subs[:index], subs[index+1:]...)
+			break
+		}
+	}
+	close(ch)
+}
+
+func (b *fakeBridge) Send(msg map[string]any) error {
+	b.mu.Lock()
+	b.msgs = append(b.msgs, msg)
+	var subs []chan map[string]any
+	if msg["type"] == "slop-relay" {
+		if message, ok := msg["message"].(map[string]any); ok && message["type"] == "connect" {
+			providerKey, _ := msg["providerKey"].(string)
+			subs = append(subs, b.subs[providerKey]...)
+		}
+	}
+	b.mu.Unlock()
+
+	for _, ch := range subs {
+		ch <- map[string]any{"type": "hello", "provider": map[string]any{"name": "Browser App"}}
+	}
+	return nil
+}
+
+func (b *fakeBridge) Stop() {}

--- a/packages/go/slop-ai/discovery/doc.go
+++ b/packages/go/slop-ai/discovery/doc.go
@@ -1,0 +1,6 @@
+// Package discovery implements the SLOP core discovery layer for Go.
+//
+// It sits above the base consumer SDK and handles provider discovery,
+// bridge client/server management, relay transports for browser providers,
+// connection orchestration, and AI-facing tool helpers.
+package discovery

--- a/packages/go/slop-ai/discovery/relay_transport.go
+++ b/packages/go/slop-ai/discovery/relay_transport.go
@@ -1,0 +1,206 @@
+package discovery
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	slop "github.com/devteapot/slop/packages/go/slop-ai"
+)
+
+const (
+	relayRetryDelay = 300 * time.Millisecond
+	relayMaxRetries = 3
+)
+
+// BridgeRelayTransport routes SLOP messages through the extension bridge.
+type BridgeRelayTransport struct {
+	Bridge      Bridge
+	ProviderKey string
+}
+
+// Connect opens a relay connection through the bridge.
+func (t *BridgeRelayTransport) Connect(ctx context.Context) (slop.ClientConnection, error) {
+	relayCh := t.Bridge.SubscribeRelay(t.ProviderKey)
+
+	if err := t.Bridge.Send(map[string]any{
+		"type":        "relay-open",
+		"providerKey": t.ProviderKey,
+	}); err != nil {
+		t.Bridge.UnsubscribeRelay(t.ProviderKey, relayCh)
+		return nil, err
+	}
+
+	rc := &relayConn{
+		bridge:      t.Bridge,
+		providerKey: t.ProviderKey,
+		relayCh:     relayCh,
+		done:        make(chan struct{}),
+		buffering:   true,
+	}
+	go rc.readLoop()
+
+	var (
+		gotResponse bool
+		seenMu      sync.Mutex
+	)
+	markResponse := func(map[string]any) {
+		seenMu.Lock()
+		gotResponse = true
+		seenMu.Unlock()
+	}
+	rc.addMessageHandler(markResponse)
+
+	for attempt := 0; attempt <= relayMaxRetries; attempt++ {
+		if err := t.Bridge.Send(map[string]any{
+			"type":        "slop-relay",
+			"providerKey": t.ProviderKey,
+			"message": map[string]any{
+				"type": "connect",
+			},
+		}); err != nil {
+			rc.Close()
+			return nil, err
+		}
+
+		seenMu.Lock()
+		seen := gotResponse
+		seenMu.Unlock()
+		if seen {
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			rc.Close()
+			return nil, ctx.Err()
+		case <-time.After(relayRetryDelay):
+		}
+	}
+
+	return rc, nil
+}
+
+type relayConn struct {
+	bridge      Bridge
+	providerKey string
+	relayCh     chan map[string]any
+
+	mu              sync.Mutex
+	messageHandlers []func(map[string]any)
+	closeHandlers   []func()
+	earlyMessages   []map[string]any
+	buffering       bool
+	closed          bool
+	done            chan struct{}
+}
+
+func (rc *relayConn) Send(msg map[string]any) error {
+	rc.mu.Lock()
+	closed := rc.closed
+	rc.mu.Unlock()
+	if closed {
+		return nil
+	}
+
+	return rc.bridge.Send(map[string]any{
+		"type":        "slop-relay",
+		"providerKey": rc.providerKey,
+		"message":     msg,
+	})
+}
+
+func (rc *relayConn) OnMessage(handler func(map[string]any)) {
+	rc.mu.Lock()
+	rc.messageHandlers = append(rc.messageHandlers, handler)
+	earlyMessages := append([]map[string]any(nil), rc.earlyMessages...)
+	if rc.buffering {
+		rc.buffering = false
+		rc.earlyMessages = nil
+	}
+	rc.mu.Unlock()
+
+	for _, msg := range earlyMessages {
+		handler(msg)
+	}
+}
+
+func (rc *relayConn) OnClose(handler func()) {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	rc.closeHandlers = append(rc.closeHandlers, handler)
+}
+
+func (rc *relayConn) Close() error {
+	rc.mu.Lock()
+	if rc.closed {
+		rc.mu.Unlock()
+		return nil
+	}
+	rc.closed = true
+	closeHandlers := append([]func(){}, rc.closeHandlers...)
+	rc.closeHandlers = nil
+	rc.mu.Unlock()
+
+	_ = rc.bridge.Send(map[string]any{
+		"type":        "relay-close",
+		"providerKey": rc.providerKey,
+	})
+	rc.bridge.UnsubscribeRelay(rc.providerKey, rc.relayCh)
+	close(rc.done)
+
+	for _, handler := range closeHandlers {
+		handler()
+	}
+	return nil
+}
+
+func (rc *relayConn) readLoop() {
+	for {
+		select {
+		case msg, ok := <-rc.relayCh:
+			if !ok {
+				rc.fireClose()
+				return
+			}
+			rc.dispatchMessage(msg)
+		case <-rc.done:
+			return
+		}
+	}
+}
+
+func (rc *relayConn) dispatchMessage(msg map[string]any) {
+	rc.mu.Lock()
+	if rc.buffering {
+		rc.earlyMessages = append(rc.earlyMessages, msg)
+	}
+	handlers := append([]func(map[string]any){}, rc.messageHandlers...)
+	rc.mu.Unlock()
+
+	for _, handler := range handlers {
+		handler(msg)
+	}
+}
+
+func (rc *relayConn) fireClose() {
+	rc.mu.Lock()
+	if rc.closed {
+		rc.mu.Unlock()
+		return
+	}
+	rc.closed = true
+	handlers := append([]func(){}, rc.closeHandlers...)
+	rc.closeHandlers = nil
+	rc.mu.Unlock()
+
+	for _, handler := range handlers {
+		handler()
+	}
+}
+
+func (rc *relayConn) addMessageHandler(handler func(map[string]any)) {
+	rc.mu.Lock()
+	rc.messageHandlers = append(rc.messageHandlers, handler)
+	rc.mu.Unlock()
+}

--- a/packages/go/slop-ai/discovery/service.go
+++ b/packages/go/slop-ai/discovery/service.go
@@ -1,0 +1,741 @@
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	slop "github.com/devteapot/slop/packages/go/slop-ai"
+	"github.com/fsnotify/fsnotify"
+)
+
+var validTransportTypes = map[string]struct{}{
+	"unix":  {},
+	"ws":    {},
+	"stdio": {},
+	"relay": {},
+}
+
+// Service manages provider discovery and connections.
+type Service struct {
+	config serviceConfig
+
+	mu                sync.RWMutex
+	providers         map[string]*ConnectedProvider
+	localDescriptors  []ProviderDescriptor
+	lastAccessed      map[string]time.Time
+	reconnectAttempts map[string]int
+	suppressReconnect map[string]bool
+	bridge            Bridge
+	stateChange       func()
+	started           bool
+	ctx               context.Context
+	cancel            context.CancelFunc
+	watcher           *fsnotify.Watcher
+	watchDebounce     *time.Timer
+	watchedDirs       map[string]struct{}
+
+	scanMu sync.Mutex
+}
+
+// NewService creates a discovery service.
+func NewService(opts ServiceOptions) *Service {
+	return &Service{
+		config:            normalizeOptions(opts),
+		providers:         map[string]*ConnectedProvider{},
+		lastAccessed:      map[string]time.Time{},
+		reconnectAttempts: map[string]int{},
+		suppressReconnect: map[string]bool{},
+		watchedDirs:       map[string]struct{}{},
+	}
+}
+
+// Start begins scanning directories, watching for changes, and managing the bridge.
+func (s *Service) Start(ctx context.Context) {
+	s.mu.Lock()
+	if s.started {
+		s.mu.Unlock()
+		return
+	}
+	s.ctx, s.cancel = context.WithCancel(ctx)
+	s.started = true
+	s.mu.Unlock()
+
+	watcher, err := fsnotify.NewWatcher()
+	if err == nil {
+		s.mu.Lock()
+		s.watcher = watcher
+		s.mu.Unlock()
+		go s.watchLoop(watcher)
+	} else {
+		s.config.logger.errorf("[slop] Failed to start discovery watcher: %v", err)
+	}
+
+	s.scan()
+	go s.scanTickerLoop()
+	go s.idleTickerLoop()
+	go s.initBridge()
+}
+
+// Stop shuts down the service and disconnects all providers.
+func (s *Service) Stop() {
+	s.mu.Lock()
+	if !s.started {
+		s.mu.Unlock()
+		return
+	}
+	if s.cancel != nil {
+		s.cancel()
+		s.cancel = nil
+	}
+	if s.watchDebounce != nil {
+		s.watchDebounce.Stop()
+		s.watchDebounce = nil
+	}
+	watcher := s.watcher
+	s.watcher = nil
+	bridge := s.bridge
+	s.bridge = nil
+	providers := make([]*ConnectedProvider, 0, len(s.providers))
+	for id, provider := range s.providers {
+		s.suppressReconnect[id] = true
+		providers = append(providers, provider)
+	}
+	s.providers = map[string]*ConnectedProvider{}
+	s.lastAccessed = map[string]time.Time{}
+	s.reconnectAttempts = map[string]int{}
+	s.started = false
+	s.mu.Unlock()
+
+	if watcher != nil {
+		_ = watcher.Close()
+	}
+	if bridge != nil {
+		bridge.Stop()
+	}
+	for _, provider := range providers {
+		provider.Consumer.Disconnect()
+	}
+}
+
+// OnStateChange registers a callback fired on provider connect, disconnect, and state patch.
+func (s *Service) OnStateChange(fn func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stateChange = fn
+}
+
+// GetDiscovered returns all currently known provider descriptors.
+func (s *Service) GetDiscovered() []ProviderDescriptor {
+	s.mu.RLock()
+	local := append([]ProviderDescriptor(nil), s.localDescriptors...)
+	bridge := s.bridge
+	s.mu.RUnlock()
+
+	return append(local, s.bridgeDescriptors(bridge)...)
+}
+
+// GetProviders returns all currently connected providers.
+func (s *Service) GetProviders() []*ConnectedProvider {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	providers := make([]*ConnectedProvider, 0, len(s.providers))
+	for _, provider := range s.providers {
+		if provider.Status == StatusConnected {
+			providers = append(providers, provider)
+		}
+	}
+	return providers
+}
+
+// GetProvider returns a connected provider by ID.
+func (s *Service) GetProvider(id string) *ConnectedProvider {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	provider, ok := s.providers[id]
+	if !ok || provider.Status != StatusConnected {
+		return nil
+	}
+	s.lastAccessed[id] = time.Now()
+	return provider
+}
+
+// EnsureConnected returns a connected provider by ID or name, connecting it if needed.
+func (s *Service) EnsureConnected(ctx context.Context, idOrName string) (*ConnectedProvider, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if provider := s.findConnectedProvider(idOrName); provider != nil {
+		return provider, nil
+	}
+
+	desc := s.findDescriptor(idOrName)
+	if desc == nil {
+		return nil, nil
+	}
+
+	return s.connectProvider(ctx, *desc)
+}
+
+// Disconnect explicitly disconnects a provider by ID or fuzzy name.
+func (s *Service) Disconnect(idOrName string) bool {
+	provider := s.findAnyProvider(idOrName)
+	if provider == nil {
+		return false
+	}
+
+	s.markIntentionalDisconnect(provider.ID)
+	provider.Consumer.Disconnect()
+	s.forgetProvider(provider.ID)
+	s.fireStateChange()
+	return true
+}
+
+func (s *Service) initBridge() {
+	s.mu.RLock()
+	ctx := s.ctx
+	config := s.config
+	s.mu.RUnlock()
+	if ctx == nil {
+		return
+	}
+
+	client := NewBridgeClient(config.bridgeURL, config.logger)
+	client.reconnectDelay = config.bridgeRetryDelay
+
+	dialCtx, cancel := context.WithTimeout(ctx, config.bridgeDialTimeout)
+	err := client.ConnectOnce(dialCtx)
+	cancel()
+	if err == nil {
+		client.Start(ctx)
+		s.attachBridge(client)
+		config.logger.infof("[slop-bridge] Connected as client to existing bridge")
+		return
+	}
+
+	if !config.hostBridge {
+		config.logger.infof("[slop-bridge] No bridge found, retrying as client")
+		client.Start(ctx)
+		s.attachBridge(client)
+		return
+	}
+
+	server := NewBridgeServer(config.bridgeAddr, config.bridgePath, config.logger)
+	if err := server.Start(ctx); err == nil {
+		s.attachBridge(server)
+		return
+	}
+
+	config.logger.infof("[slop-bridge] Port taken, retrying as client")
+	client = NewBridgeClient(config.bridgeURL, config.logger)
+	client.reconnectDelay = config.bridgeRetryDelay
+	client.Start(ctx)
+	s.attachBridge(client)
+}
+
+func (s *Service) attachBridge(bridge Bridge) {
+	bridge.OnProviderChange(func() {
+		s.scan()
+	})
+
+	s.mu.Lock()
+	if !s.started {
+		s.mu.Unlock()
+		bridge.Stop()
+		return
+	}
+	s.bridge = bridge
+	s.mu.Unlock()
+
+	s.scan()
+}
+
+func (s *Service) scanTickerLoop() {
+	ticker := time.NewTicker(s.config.scanInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			s.scan()
+		case <-s.done():
+			return
+		}
+	}
+}
+
+func (s *Service) idleTickerLoop() {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			s.checkIdle()
+		case <-s.done():
+			return
+		}
+	}
+}
+
+func (s *Service) watchLoop(watcher *fsnotify.Watcher) {
+	for {
+		select {
+		case <-s.done():
+			return
+		case _, ok := <-watcher.Events:
+			if !ok {
+				return
+			}
+			s.scheduleScan()
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return
+			}
+			s.config.logger.errorf("[slop] Discovery watcher error: %v", err)
+		}
+	}
+}
+
+func (s *Service) scheduleScan() {
+	s.mu.Lock()
+	if s.watchDebounce != nil {
+		s.watchDebounce.Stop()
+	}
+	s.watchDebounce = time.AfterFunc(s.config.watchDebounce, s.scan)
+	s.mu.Unlock()
+}
+
+func (s *Service) scan() {
+	s.scanMu.Lock()
+	defer s.scanMu.Unlock()
+
+	local := s.readDescriptors()
+	s.syncWatches()
+
+	s.mu.Lock()
+	s.localDescriptors = local
+	bridge := s.bridge
+	ctx := s.ctx
+	autoConnect := s.config.autoConnect
+	providers := make([]*ConnectedProvider, 0, len(s.providers))
+	for _, provider := range s.providers {
+		providers = append(providers, provider)
+	}
+	s.mu.Unlock()
+
+	allDescriptors := append([]ProviderDescriptor{}, local...)
+	allDescriptors = append(allDescriptors, s.bridgeDescriptors(bridge)...)
+
+	allIDs := map[string]struct{}{}
+	for _, desc := range allDescriptors {
+		allIDs[desc.ID] = struct{}{}
+	}
+
+	for _, provider := range providers {
+		if _, ok := allIDs[provider.ID]; ok {
+			continue
+		}
+		s.markIntentionalDisconnect(provider.ID)
+		provider.Consumer.Disconnect()
+		s.forgetProvider(provider.ID)
+	}
+
+	if !autoConnect || ctx == nil {
+		return
+	}
+
+	for _, desc := range allDescriptors {
+		if s.hasProvider(desc.ID) {
+			continue
+		}
+		go func(desc ProviderDescriptor) {
+			_, _ = s.connectProvider(ctx, desc)
+		}(desc)
+	}
+}
+
+func (s *Service) checkIdle() {
+	now := time.Now()
+	var toDisconnect []*ConnectedProvider
+
+	s.mu.RLock()
+	for id, accessed := range s.lastAccessed {
+		if now.Sub(accessed) <= s.config.idleTimeout {
+			continue
+		}
+		if provider, ok := s.providers[id]; ok {
+			toDisconnect = append(toDisconnect, provider)
+		}
+	}
+	s.mu.RUnlock()
+
+	for _, provider := range toDisconnect {
+		s.config.logger.infof("[slop] Idle timeout: disconnecting %s", provider.Name)
+		s.markIntentionalDisconnect(provider.ID)
+		provider.Consumer.Disconnect()
+		s.forgetProvider(provider.ID)
+		s.fireStateChange()
+	}
+}
+
+func (s *Service) connectProvider(ctx context.Context, desc ProviderDescriptor) (*ConnectedProvider, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	for {
+		s.mu.Lock()
+		existing := s.providers[desc.ID]
+		if existing != nil {
+			switch existing.Status {
+			case StatusConnected:
+				s.lastAccessed[desc.ID] = time.Now()
+				s.mu.Unlock()
+				return existing, nil
+			case StatusConnecting:
+				s.mu.Unlock()
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(10 * time.Millisecond):
+				}
+				continue
+			}
+		}
+
+		transport := s.createTransport(desc)
+		if transport == nil {
+			s.mu.Unlock()
+			s.config.logger.infof("[slop] Skipping %s: unsupported transport %s", desc.Name, desc.Transport.Type)
+			return nil, nil
+		}
+
+		provider := &ConnectedProvider{
+			ID:         desc.ID,
+			Name:       desc.Name,
+			Descriptor: desc,
+			Consumer:   slop.NewConsumer(transport),
+			Status:     StatusConnecting,
+		}
+		s.providers[desc.ID] = provider
+		s.mu.Unlock()
+
+		connectCtx, cancel := context.WithTimeout(ctx, s.config.connectTimeout)
+		hello, err := provider.Consumer.Connect(connectCtx)
+		if err == nil {
+			provider.Consumer.OnPatch(func(_ string, _ []slop.PatchOp, _ int) {
+				s.fireStateChange()
+			})
+			provider.Consumer.OnDisconnect(func() {
+				s.handleProviderDisconnect(desc, provider.Name)
+			})
+			provider.Consumer.OnError(func(code, message string) {
+				s.config.logger.errorf("[slop] Provider %s error [%s]: %s", desc.ID, code, message)
+			})
+			provider.Consumer.OnEvent(func(name string, data any) {
+				s.config.logger.infof("[slop] Provider %s event %s: %v", desc.ID, name, data)
+			})
+
+			var tree slop.WireNode
+			provider.SubscriptionID, tree, err = provider.Consumer.Subscribe(connectCtx, "/", -1)
+			_ = tree
+			if err == nil {
+				provider.Status = StatusConnected
+				provider.Name = providerName(hello, desc.Name)
+				provider.Descriptor.Name = desc.Name
+				cancel()
+
+				s.mu.Lock()
+				s.lastAccessed[desc.ID] = time.Now()
+				delete(s.reconnectAttempts, desc.ID)
+				delete(s.suppressReconnect, desc.ID)
+				s.mu.Unlock()
+
+				s.config.logger.infof("[slop] Connected to %s (%s) via %s", provider.Name, desc.ID, desc.Transport.Type)
+				s.fireStateChange()
+				return provider, nil
+			}
+		}
+		cancel()
+
+		s.config.logger.errorf("[slop] Failed to connect to %s: %v", desc.Name, err)
+		s.forgetProvider(desc.ID)
+		return nil, err
+	}
+}
+
+func (s *Service) handleProviderDisconnect(desc ProviderDescriptor, name string) {
+	s.forgetProvider(desc.ID)
+	s.fireStateChange()
+
+	if s.consumeIntentionalDisconnect(desc.ID) {
+		return
+	}
+	if !s.descriptorExists(desc.ID) {
+		return
+	}
+
+	attempt := s.incrementReconnectAttempt(desc.ID)
+	delay := s.config.reconnectBaseDelay << (attempt - 1)
+	if delay > s.config.maxReconnectDelay {
+		delay = s.config.maxReconnectDelay
+	}
+
+	s.config.logger.infof("[slop] Will reconnect to %s in %s (attempt %d)", name, delay, attempt)
+	time.AfterFunc(delay, func() {
+		if s.doneErr() != nil || s.hasProvider(desc.ID) {
+			return
+		}
+		ctx := s.context()
+		if ctx == nil {
+			return
+		}
+		_, _ = s.connectProvider(ctx, desc)
+	})
+}
+
+func (s *Service) createTransport(desc ProviderDescriptor) slop.ClientTransport {
+	switch desc.Transport.Type {
+	case "unix":
+		if desc.Transport.Path != "" {
+			return &slop.UnixClientTransport{Path: desc.Transport.Path}
+		}
+	case "ws":
+		if desc.Transport.URL != "" {
+			return &slop.WSClientTransport{URL: desc.Transport.URL}
+		}
+	case "relay":
+		if desc.ProviderKey != "" && s.bridge != nil {
+			return &BridgeRelayTransport{Bridge: s.bridge, ProviderKey: desc.ProviderKey}
+		}
+	}
+	return nil
+}
+
+func (s *Service) readDescriptors() []ProviderDescriptor {
+	var descriptors []ProviderDescriptor
+	for _, dir := range s.config.providersDirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+				continue
+			}
+			path := filepath.Join(dir, entry.Name())
+			content, err := os.ReadFile(path)
+			if err != nil {
+				s.config.logger.errorf("[slop] Failed to read %s: %v", path, err)
+				continue
+			}
+
+			var desc ProviderDescriptor
+			if err := json.Unmarshal(content, &desc); err != nil {
+				s.config.logger.errorf("[slop] Failed to parse %s: %v", path, err)
+				continue
+			}
+			if !isValidDescriptor(desc) {
+				s.config.logger.errorf("[slop] Invalid descriptor in %s", path)
+				continue
+			}
+
+			desc.Source = SourceLocal
+			descriptors = append(descriptors, desc)
+		}
+	}
+	return descriptors
+}
+
+func (s *Service) syncWatches() {
+	s.mu.RLock()
+	watcher := s.watcher
+	s.mu.RUnlock()
+	if watcher == nil {
+		return
+	}
+
+	for _, dir := range s.config.providersDirs {
+		if _, err := os.Stat(dir); err != nil {
+			continue
+		}
+
+		s.mu.RLock()
+		_, watched := s.watchedDirs[dir]
+		s.mu.RUnlock()
+		if watched {
+			continue
+		}
+
+		if err := watcher.Add(dir); err != nil {
+			s.config.logger.errorf("[slop] Failed to watch %s: %v", dir, err)
+			continue
+		}
+
+		s.mu.Lock()
+		s.watchedDirs[dir] = struct{}{}
+		s.mu.Unlock()
+	}
+}
+
+func (s *Service) bridgeDescriptors(bridge Bridge) []ProviderDescriptor {
+	if bridge == nil || !bridge.Running() {
+		return nil
+	}
+	providers := bridge.Providers()
+	descriptors := make([]ProviderDescriptor, 0, len(providers))
+	for _, provider := range providers {
+		descriptors = append(descriptors, bridgeProviderToDescriptor(provider))
+	}
+	return descriptors
+}
+
+func (s *Service) findConnectedProvider(idOrName string) *ConnectedProvider {
+	needle := strings.ToLower(idOrName)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if provider, ok := s.providers[idOrName]; ok && provider.Status == StatusConnected {
+		s.lastAccessed[provider.ID] = time.Now()
+		return provider
+	}
+	for _, provider := range s.providers {
+		if provider.Status == StatusConnected && strings.Contains(strings.ToLower(provider.Name), needle) {
+			s.lastAccessed[provider.ID] = time.Now()
+			return provider
+		}
+	}
+	return nil
+}
+
+func (s *Service) findAnyProvider(idOrName string) *ConnectedProvider {
+	needle := strings.ToLower(idOrName)
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if provider, ok := s.providers[idOrName]; ok {
+		return provider
+	}
+	for _, provider := range s.providers {
+		if strings.Contains(strings.ToLower(provider.Name), needle) {
+			return provider
+		}
+	}
+	return nil
+}
+
+func (s *Service) findDescriptor(idOrName string) *ProviderDescriptor {
+	needle := strings.ToLower(idOrName)
+	for _, desc := range s.GetDiscovered() {
+		if desc.ID == idOrName || strings.Contains(strings.ToLower(desc.Name), needle) {
+			copy := desc
+			return &copy
+		}
+	}
+	return nil
+}
+
+func (s *Service) hasProvider(id string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	_, ok := s.providers[id]
+	return ok
+}
+
+func (s *Service) forgetProvider(id string) {
+	s.mu.Lock()
+	delete(s.providers, id)
+	delete(s.lastAccessed, id)
+	delete(s.reconnectAttempts, id)
+	s.mu.Unlock()
+}
+
+func (s *Service) markIntentionalDisconnect(id string) {
+	s.mu.Lock()
+	s.suppressReconnect[id] = true
+	s.mu.Unlock()
+}
+
+func (s *Service) consumeIntentionalDisconnect(id string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	marked := s.suppressReconnect[id]
+	delete(s.suppressReconnect, id)
+	return marked
+}
+
+func (s *Service) incrementReconnectAttempt(id string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.reconnectAttempts[id]++
+	return s.reconnectAttempts[id]
+}
+
+func (s *Service) descriptorExists(id string) bool {
+	for _, desc := range s.GetDiscovered() {
+		if desc.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Service) context() context.Context {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.ctx
+}
+
+func (s *Service) done() <-chan struct{} {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.ctx == nil {
+		return nil
+	}
+	return s.ctx.Done()
+}
+
+func (s *Service) doneErr() error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.ctx == nil {
+		return context.Canceled
+	}
+	return s.ctx.Err()
+}
+
+func (s *Service) fireStateChange() {
+	s.mu.RLock()
+	callback := s.stateChange
+	s.mu.RUnlock()
+	if callback != nil {
+		callback()
+	}
+}
+
+func isValidDescriptor(desc ProviderDescriptor) bool {
+	if desc.ID == "" || desc.Name == "" {
+		return false
+	}
+	if _, ok := validTransportTypes[desc.Transport.Type]; !ok {
+		return false
+	}
+	if desc.Capabilities == nil {
+		return false
+	}
+	return true
+}
+
+func providerName(hello map[string]any, fallback string) string {
+	provider, _ := hello["provider"].(map[string]any)
+	name, _ := provider["name"].(string)
+	if name == "" {
+		return fallback
+	}
+	return name
+}

--- a/packages/go/slop-ai/discovery/tools.go
+++ b/packages/go/slop-ai/discovery/tools.go
@@ -1,0 +1,217 @@
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	slop "github.com/devteapot/slop/packages/go/slop-ai"
+)
+
+// ToolContent is a text content block for host integrations.
+type ToolContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// ToolResult is a host-agnostic tool result payload.
+type ToolResult struct {
+	Content []ToolContent `json:"content"`
+	IsError bool          `json:"isError,omitempty"`
+}
+
+// DynamicToolEntry describes a single affordance-backed tool.
+type DynamicToolEntry struct {
+	Name        string
+	Description string
+	InputSchema any
+	ProviderID  string
+	Path        string
+	Action      string
+}
+
+// DynamicToolResolution resolves a dynamic tool name back to invoke coordinates.
+type DynamicToolResolution struct {
+	ProviderID string
+	Path       string
+	Action     string
+}
+
+// DynamicToolSet contains all affordance-backed tools across connected providers.
+type DynamicToolSet struct {
+	Tools      []DynamicToolEntry
+	resolveMap map[string]DynamicToolResolution
+}
+
+// Resolve maps a dynamic tool name back to invoke coordinates.
+func (d DynamicToolSet) Resolve(toolName string) (DynamicToolResolution, bool) {
+	resolution, ok := d.resolveMap[toolName]
+	return resolution, ok
+}
+
+// CreateDynamicTools builds namespaced tool definitions from all connected providers.
+func CreateDynamicTools(service *Service) DynamicToolSet {
+	entries := []DynamicToolEntry{}
+	resolveMap := map[string]DynamicToolResolution{}
+
+	for _, provider := range service.GetProviders() {
+		tree := provider.Consumer.Tree(provider.SubscriptionID)
+		if tree == nil {
+			continue
+		}
+
+		prefix := sanitizePrefix(provider.ID)
+		toolSet := slop.AffordancesToTools(*tree, "")
+		for _, tool := range toolSet.Tools {
+			resolution, ok := toolSet.Resolve(tool.Function.Name)
+			if !ok {
+				continue
+			}
+
+			name := prefix + "__" + tool.Function.Name
+			entries = append(entries, DynamicToolEntry{
+				Name:        name,
+				Description: fmt.Sprintf("[%s] %s", provider.Name, tool.Function.Description),
+				InputSchema: tool.Function.Parameters,
+				ProviderID:  provider.ID,
+				Path:        resolution.Path,
+				Action:      resolution.Action,
+			})
+			resolveMap[name] = DynamicToolResolution{
+				ProviderID: provider.ID,
+				Path:       resolution.Path,
+				Action:     resolution.Action,
+			}
+		}
+	}
+
+	return DynamicToolSet{Tools: entries, resolveMap: resolveMap}
+}
+
+// ToolHandlers exposes the core discovery tool handlers.
+type ToolHandlers struct {
+	service *Service
+}
+
+// CreateToolHandlers builds the host-agnostic core tool handlers.
+func CreateToolHandlers(service *Service) ToolHandlers {
+	return ToolHandlers{service: service}
+}
+
+// ListApps lists all discovered providers and connection state.
+func (h ToolHandlers) ListApps() ToolResult {
+	discovered := h.service.GetDiscovered()
+	if len(discovered) == 0 {
+		return ToolResult{
+			Content: []ToolContent{{
+				Type: "text",
+				Text: "No applications found. Desktop and web apps that support external control will appear here automatically when they're running.",
+			}},
+		}
+	}
+
+	connected := h.service.GetProviders()
+	connectedByID := map[string]*ConnectedProvider{}
+	for _, provider := range connected {
+		connectedByID[provider.ID] = provider
+	}
+
+	lines := make([]string, 0, len(discovered))
+	for _, desc := range discovered {
+		provider := connectedByID[desc.ID]
+		tree := (*slop.WireNode)(nil)
+		actionCount := 0
+		if provider != nil {
+			tree = provider.Consumer.Tree(provider.SubscriptionID)
+			if tree != nil {
+				actionCount = len(slop.AffordancesToTools(*tree, "").Tools)
+			}
+		}
+
+		label := desc.Name
+		if tree != nil {
+			if value, ok := tree.Properties["label"].(string); ok && value != "" {
+				label = value
+			}
+		}
+
+		status := "available"
+		if provider != nil {
+			status = fmt.Sprintf("connected, %d actions", actionCount)
+		}
+
+		lines = append(lines, fmt.Sprintf("- **%s** (id: `%s`, %s) - %s", label, desc.ID, desc.Transport.Type, status))
+	}
+
+	return ToolResult{
+		Content: []ToolContent{{
+			Type: "text",
+			Text: fmt.Sprintf("Applications on this computer:\n%s\n\nUse connect_app with an app name or ID to connect and inspect it.", strings.Join(lines, "\n")),
+		}},
+	}
+}
+
+// ConnectApp connects to a provider and returns its current state snapshot and actions.
+func (h ToolHandlers) ConnectApp(ctx context.Context, app string) ToolResult {
+	provider, err := h.service.EnsureConnected(ctx, app)
+	if err != nil {
+		return ToolResult{Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Failed to connect to %q: %v", app, err)}}, IsError: true}
+	}
+	if provider == nil {
+		available := make([]string, 0, len(h.service.GetDiscovered()))
+		for _, desc := range h.service.GetDiscovered() {
+			available = append(available, fmt.Sprintf("%s (%s)", desc.Name, desc.ID))
+		}
+		return ToolResult{Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("App %q not found. Available: %s", app, strings.Join(available, ", "))}}, IsError: true}
+	}
+
+	tree := provider.Consumer.Tree(provider.SubscriptionID)
+	if tree == nil {
+		return ToolResult{Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("%s is connected but has no state yet.", provider.Name)}}}
+	}
+
+	toolSet := slop.AffordancesToTools(*tree, "")
+	actions := make([]string, 0, len(toolSet.Tools))
+	for _, tool := range toolSet.Tools {
+		resolution, ok := toolSet.Resolve(tool.Function.Name)
+		action := tool.Function.Name
+		pathInfo := ""
+		if ok {
+			action = resolution.Action
+			pathInfo = fmt.Sprintf(" on `%s`", resolution.Path)
+		}
+		actions = append(actions, fmt.Sprintf("  - **%s**%s: %s", action, pathInfo, tool.Function.Description))
+	}
+
+	return ToolResult{
+		Content: []ToolContent{{
+			Type: "text",
+			Text: fmt.Sprintf("## %s\nID: `%s`\n\n### Current State\n```\n%s\n```\n\n### Available Actions (%d)\n%s", provider.Name, provider.ID, slop.FormatTree(*tree, 0), len(toolSet.Tools), strings.Join(actions, "\n")),
+		}},
+	}
+}
+
+// DisconnectApp disconnects an active provider connection.
+func (h ToolHandlers) DisconnectApp(app string) ToolResult {
+	if !h.service.Disconnect(app) {
+		return ToolResult{Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("App %q is not connected. Use list_apps to see available apps.", app)}}, IsError: true}
+	}
+	return ToolResult{Content: []ToolContent{{Type: "text", Text: fmt.Sprintf("Disconnected from %q. Its tools have been removed.", app)}}}
+}
+
+func sanitizePrefix(value string) string {
+	var b strings.Builder
+	lastUnderscore := false
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore && b.Len() > 0 {
+			b.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	return strings.Trim(b.String(), "_")
+}

--- a/packages/go/slop-ai/discovery/types.go
+++ b/packages/go/slop-ai/discovery/types.go
@@ -1,0 +1,236 @@
+package discovery
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	slop "github.com/devteapot/slop/packages/go/slop-ai"
+)
+
+const (
+	DefaultBridgeAddr = "127.0.0.1:9339"
+	DefaultBridgePath = "/slop-bridge"
+	DefaultBridgeURL  = "ws://127.0.0.1:9339/slop-bridge"
+)
+
+const (
+	defaultIdleTimeout         = 5 * time.Minute
+	defaultConnectTimeout      = 10 * time.Second
+	defaultScanInterval        = 15 * time.Second
+	defaultWatchDebounce       = 500 * time.Millisecond
+	defaultReconnectBaseDelay  = 3 * time.Second
+	defaultMaxReconnectDelay   = 30 * time.Second
+	defaultBridgeDialTimeout   = 1 * time.Second
+	defaultBridgeReconnectWait = 5 * time.Second
+)
+
+// Logger is an optional structured logger used by the discovery layer.
+type Logger struct {
+	Infof  func(format string, args ...any)
+	Errorf func(format string, args ...any)
+}
+
+func (l Logger) infof(format string, args ...any) {
+	if l.Infof != nil {
+		l.Infof(format, args...)
+	}
+}
+
+func (l Logger) errorf(format string, args ...any) {
+	if l.Errorf != nil {
+		l.Errorf(format, args...)
+	}
+}
+
+// ProviderSource identifies where a provider descriptor came from.
+type ProviderSource string
+
+const (
+	SourceLocal  ProviderSource = "local"
+	SourceBridge ProviderSource = "bridge"
+)
+
+// ProviderStatus describes a provider connection state.
+type ProviderStatus string
+
+const (
+	StatusConnecting   ProviderStatus = "connecting"
+	StatusConnected    ProviderStatus = "connected"
+	StatusDisconnected ProviderStatus = "disconnected"
+)
+
+// TransportDescriptor describes how to connect to a provider.
+type TransportDescriptor struct {
+	Type string `json:"type"`
+	Path string `json:"path,omitempty"`
+	URL  string `json:"url,omitempty"`
+}
+
+// ProviderDescriptor describes a discoverable SLOP provider.
+type ProviderDescriptor struct {
+	ID           string              `json:"id"`
+	Name         string              `json:"name"`
+	SlopVersion  string              `json:"slop_version"`
+	Transport    TransportDescriptor `json:"transport"`
+	PID          int                 `json:"pid,omitempty"`
+	Capabilities []string            `json:"capabilities"`
+	ProviderKey  string              `json:"-"`
+	Source       ProviderSource      `json:"-"`
+}
+
+// Address returns a display-friendly address for a provider descriptor.
+func (d ProviderDescriptor) Address() string {
+	switch d.Transport.Type {
+	case "unix":
+		return "unix:" + d.Transport.Path
+	case "ws":
+		return d.Transport.URL
+	case "relay":
+		if d.ProviderKey != "" {
+			return "bridge:" + d.ProviderKey
+		}
+	}
+	return d.Transport.Type
+}
+
+// ConnectedProvider is an active provider connection managed by the service.
+type ConnectedProvider struct {
+	ID             string
+	Name           string
+	Descriptor     ProviderDescriptor
+	Consumer       *slop.Consumer
+	SubscriptionID string
+	Status         ProviderStatus
+}
+
+// ServiceOptions configures the discovery service.
+type ServiceOptions struct {
+	Logger             Logger
+	AutoConnect        bool
+	HostBridge         *bool
+	ProvidersDirs      []string
+	BridgeURL          string
+	BridgeAddr         string
+	BridgePath         string
+	IdleTimeout        time.Duration
+	ConnectTimeout     time.Duration
+	ScanInterval       time.Duration
+	WatchDebounce      time.Duration
+	ReconnectBaseDelay time.Duration
+	MaxReconnectDelay  time.Duration
+	BridgeDialTimeout  time.Duration
+	BridgeRetryDelay   time.Duration
+}
+
+type serviceConfig struct {
+	logger             Logger
+	autoConnect        bool
+	hostBridge         bool
+	providersDirs      []string
+	bridgeURL          string
+	bridgeAddr         string
+	bridgePath         string
+	idleTimeout        time.Duration
+	connectTimeout     time.Duration
+	scanInterval       time.Duration
+	watchDebounce      time.Duration
+	reconnectBaseDelay time.Duration
+	maxReconnectDelay  time.Duration
+	bridgeDialTimeout  time.Duration
+	bridgeRetryDelay   time.Duration
+}
+
+func normalizeOptions(opts ServiceOptions) serviceConfig {
+	bridgeURL, bridgeAddr, bridgePath := normalizeBridgeLocation(opts)
+
+	providersDirs := opts.ProvidersDirs
+	if len(providersDirs) == 0 {
+		providersDirs = defaultProvidersDirs()
+	}
+
+	return serviceConfig{
+		logger:             opts.Logger,
+		autoConnect:        opts.AutoConnect,
+		hostBridge:         boolOrDefault(opts.HostBridge, true),
+		providersDirs:      providersDirs,
+		bridgeURL:          bridgeURL,
+		bridgeAddr:         bridgeAddr,
+		bridgePath:         bridgePath,
+		idleTimeout:        durationOr(opts.IdleTimeout, defaultIdleTimeout),
+		connectTimeout:     durationOr(opts.ConnectTimeout, defaultConnectTimeout),
+		scanInterval:       durationOr(opts.ScanInterval, defaultScanInterval),
+		watchDebounce:      durationOr(opts.WatchDebounce, defaultWatchDebounce),
+		reconnectBaseDelay: durationOr(opts.ReconnectBaseDelay, defaultReconnectBaseDelay),
+		maxReconnectDelay:  durationOr(opts.MaxReconnectDelay, defaultMaxReconnectDelay),
+		bridgeDialTimeout:  durationOr(opts.BridgeDialTimeout, defaultBridgeDialTimeout),
+		bridgeRetryDelay:   durationOr(opts.BridgeRetryDelay, defaultBridgeReconnectWait),
+	}
+}
+
+func durationOr(value, fallback time.Duration) time.Duration {
+	if value > 0 {
+		return value
+	}
+	return fallback
+}
+
+func defaultProvidersDirs() []string {
+	home := homeDir()
+	return []string{
+		filepath.Join(home, ".slop", "providers"),
+		filepath.Join(os.TempDir(), "slop", "providers"),
+	}
+}
+
+func homeDir() string {
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return home
+	}
+	if home := os.Getenv("HOME"); home != "" {
+		return home
+	}
+	return os.TempDir()
+}
+
+func normalizeBridgeLocation(opts ServiceOptions) (bridgeURL, bridgeAddr, bridgePath string) {
+	bridgeURL = opts.BridgeURL
+	bridgeAddr = opts.BridgeAddr
+	bridgePath = opts.BridgePath
+
+	if bridgeURL == "" && bridgeAddr == "" && bridgePath == "" {
+		return DefaultBridgeURL, DefaultBridgeAddr, DefaultBridgePath
+	}
+
+	if bridgeURL != "" {
+		if parsed, err := url.Parse(bridgeURL); err == nil {
+			if bridgeAddr == "" {
+				bridgeAddr = parsed.Host
+			}
+			if bridgePath == "" {
+				bridgePath = parsed.Path
+			}
+		}
+	}
+
+	if bridgeAddr == "" {
+		bridgeAddr = DefaultBridgeAddr
+	}
+	if bridgePath == "" {
+		bridgePath = DefaultBridgePath
+	}
+	if bridgeURL == "" {
+		bridgeURL = fmt.Sprintf("ws://%s%s", bridgeAddr, bridgePath)
+	}
+
+	return bridgeURL, bridgeAddr, bridgePath
+}
+
+func boolOrDefault(value *bool, fallback bool) bool {
+	if value != nil {
+		return *value
+	}
+	return fallback
+}

--- a/packages/go/slop-ai/go.mod
+++ b/packages/go/slop-ai/go.mod
@@ -3,3 +3,8 @@ module github.com/devteapot/slop/packages/go/slop-ai
 go 1.22
 
 require nhooyr.io/websocket v1.8.17
+
+require (
+	github.com/fsnotify/fsnotify v1.8.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
+)

--- a/packages/go/slop-ai/go.sum
+++ b/packages/go/slop-ai/go.sum
@@ -1,2 +1,6 @@
+github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
+github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 nhooyr.io/websocket v1.8.17 h1:KEVeLJkUywCKVsnLIDlD/5gtayKp8VoCkksHCGGfT9Y=
 nhooyr.io/websocket v1.8.17/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=

--- a/packages/python/slop-ai/README.md
+++ b/packages/python/slop-ai/README.md
@@ -42,9 +42,36 @@ app.add_middleware(SlopMiddleware, slop=slop)
 ## Included modules
 
 - `slop_ai.SlopServer` and `slop_ai.SlopConsumer`
+- `slop_ai.discovery` for provider scanning, bridge relay, lazy/auto-connect, and AI-facing tool helpers
 - `slop_ai.pick`, `slop_ai.omit`, `slop_ai.normalize_descriptor`
 - `slop_ai.transports.asgi`, `.websocket`, `.unix`, `.stdio`
 - scaling helpers such as `prepare_tree`, `truncate_tree`, and `auto_compact`
+
+## Discovery layer
+
+The Python SDK now includes the core discovery layer in `slop_ai.discovery`:
+
+```python
+import asyncio
+
+from slop_ai.discovery import DiscoveryOptions, create_discovery_service
+
+
+async def main() -> None:
+    service = create_discovery_service(DiscoveryOptions())
+    await service.start()
+    try:
+        provider = await service.ensure_connected("my-app")
+        if provider is not None:
+            print(provider.name)
+    finally:
+        await service.stop()
+
+
+asyncio.run(main())
+```
+
+Install `slop-ai[websocket]` when discovery needs browser bridge support or direct WebSocket providers.
 
 ## Documentation
 

--- a/packages/python/slop-ai/src/slop_ai/discovery/__init__.py
+++ b/packages/python/slop-ai/src/slop_ai/discovery/__init__.py
@@ -1,0 +1,37 @@
+"""Core discovery layer for the Python SDK."""
+
+from .bridge import Bridge, BridgeClient, BridgeServer, RelayHandler
+from .models import (
+    BridgeProvider,
+    ConnectedProvider,
+    DiscoveryOptions,
+    DynamicToolEntry,
+    DynamicToolResolution,
+    DynamicToolSet,
+    ProviderDescriptor,
+    ToolResult,
+)
+from .relay_transport import BridgeRelayTransport
+from .service import DiscoveryService, create_discovery_service
+from .tools import ToolHandlers, create_dynamic_tools, create_tool_handlers
+
+__all__ = [
+    "Bridge",
+    "BridgeClient",
+    "BridgeProvider",
+    "BridgeRelayTransport",
+    "BridgeServer",
+    "ConnectedProvider",
+    "DiscoveryOptions",
+    "DiscoveryService",
+    "DynamicToolEntry",
+    "DynamicToolResolution",
+    "DynamicToolSet",
+    "RelayHandler",
+    "ProviderDescriptor",
+    "ToolHandlers",
+    "ToolResult",
+    "create_discovery_service",
+    "create_dynamic_tools",
+    "create_tool_handlers",
+]

--- a/packages/python/slop-ai/src/slop_ai/discovery/bridge.py
+++ b/packages/python/slop-ai/src/slop_ai/discovery/bridge.py
@@ -1,0 +1,388 @@
+"""Bridge client and server for browser-backed SLOP providers."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import importlib
+import json
+from collections import defaultdict
+from typing import Any, Callable, Protocol
+from urllib.parse import urlparse
+
+from .models import BridgeProvider, parse_bridge_provider
+
+RelayHandler = Callable[[dict[str, Any]], None]
+ProviderChangeHandler = Callable[[], None]
+
+WsClientConnection = Any
+WsServer = Any
+WsServerConnection = Any
+
+try:
+    ws_connect = importlib.import_module("websockets.asyncio.client").connect
+    ws_serve = importlib.import_module("websockets.asyncio.server").serve
+except ImportError:  # pragma: no cover - exercised by import sites
+    ws_connect = None  # type: ignore[assignment]
+    ws_serve = None  # type: ignore[assignment]
+
+
+class Bridge(Protocol):
+    """Shared interface for bridge client and server."""
+
+    def running(self) -> bool: ...
+    def providers(self) -> list[BridgeProvider]: ...
+    def on_provider_change(self, fn: ProviderChangeHandler) -> None: ...
+    def subscribe_relay(self, provider_key: str, handler: RelayHandler) -> None: ...
+    def unsubscribe_relay(self, provider_key: str, handler: RelayHandler) -> None: ...
+    async def send(self, message: dict[str, Any]) -> None: ...
+    async def stop(self) -> None: ...
+
+
+class BridgeClient:
+    """Connects to an existing bridge and mirrors provider announcements."""
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        logger: Any | None = None,
+        reconnect_delay: float = 5.0,
+        dial_timeout: float = 1.0,
+    ) -> None:
+        self._url = url
+        self._logger = logger
+        self._reconnect_delay = reconnect_delay
+        self._dial_timeout = dial_timeout
+        self._ws: WsClientConnection | None = None
+        self._reader_task: asyncio.Task[None] | None = None
+        self._reconnect_task: asyncio.Task[None] | None = None
+        self._providers: dict[str, BridgeProvider] = {}
+        self._relay_subscribers: dict[str, list[RelayHandler]] = defaultdict(list)
+        self._running = False
+        self._started = False
+        self._provider_change_handlers: list[ProviderChangeHandler] = []
+
+    async def connect_once(self) -> None:
+        """Try a single connection attempt."""
+        if ws_connect is None:
+            raise ImportError(
+                "Install websockets to use slop_ai.discovery bridge support"
+            )
+        if self._ws is not None:
+            return
+
+        assert ws_connect is not None
+        self._ws = await ws_connect(self._url, open_timeout=self._dial_timeout)
+        self._running = True
+        self._reader_task = asyncio.create_task(self._read_loop())
+        self._log_info(f"[slop-bridge] Connected to existing bridge at {self._url}")
+
+    def start(self) -> None:
+        """Enable reconnect behavior for future disconnects."""
+        if self._started:
+            return
+        self._started = True
+        if self._ws is None:
+            self._schedule_reconnect(0.0)
+
+    async def stop(self) -> None:
+        """Stop reconnecting and close the bridge connection."""
+        self._started = False
+
+        if self._reconnect_task is not None:
+            self._reconnect_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._reconnect_task
+            self._reconnect_task = None
+
+        if self._reader_task is not None:
+            self._reader_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._reader_task
+            self._reader_task = None
+
+        if self._ws is not None:
+            await self._ws.close()
+            self._ws = None
+
+        providers_changed = bool(self._providers)
+        self._providers.clear()
+        self._relay_subscribers.clear()
+        self._running = False
+        if providers_changed:
+            self._emit_provider_change()
+
+    def running(self) -> bool:
+        return self._running
+
+    def providers(self) -> list[BridgeProvider]:
+        return list(self._providers.values())
+
+    def on_provider_change(self, fn: ProviderChangeHandler) -> None:
+        self._provider_change_handlers.append(fn)
+
+    def subscribe_relay(self, provider_key: str, handler: RelayHandler) -> None:
+        self._relay_subscribers[provider_key].append(handler)
+
+    def unsubscribe_relay(self, provider_key: str, handler: RelayHandler) -> None:
+        handlers = self._relay_subscribers.get(provider_key)
+        if not handlers:
+            return
+        with contextlib.suppress(ValueError):
+            handlers.remove(handler)
+        if not handlers:
+            self._relay_subscribers.pop(provider_key, None)
+
+    async def send(self, message: dict[str, Any]) -> None:
+        if self._ws is None:
+            raise RuntimeError("Bridge client is not connected")
+        await self._ws.send(json.dumps(message))
+
+    async def _read_loop(self) -> None:
+        assert self._ws is not None
+        try:
+            async for raw in self._ws:
+                message = json.loads(raw)
+                self._handle_message(message)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self._log_error("[slop-bridge] Bridge client read error")
+        finally:
+            await self._handle_disconnect()
+
+    async def _handle_disconnect(self) -> None:
+        if self._ws is None and not self._running:
+            return
+
+        self._ws = None
+        self._running = False
+        providers_changed = bool(self._providers)
+        self._providers.clear()
+        self._relay_subscribers.clear()
+        if providers_changed:
+            self._emit_provider_change()
+
+        if self._started:
+            self._schedule_reconnect(self._reconnect_delay)
+
+    def _schedule_reconnect(self, delay: float) -> None:
+        if not self._started or self._reconnect_task is not None:
+            return
+
+        async def _retry() -> None:
+            try:
+                if delay > 0:
+                    await asyncio.sleep(delay)
+                while self._started and self._ws is None:
+                    try:
+                        await self.connect_once()
+                        return
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception:
+                        await asyncio.sleep(self._reconnect_delay)
+            finally:
+                self._reconnect_task = None
+
+        self._reconnect_task = asyncio.create_task(_retry())
+
+    def _handle_message(self, message: dict[str, Any]) -> None:
+        message_type = message.get("type")
+
+        if message_type == "provider-available":
+            provider = parse_bridge_provider(message)
+            if provider is None:
+                return
+            self._providers[provider.provider_key] = provider
+            self._emit_provider_change()
+            return
+
+        if message_type == "provider-unavailable":
+            provider_key = message.get("providerKey")
+            if not isinstance(provider_key, str) or not provider_key:
+                return
+            self._providers.pop(provider_key, None)
+            self._relay_subscribers.pop(provider_key, None)
+            self._emit_provider_change()
+            return
+
+        if message_type == "slop-relay":
+            provider_key = message.get("providerKey")
+            payload = message.get("message")
+            if not isinstance(provider_key, str) or not isinstance(payload, dict):
+                return
+            for handler in list(self._relay_subscribers.get(provider_key, [])):
+                handler(payload)
+
+    def _emit_provider_change(self) -> None:
+        for handler in self._provider_change_handlers:
+            handler()
+
+    def _log_info(self, message: str) -> None:
+        if self._logger is None:
+            return
+        info = getattr(self._logger, "info", None)
+        if callable(info):
+            info(message)
+
+    def _log_error(self, message: str) -> None:
+        if self._logger is None:
+            return
+        error = getattr(self._logger, "error", None)
+        if callable(error):
+            error(message)
+
+
+class BridgeServer:
+    """Hosts the extension bridge locally for browser-backed providers."""
+
+    def __init__(self, url: str, *, logger: Any | None = None) -> None:
+        if ws_serve is None:
+            raise ImportError(
+                "Install websockets to use slop_ai.discovery bridge support"
+            )
+
+        parsed = urlparse(url)
+        self._host = parsed.hostname or "127.0.0.1"
+        self._port = parsed.port or 9339
+        self._path = parsed.path or "/slop-bridge"
+        self._logger = logger
+        self._server: WsServer | None = None
+        self._sinks: set[WsServerConnection] = set()
+        self._providers: dict[str, BridgeProvider] = {}
+        self._relay_subscribers: dict[str, list[RelayHandler]] = defaultdict(list)
+        self._provider_change_handlers: list[ProviderChangeHandler] = []
+        self._running = False
+
+    async def start(self) -> None:
+        assert ws_serve is not None
+        self._server = await ws_serve(self._handle_connection, self._host, self._port)
+        self._running = True
+
+    async def stop(self) -> None:
+        self._running = False
+        providers_changed = bool(self._providers)
+        self._providers.clear()
+        self._relay_subscribers.clear()
+
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+        sinks = list(self._sinks)
+        self._sinks.clear()
+        for sink in sinks:
+            with contextlib.suppress(Exception):
+                await sink.close()
+
+        if providers_changed:
+            self._emit_provider_change()
+
+    def running(self) -> bool:
+        return self._running
+
+    def providers(self) -> list[BridgeProvider]:
+        return list(self._providers.values())
+
+    def on_provider_change(self, fn: ProviderChangeHandler) -> None:
+        self._provider_change_handlers.append(fn)
+
+    def subscribe_relay(self, provider_key: str, handler: RelayHandler) -> None:
+        self._relay_subscribers[provider_key].append(handler)
+
+    def unsubscribe_relay(self, provider_key: str, handler: RelayHandler) -> None:
+        handlers = self._relay_subscribers.get(provider_key)
+        if not handlers:
+            return
+        with contextlib.suppress(ValueError):
+            handlers.remove(handler)
+        if not handlers:
+            self._relay_subscribers.pop(provider_key, None)
+
+    async def send(self, message: dict[str, Any]) -> None:
+        await self._broadcast(message)
+
+    async def _broadcast(self, message: dict[str, Any]) -> None:
+        if not self._sinks:
+            return
+        payload = json.dumps(message)
+        for sink in list(self._sinks):
+            try:
+                await sink.send(payload)
+            except Exception:
+                self._sinks.discard(sink)
+
+    async def _handle_connection(self, ws: WsServerConnection) -> None:
+        if ws.request and ws.request.path != self._path:
+            await ws.close(4004, f"Not found: {ws.request.path}")
+            return
+
+        self._sinks.add(ws)
+        for provider in self._providers.values():
+            message = {
+                "type": "provider-available",
+                "tabId": provider.tab_id,
+                "providerKey": provider.provider_key,
+                "provider": {
+                    "id": provider.id,
+                    "name": provider.name,
+                    "transport": provider.transport,
+                },
+            }
+            if provider.url:
+                message["provider"]["url"] = provider.url
+            await ws.send(json.dumps(message))
+
+        try:
+            async for raw in ws:
+                await self._handle_message(json.loads(raw))
+        finally:
+            self._sinks.discard(ws)
+            if not self._sinks:
+                providers_changed = bool(self._providers)
+                self._providers.clear()
+                self._relay_subscribers.clear()
+                if providers_changed:
+                    self._emit_provider_change()
+
+    async def _handle_message(self, message: dict[str, Any]) -> None:
+        message_type = message.get("type")
+
+        if message_type == "provider-available":
+            provider = parse_bridge_provider(message)
+            if provider is None:
+                return
+            self._providers[provider.provider_key] = provider
+            await self._broadcast(message)
+            self._emit_provider_change()
+            return
+
+        if message_type == "provider-unavailable":
+            provider_key = message.get("providerKey")
+            if not isinstance(provider_key, str) or not provider_key:
+                return
+            self._providers.pop(provider_key, None)
+            self._relay_subscribers.pop(provider_key, None)
+            await self._broadcast(message)
+            self._emit_provider_change()
+            return
+
+        if message_type == "slop-relay":
+            provider_key = message.get("providerKey")
+            payload = message.get("message")
+            if not isinstance(provider_key, str) or not isinstance(payload, dict):
+                return
+            for handler in list(self._relay_subscribers.get(provider_key, [])):
+                handler(payload)
+            await self._broadcast(message)
+            return
+
+        if message_type in {"relay-open", "relay-close"}:
+            await self._broadcast(message)
+
+    def _emit_provider_change(self) -> None:
+        for handler in self._provider_change_handlers:
+            handler()

--- a/packages/python/slop-ai/src/slop_ai/discovery/models.py
+++ b/packages/python/slop-ai/src/slop_ai/discovery/models.py
@@ -1,0 +1,232 @@
+"""Shared discovery-layer models for the Python SDK."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from slop_ai.consumer import SlopConsumer
+
+ProviderSource = Literal["local", "bridge"]
+ProviderStatus = Literal["connecting", "connected", "disconnected"]
+
+
+@dataclass(slots=True)
+class TransportDescriptor:
+    """How to connect to a provider."""
+
+    type: Literal["unix", "ws", "stdio", "relay"]
+    path: str | None = None
+    url: str | None = None
+
+
+@dataclass(slots=True)
+class ProviderDescriptor:
+    """Discoverable provider descriptor."""
+
+    id: str
+    name: str
+    slop_version: str
+    transport: TransportDescriptor
+    capabilities: list[str]
+    pid: int | None = None
+    provider_key: str | None = None
+    source: ProviderSource = "local"
+
+    def address(self) -> str:
+        if self.transport.type == "unix" and self.transport.path:
+            return f"unix:{self.transport.path}"
+        if self.transport.type == "ws" and self.transport.url:
+            return self.transport.url
+        if self.transport.type == "relay" and self.provider_key:
+            return f"bridge:{self.provider_key}"
+        return self.transport.type
+
+
+@dataclass(slots=True)
+class ConnectedProvider:
+    """Active provider connection managed by the discovery service."""
+
+    id: str
+    name: str
+    descriptor: ProviderDescriptor
+    consumer: SlopConsumer
+    subscription_id: str
+    status: ProviderStatus
+
+
+@dataclass(slots=True)
+class BridgeProvider:
+    """Provider announced through the extension bridge."""
+
+    provider_key: str
+    tab_id: int
+    id: str
+    name: str
+    transport: Literal["ws", "postmessage"]
+    url: str | None = None
+
+
+@dataclass(slots=True)
+class DiscoveryOptions:
+    """Discovery service configuration."""
+
+    logger: Any | None = None
+    auto_connect: bool = False
+    host_bridge: bool = True
+    providers_dirs: list[str] | None = None
+    bridge_url: str = "ws://127.0.0.1:9339/slop-bridge"
+    idle_timeout: float = 5 * 60.0
+    connect_timeout: float = 10.0
+    scan_interval: float = 15.0
+    watch_interval: float = 0.5
+    reconnect_base_delay: float = 3.0
+    max_reconnect_delay: float = 30.0
+    bridge_dial_timeout: float = 1.0
+    bridge_retry_delay: float = 5.0
+
+
+@dataclass(slots=True)
+class DynamicToolEntry:
+    """Provider-scoped dynamic affordance tool."""
+
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+    provider_id: str
+    path: str
+    action: str
+
+
+@dataclass(slots=True)
+class DynamicToolResolution:
+    """Maps a dynamic tool name back to invoke coordinates."""
+
+    provider_id: str
+    path: str
+    action: str
+
+
+@dataclass(slots=True)
+class DynamicToolSet:
+    """Dynamic tool definitions and a resolver."""
+
+    tools: list[DynamicToolEntry] = field(default_factory=list)
+    _resolve_map: dict[str, DynamicToolResolution] = field(default_factory=dict)
+
+    def resolve(self, tool_name: str) -> DynamicToolResolution | None:
+        return self._resolve_map.get(tool_name)
+
+
+@dataclass(slots=True)
+class ToolResult:
+    """Host-agnostic tool result payload."""
+
+    content: list[dict[str, str]]
+    is_error: bool = False
+
+
+def descriptor_from_dict(
+    data: dict[str, Any], *, source: ProviderSource = "local"
+) -> ProviderDescriptor | None:
+    """Parse and validate a provider descriptor dictionary."""
+    provider_id = data.get("id")
+    name = data.get("name")
+    transport_data = data.get("transport")
+    capabilities = data.get("capabilities")
+
+    if not isinstance(provider_id, str) or not provider_id:
+        return None
+    if not isinstance(name, str) or not name:
+        return None
+    if not isinstance(transport_data, dict):
+        return None
+    transport_type = transport_data.get("type")
+    if transport_type not in {"unix", "ws", "stdio", "relay"}:
+        return None
+    if not isinstance(capabilities, list):
+        return None
+
+    transport = TransportDescriptor(
+        type=transport_type,
+        path=transport_data.get("path")
+        if isinstance(transport_data.get("path"), str)
+        else None,
+        url=transport_data.get("url")
+        if isinstance(transport_data.get("url"), str)
+        else None,
+    )
+
+    pid = data.get("pid")
+    if not isinstance(pid, int):
+        pid = None
+
+    provider_key = data.get("providerKey")
+    if not isinstance(provider_key, str):
+        provider_key = None
+
+    return ProviderDescriptor(
+        id=provider_id,
+        name=name,
+        slop_version=str(data.get("slop_version") or "0.1"),
+        transport=transport,
+        capabilities=[str(item) for item in capabilities],
+        pid=pid,
+        provider_key=provider_key,
+        source=source,
+    )
+
+
+def bridge_provider_to_descriptor(provider: BridgeProvider) -> ProviderDescriptor:
+    """Convert a bridge-announced provider to a merged descriptor."""
+    transport = TransportDescriptor(type="relay")
+    if provider.transport == "ws" and provider.url:
+        transport = TransportDescriptor(type="ws", url=provider.url)
+
+    return ProviderDescriptor(
+        id=provider.provider_key,
+        name=provider.name,
+        slop_version="1.0",
+        transport=transport,
+        capabilities=[],
+        provider_key=provider.provider_key,
+        source="bridge",
+    )
+
+
+def parse_bridge_provider(message: dict[str, Any]) -> BridgeProvider | None:
+    """Parse a `provider-available` bridge message."""
+    provider_key = message.get("providerKey")
+    provider = message.get("provider")
+
+    if not isinstance(provider_key, str) or not provider_key:
+        return None
+    if not isinstance(provider, dict):
+        provider = {}
+
+    raw_tab_id = message.get("tabId")
+    tab_id = int(raw_tab_id) if isinstance(raw_tab_id, (int, float)) else 0
+    transport = provider.get("transport")
+    if transport not in {"ws", "postmessage"}:
+        transport = "postmessage"
+
+    provider_id = provider.get("id")
+    if not isinstance(provider_id, str) or not provider_id:
+        provider_id = provider_key
+
+    name = provider.get("name")
+    if not isinstance(name, str) or not name:
+        name = "Tab"
+
+    url = provider.get("url")
+    if not isinstance(url, str):
+        url = None
+
+    return BridgeProvider(
+        provider_key=provider_key,
+        tab_id=tab_id,
+        id=provider_id,
+        name=name,
+        transport=transport,
+        url=url,
+    )

--- a/packages/python/slop-ai/src/slop_ai/discovery/relay_transport.py
+++ b/packages/python/slop-ai/src/slop_ai/discovery/relay_transport.py
@@ -1,0 +1,108 @@
+"""Relay transport for postMessage browser providers."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Callable
+
+from slop_ai.consumer import ClientConnection, ClientTransport
+
+from .bridge import Bridge, RelayHandler
+
+
+class BridgeRelayConnection:
+    """Client connection that relays SLOP messages through the bridge."""
+
+    def __init__(
+        self, bridge: Bridge, provider_key: str, relay_handler: RelayHandler
+    ) -> None:
+        self._bridge = bridge
+        self._provider_key = provider_key
+        self._relay_handler = relay_handler
+        self._message_handlers: list[Callable[[dict[str, Any]], None]] = []
+        self._close_handlers: list[Callable[[], None]] = []
+        self._early_messages: list[dict[str, Any]] = []
+        self._buffering = True
+        self._closed = False
+
+    async def send(self, message: dict[str, Any]) -> None:
+        if self._closed:
+            return
+        await self._bridge.send(
+            {
+                "type": "slop-relay",
+                "providerKey": self._provider_key,
+                "message": message,
+            }
+        )
+
+    def on_message(self, handler: Callable[[dict[str, Any]], None]) -> None:
+        self._message_handlers.append(handler)
+        if self._buffering:
+            self._buffering = False
+            early_messages = list(self._early_messages)
+            self._early_messages.clear()
+            for message in early_messages:
+                handler(message)
+
+    def on_close(self, handler: Callable[[], None]) -> None:
+        self._close_handlers.append(handler)
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        await self._bridge.send(
+            {"type": "relay-close", "providerKey": self._provider_key}
+        )
+        self._bridge.unsubscribe_relay(self._provider_key, self._relay_handler)
+        for handler in list(self._close_handlers):
+            handler()
+
+    def handle_message(self, message: dict[str, Any]) -> None:
+        if self._buffering:
+            self._early_messages.append(message)
+        for handler in list(self._message_handlers):
+            handler(message)
+
+
+class BridgeRelayTransport(ClientTransport):
+    """Relay browser-tab SLOP messages through the extension bridge."""
+
+    def __init__(self, bridge: Bridge, provider_key: str) -> None:
+        self._bridge = bridge
+        self._provider_key = provider_key
+
+    async def connect(self) -> ClientConnection:
+        got_response = asyncio.Event()
+        connection: BridgeRelayConnection | None = None
+
+        def _relay_handler(message: dict[str, Any]) -> None:
+            got_response.set()
+            if connection is not None:
+                connection.handle_message(message)
+
+        connection = BridgeRelayConnection(
+            self._bridge, self._provider_key, _relay_handler
+        )
+        self._bridge.subscribe_relay(self._provider_key, _relay_handler)
+
+        await self._bridge.send(
+            {"type": "relay-open", "providerKey": self._provider_key}
+        )
+
+        for _ in range(4):
+            await self._bridge.send(
+                {
+                    "type": "slop-relay",
+                    "providerKey": self._provider_key,
+                    "message": {"type": "connect"},
+                }
+            )
+            try:
+                await asyncio.wait_for(got_response.wait(), timeout=0.3)
+                break
+            except asyncio.TimeoutError:
+                continue
+
+        return connection

--- a/packages/python/slop-ai/src/slop_ai/discovery/service.py
+++ b/packages/python/slop-ai/src/slop_ai/discovery/service.py
@@ -1,0 +1,521 @@
+"""Core discovery service for the Python SDK."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from slop_ai.consumer import SlopConsumer
+from slop_ai.transports.unix_client import UnixClientTransport
+from slop_ai.transports.ws_client import WebSocketClientTransport
+
+from .bridge import Bridge, BridgeClient, BridgeServer
+from .models import (
+    ConnectedProvider,
+    DiscoveryOptions,
+    ProviderDescriptor,
+    bridge_provider_to_descriptor,
+    descriptor_from_dict,
+)
+from .relay_transport import BridgeRelayTransport
+
+
+class DiscoveryService:
+    """Discover, connect, and manage local and browser-backed SLOP providers."""
+
+    def __init__(self, options: DiscoveryOptions | None = None) -> None:
+        self._options = options or DiscoveryOptions()
+        self._providers_dirs = [
+            Path(path)
+            for path in (self._options.providers_dirs or _default_providers_dirs())
+        ]
+        self._providers: dict[str, ConnectedProvider] = {}
+        self._local_descriptors: list[ProviderDescriptor] = []
+        self._last_accessed: dict[str, float] = {}
+        self._reconnect_attempts: dict[str, int] = {}
+        self._intentional_disconnects: set[str] = set()
+        self._connect_tasks: dict[str, asyncio.Task[ConnectedProvider | None]] = {}
+        self._reconnect_tasks: dict[str, asyncio.Task[None]] = {}
+        self._state_change_handlers: list[Callable[[], None]] = []
+        self._bridge: Bridge | None = None
+        self._started = False
+        self._scan_task: asyncio.Task[None] | None = None
+        self._watch_task: asyncio.Task[None] | None = None
+        self._idle_task: asyncio.Task[None] | None = None
+        self._bridge_task: asyncio.Task[None] | None = None
+        self._dir_snapshot: dict[Path, tuple[str, ...]] = {}
+
+    async def start(self) -> None:
+        """Start discovery scanning, watching, and bridge management."""
+        if self._started:
+            return
+        self._started = True
+
+        await self._scan()
+        self._scan_task = asyncio.create_task(self._scan_loop())
+        self._watch_task = asyncio.create_task(self._watch_loop())
+        self._idle_task = asyncio.create_task(self._idle_loop())
+        self._bridge_task = asyncio.create_task(self._init_bridge())
+
+    async def stop(self) -> None:
+        """Stop discovery management and disconnect all providers."""
+        if not self._started:
+            return
+        self._started = False
+
+        tasks = [
+            task
+            for task in [
+                self._bridge_task,
+                self._watch_task,
+                self._scan_task,
+                self._idle_task,
+            ]
+            if task is not None
+        ]
+        for task in tasks:
+            task.cancel()
+        for task in tasks:
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+        self._bridge_task = None
+        self._watch_task = None
+        self._scan_task = None
+        self._idle_task = None
+
+        reconnect_tasks = list(self._reconnect_tasks.values())
+        self._reconnect_tasks.clear()
+        for task in reconnect_tasks:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+        if self._bridge is not None:
+            await self._bridge.stop()
+            self._bridge = None
+
+        providers = list(self._providers.values())
+        self._providers.clear()
+        self._last_accessed.clear()
+        self._reconnect_attempts.clear()
+        self._intentional_disconnects.clear()
+        for provider in providers:
+            provider.consumer.disconnect()
+
+    def on_state_change(self, fn: Callable[[], None]) -> None:
+        """Register a callback fired on connect, disconnect, and state patch."""
+        self._state_change_handlers.append(fn)
+
+    def get_discovered(self) -> list[ProviderDescriptor]:
+        """Return all currently known provider descriptors."""
+        return [*self._local_descriptors, *self._bridge_descriptors()]
+
+    def get_providers(self) -> list[ConnectedProvider]:
+        """Return connected providers."""
+        return [
+            provider
+            for provider in self._providers.values()
+            if provider.status == "connected"
+        ]
+
+    def get_provider(self, provider_id: str) -> ConnectedProvider | None:
+        """Return a connected provider by ID."""
+        provider = self._providers.get(provider_id)
+        if provider is None or provider.status != "connected":
+            return None
+        self._last_accessed[provider.id] = asyncio.get_running_loop().time()
+        return provider
+
+    async def ensure_connected(self, id_or_name: str) -> ConnectedProvider | None:
+        """Return a connected provider by ID or name, connecting it if needed."""
+        provider = self._find_connected_provider(id_or_name)
+        if provider is not None:
+            return provider
+
+        descriptor = self._find_descriptor(id_or_name)
+        if descriptor is None:
+            return None
+
+        return await self._connect_provider(descriptor)
+
+    def disconnect(self, id_or_name: str) -> bool:
+        """Disconnect a provider by ID or fuzzy name."""
+        provider = self._find_any_provider(id_or_name)
+        if provider is None:
+            return False
+
+        self._intentional_disconnects.add(provider.id)
+        provider.consumer.disconnect()
+        self._forget_provider(provider.id)
+        self._fire_state_change()
+        return True
+
+    async def _init_bridge(self) -> None:
+        client = BridgeClient(
+            self._options.bridge_url,
+            logger=self._options.logger,
+            reconnect_delay=self._options.bridge_retry_delay,
+            dial_timeout=self._options.bridge_dial_timeout,
+        )
+
+        try:
+            await client.connect_once()
+        except Exception:
+            if not self._options.host_bridge:
+                client.start()
+                self._attach_bridge(client)
+                return
+
+            try:
+                server = BridgeServer(
+                    self._options.bridge_url, logger=self._options.logger
+                )
+                await server.start()
+            except Exception:
+                client.start()
+                self._attach_bridge(client)
+                return
+
+            self._attach_bridge(server)
+            return
+
+        client.start()
+        self._attach_bridge(client)
+
+    def _attach_bridge(self, bridge: Bridge) -> None:
+        self._bridge = bridge
+
+        def _on_provider_change() -> None:
+            asyncio.create_task(self._scan())
+
+        bridge.on_provider_change(_on_provider_change)
+        asyncio.create_task(self._scan())
+
+    async def _scan_loop(self) -> None:
+        try:
+            while self._started:
+                await asyncio.sleep(self._options.scan_interval)
+                await self._scan()
+        except asyncio.CancelledError:
+            return
+
+    async def _watch_loop(self) -> None:
+        try:
+            while self._started:
+                changed = False
+                for directory in self._providers_dirs:
+                    snapshot = _directory_signature(directory)
+                    if self._dir_snapshot.get(directory) != snapshot:
+                        self._dir_snapshot[directory] = snapshot
+                        changed = True
+                if changed:
+                    await self._scan()
+                await asyncio.sleep(self._options.watch_interval)
+        except asyncio.CancelledError:
+            return
+
+    async def _idle_loop(self) -> None:
+        try:
+            while self._started:
+                await asyncio.sleep(60.0)
+                self._check_idle()
+        except asyncio.CancelledError:
+            return
+
+    async def _scan(self) -> None:
+        self._local_descriptors = self._read_descriptors()
+        all_descriptors = self.get_discovered()
+        all_ids = {desc.id for desc in all_descriptors}
+        disconnected = False
+
+        for provider_id, provider in list(self._providers.items()):
+            if provider_id not in all_ids:
+                self._intentional_disconnects.add(provider_id)
+                provider.consumer.disconnect()
+                self._forget_provider(provider_id)
+                disconnected = True
+
+        if disconnected:
+            self._fire_state_change()
+
+        if not self._options.auto_connect:
+            return
+
+        for descriptor in all_descriptors:
+            if descriptor.id in self._providers or descriptor.id in self._connect_tasks:
+                continue
+            asyncio.create_task(self._connect_provider(descriptor))
+
+    async def _connect_provider(
+        self, descriptor: ProviderDescriptor
+    ) -> ConnectedProvider | None:
+        existing = self._providers.get(descriptor.id)
+        if existing is not None and existing.status == "connected":
+            self._last_accessed[descriptor.id] = asyncio.get_running_loop().time()
+            return existing
+
+        task = self._connect_tasks.get(descriptor.id)
+        if task is not None:
+            return await task
+
+        async def _run() -> ConnectedProvider | None:
+            try:
+                transport = self._create_transport(descriptor)
+            except Exception as exc:
+                self._log_error(
+                    f"[slop] Failed to create transport for {descriptor.name}: {exc}"
+                )
+                return None
+            if transport is None:
+                self._log_info(
+                    f"[slop] Skipping {descriptor.name}: unsupported transport {descriptor.transport.type}"
+                )
+                return None
+
+            provider = ConnectedProvider(
+                id=descriptor.id,
+                name=descriptor.name,
+                descriptor=descriptor,
+                consumer=SlopConsumer(transport, timeout=self._options.connect_timeout),
+                subscription_id="",
+                status="connecting",
+            )
+            self._providers[descriptor.id] = provider
+
+            try:
+                hello = await asyncio.wait_for(
+                    provider.consumer.connect(), timeout=self._options.connect_timeout
+                )
+                subscription = await asyncio.wait_for(
+                    provider.consumer.subscribe("/", -1),
+                    timeout=self._options.connect_timeout,
+                )
+            except Exception as exc:
+                self._providers.pop(descriptor.id, None)
+                self._log_error(f"[slop] Failed to connect to {descriptor.name}: {exc}")
+                return None
+
+            provider.name = _provider_name(hello, descriptor.name)
+            provider.subscription_id = subscription["id"]
+            provider.status = "connected"
+            self._last_accessed[descriptor.id] = asyncio.get_running_loop().time()
+            self._reconnect_attempts.pop(descriptor.id, None)
+            self._intentional_disconnects.discard(descriptor.id)
+
+            provider.consumer.on_patch(lambda *_: self._fire_state_change())
+
+            def _on_disconnect(
+                provider_id: str = descriptor.id,
+                name: str = provider.name,
+                desc: ProviderDescriptor = descriptor,
+            ) -> None:
+                asyncio.create_task(
+                    self._handle_provider_disconnect(provider_id, name, desc)
+                )
+
+            provider.consumer.on_disconnect(_on_disconnect)
+            provider.consumer.on_error(
+                lambda msg, provider_id=descriptor.id: self._log_error(
+                    f"[slop] Provider {provider_id} error: {msg}"
+                )
+            )
+
+            self._fire_state_change()
+            return provider
+
+        task = asyncio.create_task(_run())
+        self._connect_tasks[descriptor.id] = task
+        try:
+            return await task
+        finally:
+            self._connect_tasks.pop(descriptor.id, None)
+
+    async def _handle_provider_disconnect(
+        self, provider_id: str, name: str, descriptor: ProviderDescriptor
+    ) -> None:
+        self._forget_provider(provider_id)
+        self._fire_state_change()
+
+        if provider_id in self._intentional_disconnects:
+            self._intentional_disconnects.discard(provider_id)
+            return
+        if self._find_descriptor(provider_id) is None:
+            return
+        if not self._started:
+            return
+
+        attempt = self._reconnect_attempts.get(provider_id, 0) + 1
+        self._reconnect_attempts[provider_id] = attempt
+        delay = min(
+            self._options.reconnect_base_delay * (2 ** (attempt - 1)),
+            self._options.max_reconnect_delay,
+        )
+        self._log_info(
+            f"[slop] Will reconnect to {name} in {delay:.1f}s (attempt {attempt})"
+        )
+
+        async def _retry() -> None:
+            try:
+                await asyncio.sleep(delay)
+                if self._started and provider_id not in self._providers:
+                    await self._connect_provider(descriptor)
+            except asyncio.CancelledError:
+                return
+
+        old_task = self._reconnect_tasks.pop(provider_id, None)
+        if old_task is not None:
+            old_task.cancel()
+        self._reconnect_tasks[provider_id] = asyncio.create_task(_retry())
+
+    def _check_idle(self) -> None:
+        now = asyncio.get_running_loop().time()
+        for provider_id, last_accessed in list(self._last_accessed.items()):
+            if now - last_accessed <= self._options.idle_timeout:
+                continue
+            provider = self._providers.get(provider_id)
+            if provider is None:
+                continue
+            self._intentional_disconnects.add(provider_id)
+            provider.consumer.disconnect()
+            self._forget_provider(provider_id)
+            self._fire_state_change()
+
+    def _read_descriptors(self) -> list[ProviderDescriptor]:
+        descriptors: list[ProviderDescriptor] = []
+        for directory in self._providers_dirs:
+            if not directory.exists():
+                continue
+            for path in directory.glob("*.json"):
+                try:
+                    data = json.loads(path.read_text())
+                except Exception as exc:
+                    self._log_error(f"[slop] Failed to parse {path.name}: {exc}")
+                    continue
+                descriptor = descriptor_from_dict(data, source="local")
+                if descriptor is None:
+                    self._log_error(f"[slop] Invalid descriptor in {path.name}")
+                    continue
+                descriptors.append(descriptor)
+        return descriptors
+
+    def _bridge_descriptors(self) -> list[ProviderDescriptor]:
+        if self._bridge is None or not self._bridge.running():
+            return []
+        return [
+            bridge_provider_to_descriptor(provider)
+            for provider in self._bridge.providers()
+        ]
+
+    def _create_transport(self, descriptor: ProviderDescriptor) -> Any | None:
+        if descriptor.transport.type == "unix" and descriptor.transport.path:
+            return UnixClientTransport(descriptor.transport.path)
+        if descriptor.transport.type == "ws" and descriptor.transport.url:
+            return WebSocketClientTransport(descriptor.transport.url)
+        if (
+            descriptor.transport.type == "relay"
+            and descriptor.provider_key
+            and self._bridge is not None
+        ):
+            return BridgeRelayTransport(self._bridge, descriptor.provider_key)
+        return None
+
+    def _find_connected_provider(self, id_or_name: str) -> ConnectedProvider | None:
+        provider = self._providers.get(id_or_name)
+        if provider is not None and provider.status == "connected":
+            self._last_accessed[provider.id] = asyncio.get_running_loop().time()
+            return provider
+
+        needle = id_or_name.lower()
+        for provider in self._providers.values():
+            if provider.status == "connected" and needle in provider.name.lower():
+                self._last_accessed[provider.id] = asyncio.get_running_loop().time()
+                return provider
+        return None
+
+    def _find_any_provider(self, id_or_name: str) -> ConnectedProvider | None:
+        provider = self._providers.get(id_or_name)
+        if provider is not None:
+            return provider
+
+        needle = id_or_name.lower()
+        for provider in self._providers.values():
+            if needle in provider.name.lower():
+                return provider
+        return None
+
+    def _find_descriptor(self, id_or_name: str) -> ProviderDescriptor | None:
+        needle = id_or_name.lower()
+        for descriptor in self.get_discovered():
+            if descriptor.id == id_or_name or needle in descriptor.name.lower():
+                return descriptor
+        return None
+
+    def _forget_provider(self, provider_id: str) -> None:
+        self._providers.pop(provider_id, None)
+        self._last_accessed.pop(provider_id, None)
+        self._reconnect_attempts.pop(provider_id, None)
+        reconnect_task = self._reconnect_tasks.pop(provider_id, None)
+        if reconnect_task is not None:
+            reconnect_task.cancel()
+
+    def _fire_state_change(self) -> None:
+        for handler in self._state_change_handlers:
+            handler()
+
+    def _log_info(self, message: str) -> None:
+        if self._options.logger is None:
+            return
+        info = getattr(self._options.logger, "info", None)
+        if callable(info):
+            info(message)
+
+    def _log_error(self, message: str) -> None:
+        if self._options.logger is None:
+            return
+        error = getattr(self._options.logger, "error", None)
+        if callable(error):
+            error(message)
+
+
+def create_discovery_service(
+    options: DiscoveryOptions | None = None,
+) -> DiscoveryService:
+    """Create a discovery service using the phase-1 core contract."""
+    return DiscoveryService(options=options)
+
+
+def _default_providers_dirs() -> list[str]:
+    home = Path.home()
+    return [
+        str(home / ".slop" / "providers"),
+        str(Path(os.getenv("TMPDIR", "/tmp")) / "slop" / "providers"),
+    ]
+
+
+def _directory_signature(directory: Path) -> tuple[str, ...]:
+    if not directory.exists():
+        return ()
+
+    signature: list[str] = []
+    for path in sorted(directory.glob("*.json")):
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        signature.append(f"{path.name}:{stat.st_mtime_ns}:{stat.st_size}")
+    return tuple(signature)
+
+
+def _provider_name(hello: dict[str, Any], fallback: str) -> str:
+    provider = hello.get("provider")
+    if isinstance(provider, dict):
+        name = provider.get("name")
+        if isinstance(name, str) and name:
+            return name
+    return fallback

--- a/packages/python/slop-ai/src/slop_ai/discovery/tools.py
+++ b/packages/python/slop-ai/src/slop_ai/discovery/tools.py
@@ -1,0 +1,177 @@
+"""AI-facing discovery helpers for dynamic tools and core handlers."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from slop_ai.tools import affordances_to_tools, format_tree
+
+from .models import DynamicToolEntry, DynamicToolResolution, DynamicToolSet, ToolResult
+
+_SANITIZE_RE = re.compile(r"[^a-zA-Z0-9]")
+
+
+def _sanitize_prefix(value: str) -> str:
+    return _SANITIZE_RE.sub("_", value).strip("_")
+
+
+def create_dynamic_tools(service: object) -> DynamicToolSet:
+    """Build provider-prefixed dynamic affordance tools from connected providers."""
+    entries: list[DynamicToolEntry] = []
+    resolve_map: dict[str, DynamicToolResolution] = {}
+
+    for provider in service.get_providers():
+        tree = provider.consumer.get_tree(provider.subscription_id)
+        if tree is None:
+            continue
+
+        prefix = _sanitize_prefix(provider.id)
+        tool_set = affordances_to_tools(tree)
+        for tool in tool_set.tools:
+            resolution = tool_set.resolve(tool["function"]["name"])
+            if resolution is None:
+                continue
+            dynamic_name = f"{prefix}__{tool['function']['name']}"
+            entries.append(
+                DynamicToolEntry(
+                    name=dynamic_name,
+                    description=f"[{provider.name}] {tool['function']['description']}",
+                    input_schema=tool["function"]["parameters"],
+                    provider_id=provider.id,
+                    path=resolution.path,
+                    action=resolution.action,
+                )
+            )
+            resolve_map[dynamic_name] = DynamicToolResolution(
+                provider_id=provider.id,
+                path=resolution.path,
+                action=resolution.action,
+            )
+
+    return DynamicToolSet(tools=entries, _resolve_map=resolve_map)
+
+
+@dataclass(slots=True)
+class ToolHandlers:
+    """Core host-agnostic discovery tool handlers."""
+
+    service: object
+
+    async def list_apps(self) -> ToolResult:
+        discovered = self.service.get_discovered()
+        if not discovered:
+            return ToolResult(
+                content=[
+                    {
+                        "type": "text",
+                        "text": "No applications found. Desktop and web apps that support external control will appear here automatically when they're running.",
+                    }
+                ]
+            )
+
+        connected = {provider.id: provider for provider in self.service.get_providers()}
+        lines: list[str] = []
+        for desc in discovered:
+            provider = connected.get(desc.id)
+            tree = (
+                provider.consumer.get_tree(provider.subscription_id)
+                if provider
+                else None
+            )
+            action_count = len(affordances_to_tools(tree).tools) if tree else 0
+            label = tree.properties.get("label") if tree and tree.properties else None
+            if not isinstance(label, str) or not label:
+                label = desc.name
+            status = f"connected, {action_count} actions" if provider else "available"
+            lines.append(
+                f"- **{label}** (id: `{desc.id}`, {desc.transport.type}) - {status}"
+            )
+
+        return ToolResult(
+            content=[
+                {
+                    "type": "text",
+                    "text": "Applications on this computer:\n"
+                    + "\n".join(lines)
+                    + "\n\nUse connect_app with an app name or ID to connect and inspect it.",
+                }
+            ]
+        )
+
+    async def connect_app(self, app: str) -> ToolResult:
+        provider = await self.service.ensure_connected(app)
+        if provider is None:
+            available = (
+                ", ".join(
+                    f"{desc.name} ({desc.id})" for desc in self.service.get_discovered()
+                )
+                or "none"
+            )
+            return ToolResult(
+                content=[
+                    {
+                        "type": "text",
+                        "text": f'App "{app}" not found. Available: {available}',
+                    }
+                ],
+                is_error=True,
+            )
+
+        tree = provider.consumer.get_tree(provider.subscription_id)
+        if tree is None:
+            return ToolResult(
+                content=[
+                    {
+                        "type": "text",
+                        "text": f"{provider.name} is connected but has no state yet.",
+                    }
+                ]
+            )
+
+        tool_set = affordances_to_tools(tree)
+        actions_text = "\n".join(
+            f"  - **{(resolution.action if resolution else tool['function']['name'])}** on `{(resolution.path if resolution else '/')}`: {tool['function']['description']}"
+            for tool in tool_set.tools
+            for resolution in [tool_set.resolve(tool["function"]["name"])]
+        )
+
+        return ToolResult(
+            content=[
+                {
+                    "type": "text",
+                    "text": (
+                        f"## {provider.name}\n"
+                        f"ID: `{provider.id}`\n\n"
+                        f"### Current State\n```\n{format_tree(tree)}\n```\n\n"
+                        f"### Available Actions ({len(tool_set.tools)})\n{actions_text}"
+                    ),
+                }
+            ]
+        )
+
+    async def disconnect_app(self, app: str) -> ToolResult:
+        if not self.service.disconnect(app):
+            return ToolResult(
+                content=[
+                    {
+                        "type": "text",
+                        "text": f'App "{app}" is not connected. Use list_apps to see available apps.',
+                    }
+                ],
+                is_error=True,
+            )
+
+        return ToolResult(
+            content=[
+                {
+                    "type": "text",
+                    "text": f'Disconnected from "{app}". Its tools have been removed.',
+                }
+            ]
+        )
+
+
+def create_tool_handlers(service: object) -> ToolHandlers:
+    """Create the core discovery tool handlers."""
+    return ToolHandlers(service=service)

--- a/packages/python/slop-ai/tests/test_discovery.py
+++ b/packages/python/slop-ai/tests/test_discovery.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import importlib
+import json
+import socket
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from slop_ai.discovery import (
+    BridgeRelayTransport,
+    BridgeServer,
+    DiscoveryOptions,
+    DiscoveryService,
+)
+
+
+def test_service_scans_and_prunes_descriptors(tmp_path: Path) -> None:
+    async def _run() -> None:
+        descriptor_path = tmp_path / "test-app.json"
+        descriptor_path.write_text(
+            json.dumps(
+                {
+                    "id": "test-app",
+                    "name": "Test App",
+                    "slop_version": "0.1",
+                    "transport": {"type": "unix", "path": "/tmp/slop/test-app.sock"},
+                    "capabilities": ["state"],
+                }
+            )
+        )
+
+        service = DiscoveryService(
+            DiscoveryOptions(
+                providers_dirs=[str(tmp_path)],
+                bridge_url="ws://127.0.0.1:1/slop-bridge",
+                host_bridge=False,
+                scan_interval=0.05,
+                watch_interval=0.02,
+                bridge_retry_delay=0.05,
+                bridge_dial_timeout=0.05,
+            )
+        )
+
+        await service.start()
+        try:
+            await _wait_until(lambda: len(service.get_discovered()) == 1)
+            descriptor_path.unlink()
+            await _wait_until(lambda: len(service.get_discovered()) == 0)
+        finally:
+            await service.stop()
+
+    asyncio.run(_run())
+
+
+def test_bridge_server_forwards_relay_control_messages() -> None:
+    pytest.importorskip("websockets")
+
+    async def _run() -> None:
+        connect = importlib.import_module("websockets.asyncio.client").connect
+        port = _free_port()
+        url = f"ws://127.0.0.1:{port}/slop-bridge"
+
+        server = BridgeServer(url)
+        await server.start()
+        try:
+            async with connect(url) as client_one, connect(url) as client_two:
+                await client_one.send(
+                    json.dumps({"type": "relay-open", "providerKey": "tab-1"})
+                )
+                message = json.loads(
+                    await asyncio.wait_for(client_two.recv(), timeout=1.0)
+                )
+                assert message["type"] == "relay-open"
+
+                await client_one.send(
+                    json.dumps({"type": "relay-close", "providerKey": "tab-1"})
+                )
+                message = json.loads(
+                    await asyncio.wait_for(client_two.recv(), timeout=1.0)
+                )
+                assert message["type"] == "relay-close"
+        finally:
+            await server.stop()
+
+    asyncio.run(_run())
+
+
+def test_relay_transport_buffers_early_messages() -> None:
+    async def _run() -> None:
+        bridge = _FakeBridge()
+        transport = BridgeRelayTransport(bridge, "tab-1")
+        connection = await transport.connect()
+        try:
+            message_future: asyncio.Future[dict[str, Any]] = (
+                asyncio.get_running_loop().create_future()
+            )
+            connection.on_message(
+                lambda message: (
+                    message_future.set_result(message)
+                    if not message_future.done()
+                    else None
+                )
+            )
+            message = await asyncio.wait_for(message_future, timeout=1.0)
+            assert message["type"] == "hello"
+        finally:
+            await connection.close()
+
+    asyncio.run(_run())
+
+
+async def _wait_until(predicate: Any, timeout: float = 1.0) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("condition not met before timeout")
+
+
+def _free_port() -> int:
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+class _FakeBridge:
+    def __init__(self) -> None:
+        self._subs: dict[str, list[Any]] = {}
+
+    def running(self) -> bool:
+        return True
+
+    def providers(self) -> list[Any]:
+        return []
+
+    def on_provider_change(self, fn: Any) -> None:
+        return None
+
+    def subscribe_relay(self, provider_key: str, handler: Any) -> None:
+        self._subs.setdefault(provider_key, []).append(handler)
+
+    def unsubscribe_relay(self, provider_key: str, handler: Any) -> None:
+        with contextlib.suppress(ValueError):
+            self._subs.get(provider_key, []).remove(handler)
+
+    async def send(self, message: dict[str, Any]) -> None:
+        if message.get("type") != "slop-relay":
+            return
+        payload = message.get("message")
+        provider_key = message.get("providerKey")
+        if not isinstance(payload, dict) or payload.get("type") != "connect":
+            return
+        if not isinstance(provider_key, str):
+            return
+        for handler in list(self._subs.get(provider_key, [])):
+            handler({"type": "hello", "provider": {"name": "Browser App"}})
+
+    def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None

--- a/packages/rust/slop-ai/Cargo.toml
+++ b/packages/rust/slop-ai/Cargo.toml
@@ -28,7 +28,7 @@ serde_json = "1"
 thiserror = "2"
 
 # Optional — pulled by feature flags
-tokio = { version = "1", features = ["rt", "io-util", "io-std", "net", "sync", "macros", "rt-multi-thread"], optional = true }
+tokio = { version = "1", features = ["rt", "io-util", "io-std", "net", "sync", "macros", "rt-multi-thread", "time"], optional = true }
 tokio-tungstenite = { version = "0.26", optional = true }
 futures-util = { version = "0.3", optional = true }
 axum = { version = "0.8", features = ["ws"], optional = true }

--- a/packages/rust/slop-ai/README.md
+++ b/packages/rust/slop-ai/README.md
@@ -51,3 +51,23 @@ slop.register("todos", json!({
 - Project API page: https://docs.slopai.dev/api/rust
 - Rust guide: https://docs.slopai.dev/guides/rust
 - docs.rs: https://docs.rs/slop-ai
+
+## Discovery layer
+
+The Rust SDK now includes the core discovery layer in `slop_ai::discovery` under the default `native` feature set:
+
+```rust
+use slop_ai::discovery::{DiscoveryService, DiscoveryServiceOptions};
+
+#[tokio::main]
+async fn main() {
+    let service = DiscoveryService::new(DiscoveryServiceOptions::default());
+    service.start().await;
+
+    if let Ok(Some(provider)) = service.ensure_connected("my-app").await {
+        println!("{}", provider.name);
+    }
+
+    service.stop().await;
+}
+```

--- a/packages/rust/slop-ai/src/discovery/bridge.rs
+++ b/packages/rust/slop-ai/src/discovery/bridge.rs
@@ -1,0 +1,756 @@
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use tokio::net::TcpListener;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio::time::{sleep, timeout, Duration};
+use tokio_tungstenite::accept_async;
+use tokio_tungstenite::tungstenite::Message;
+
+use crate::error::{Result, SlopError};
+
+use super::types::{ProviderDescriptor, ProviderSource, TransportDescriptor};
+
+pub const DEFAULT_BRIDGE_ADDR: &str = "127.0.0.1:9339";
+pub const DEFAULT_BRIDGE_PATH: &str = "/slop-bridge";
+pub const DEFAULT_BRIDGE_URL: &str = "ws://127.0.0.1:9339/slop-bridge";
+
+pub type ProviderChangeCallback = Arc<dyn Fn() + Send + Sync>;
+type BridgeFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BridgeProvider {
+    pub provider_key: String,
+    pub tab_id: u64,
+    pub id: String,
+    pub name: String,
+    pub transport: String,
+    pub url: Option<String>,
+}
+
+impl BridgeProvider {
+    pub fn to_descriptor(&self) -> ProviderDescriptor {
+        let transport = if self.transport == "ws" {
+            TransportDescriptor {
+                transport_type: "ws".to_string(),
+                path: None,
+                url: self.url.clone(),
+            }
+        } else {
+            TransportDescriptor {
+                transport_type: "relay".to_string(),
+                path: None,
+                url: None,
+            }
+        };
+
+        ProviderDescriptor {
+            id: self.provider_key.clone(),
+            name: self.name.clone(),
+            slop_version: "1.0".to_string(),
+            transport,
+            pid: None,
+            capabilities: Vec::new(),
+            provider_key: Some(self.provider_key.clone()),
+            source: ProviderSource::Bridge,
+        }
+    }
+}
+
+pub struct RelaySubscription {
+    pub id: u64,
+    pub receiver: mpsc::UnboundedReceiver<Value>,
+}
+
+pub trait Bridge: Send + Sync {
+    fn running(&self) -> bool;
+    fn providers(&self) -> Vec<BridgeProvider>;
+    fn on_provider_change(&self, callback: ProviderChangeCallback);
+    fn subscribe_relay(&self, provider_key: &str) -> RelaySubscription;
+    fn unsubscribe_relay(&self, provider_key: &str, subscription_id: u64);
+    fn send(&self, message: Value) -> BridgeFuture<Result<()>>;
+    fn stop(&self) -> BridgeFuture<()>;
+}
+
+#[derive(Clone)]
+pub struct BridgeClient {
+    inner: Arc<Mutex<BridgeClientInner>>,
+}
+
+struct BridgeClientInner {
+    url: String,
+    retry_delay: Duration,
+    dial_timeout: Duration,
+    providers: HashMap<String, BridgeProvider>,
+    relay_subscribers: HashMap<String, HashMap<u64, mpsc::UnboundedSender<Value>>>,
+    next_subscription_id: u64,
+    callbacks: Vec<ProviderChangeCallback>,
+    writer: Option<mpsc::UnboundedSender<Message>>,
+    read_task: Option<JoinHandle<()>>,
+    write_task: Option<JoinHandle<()>>,
+    reconnect_task: Option<JoinHandle<()>>,
+    running: bool,
+    started: bool,
+}
+
+impl BridgeClient {
+    pub fn new(url: &str, retry_delay: Duration, dial_timeout: Duration) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(BridgeClientInner {
+                url: url.to_string(),
+                retry_delay,
+                dial_timeout,
+                providers: HashMap::new(),
+                relay_subscribers: HashMap::new(),
+                next_subscription_id: 0,
+                callbacks: Vec::new(),
+                writer: None,
+                read_task: None,
+                write_task: None,
+                reconnect_task: None,
+                running: false,
+                started: false,
+            })),
+        }
+    }
+
+    pub async fn connect_once(&self) -> Result<()> {
+        let (url, dial_timeout, already_connected) = {
+            let inner = self.inner.lock().unwrap();
+            (inner.url.clone(), inner.dial_timeout, inner.writer.is_some())
+        };
+        if already_connected {
+            return Ok(());
+        }
+
+        let (stream, _) = timeout(dial_timeout, tokio_tungstenite::connect_async(&url))
+            .await
+            .map_err(|_| SlopError::Transport("bridge client dial timed out".to_string()))?
+            .map_err(|e| SlopError::Transport(format!("bridge client connect: {e}")))?;
+
+        let (mut write, mut read) = stream.split();
+        let (writer_tx, mut writer_rx) = mpsc::unbounded_channel::<Message>();
+
+        let write_task = tokio::spawn(async move {
+            while let Some(message) = writer_rx.recv().await {
+                if write.send(message).await.is_err() {
+                    break;
+                }
+            }
+            let _ = write.close().await;
+        });
+
+        let client = self.clone();
+        let read_task = tokio::spawn(async move {
+            while let Some(Ok(message)) = read.next().await {
+                if let Message::Text(text) = message {
+                    if let Ok(value) = serde_json::from_str::<Value>(&text) {
+                        client.handle_message(value).await;
+                    }
+                }
+            }
+            client.handle_disconnect().await;
+        });
+
+        let mut inner = self.inner.lock().unwrap();
+        inner.writer = Some(writer_tx);
+        inner.write_task = Some(write_task);
+        inner.read_task = Some(read_task);
+        inner.running = true;
+        Ok(())
+    }
+
+    pub fn start(&self) {
+        let client = self.clone();
+        tokio::spawn(async move {
+            let should_schedule = {
+                let mut inner = client.inner.lock().unwrap();
+                if inner.started {
+                    false
+                } else {
+                    inner.started = true;
+                    inner.writer.is_none()
+                }
+            };
+
+            if should_schedule {
+                client.schedule_reconnect(Duration::from_millis(0));
+            }
+        });
+    }
+
+    fn schedule_reconnect(&self, initial_delay: Duration) {
+        let mut inner = self.inner.lock().unwrap();
+        if !inner.started || inner.reconnect_task.is_some() {
+            return;
+        }
+        let client = self.clone();
+        inner.reconnect_task = Some(tokio::spawn(reconnect_client_loop(client, initial_delay)));
+    }
+
+    async fn handle_message(&self, message: Value) {
+        match message["type"].as_str().unwrap_or("") {
+            "provider-available" => {
+                if let Some(provider) = parse_bridge_provider(&message) {
+                    let callbacks = {
+                        let mut inner = self.inner.lock().unwrap();
+                        inner
+                            .providers
+                            .insert(provider.provider_key.clone(), provider);
+                        inner.callbacks.clone()
+                    };
+                    fire_callbacks(callbacks);
+                }
+            }
+            "provider-unavailable" => {
+                if let Some(provider_key) = message["providerKey"].as_str() {
+                    let callbacks = {
+                        let mut inner = self.inner.lock().unwrap();
+                        inner.providers.remove(provider_key);
+                        inner.relay_subscribers.remove(provider_key);
+                        inner.callbacks.clone()
+                    };
+                    fire_callbacks(callbacks);
+                }
+            }
+            "slop-relay" => {
+                let Some(provider_key) = message["providerKey"].as_str() else {
+                    return;
+                };
+                let Some(payload) = message.get("message") else {
+                    return;
+                };
+
+                let subscribers = {
+                    let inner = self.inner.lock().unwrap();
+                    inner
+                        .relay_subscribers
+                        .get(provider_key)
+                        .map(|subs| subs.values().cloned().collect::<Vec<_>>())
+                        .unwrap_or_default()
+                };
+
+                for subscriber in subscribers {
+                    let _ = subscriber.send(payload.clone());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    async fn handle_disconnect(&self) {
+        let (callbacks, should_reconnect, writer_task, read_task) = {
+            let mut inner = self.inner.lock().unwrap();
+            let providers_changed = !inner.providers.is_empty();
+            inner.writer = None;
+            inner.running = false;
+            inner.providers.clear();
+            inner.relay_subscribers.clear();
+            let callbacks = if providers_changed {
+                inner.callbacks.clone()
+            } else {
+                Vec::new()
+            };
+            (
+                callbacks,
+                inner.started,
+                inner.write_task.take(),
+                inner.read_task.take(),
+            )
+        };
+
+        if let Some(task) = writer_task {
+            task.abort();
+        }
+        if let Some(task) = read_task {
+            task.abort();
+        }
+
+        fire_callbacks(callbacks);
+
+        if should_reconnect {
+            let delay = { self.inner.lock().unwrap().retry_delay };
+            self.schedule_reconnect(delay);
+        }
+    }
+}
+
+async fn reconnect_client_loop(client: BridgeClient, initial_delay: Duration) {
+    if !initial_delay.is_zero() {
+        sleep(initial_delay).await;
+    }
+
+    loop {
+        let (started, connected, retry_delay) = {
+            let inner = client.inner.lock().unwrap();
+            (inner.started, inner.writer.is_some(), inner.retry_delay)
+        };
+        if !started || connected {
+            break;
+        }
+
+        if client.connect_once().await.is_ok() {
+            break;
+        }
+
+        sleep(retry_delay).await;
+    }
+
+    let mut inner = client.inner.lock().unwrap();
+    inner.reconnect_task = None;
+}
+
+impl Bridge for BridgeClient {
+    fn running(&self) -> bool {
+        self.inner.lock().unwrap().running
+    }
+
+    fn providers(&self) -> Vec<BridgeProvider> {
+        self.inner
+            .lock()
+            .unwrap()
+            .providers
+            .values()
+            .cloned()
+            .collect()
+    }
+
+    fn on_provider_change(&self, callback: ProviderChangeCallback) {
+        self.inner.lock().unwrap().callbacks.push(callback);
+    }
+
+    fn subscribe_relay(&self, provider_key: &str) -> RelaySubscription {
+        let mut inner = self.inner.lock().unwrap();
+        inner.next_subscription_id += 1;
+        let subscription_id = inner.next_subscription_id;
+        let (tx, rx) = mpsc::unbounded_channel();
+        inner
+            .relay_subscribers
+            .entry(provider_key.to_string())
+            .or_default()
+            .insert(subscription_id, tx);
+
+        RelaySubscription {
+            id: subscription_id,
+            receiver: rx,
+        }
+    }
+
+    fn unsubscribe_relay(&self, provider_key: &str, subscription_id: u64) {
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(subs) = inner.relay_subscribers.get_mut(provider_key) {
+            subs.remove(&subscription_id);
+            if subs.is_empty() {
+                inner.relay_subscribers.remove(provider_key);
+            }
+        }
+    }
+
+    fn send(&self, message: Value) -> BridgeFuture<Result<()>> {
+        let client = self.clone();
+        Box::pin(async move {
+            let text = serde_json::to_string(&message)?;
+            let writer = client
+                .inner
+                .lock()
+                .unwrap()
+                .writer
+                .clone()
+                .ok_or_else(|| SlopError::Transport("bridge client is not connected".to_string()))?;
+            writer
+                .send(Message::Text(text.into()))
+                .map_err(|e| SlopError::Transport(format!("bridge send failed: {e}")))
+        })
+    }
+
+    fn stop(&self) -> BridgeFuture<()> {
+        let client = self.clone();
+        Box::pin(async move {
+            let (writer_task, read_task, reconnect_task) = {
+                let mut inner = client.inner.lock().unwrap();
+                inner.started = false;
+                inner.running = false;
+                inner.writer = None;
+                inner.providers.clear();
+                inner.relay_subscribers.clear();
+                (
+                    inner.write_task.take(),
+                    inner.read_task.take(),
+                    inner.reconnect_task.take(),
+                )
+            };
+
+            if let Some(task) = writer_task {
+                task.abort();
+            }
+            if let Some(task) = read_task {
+                task.abort();
+            }
+            if let Some(task) = reconnect_task {
+                task.abort();
+            }
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct BridgeServer {
+    inner: Arc<Mutex<BridgeServerInner>>,
+}
+
+struct BridgeServerInner {
+    addr: String,
+    path: String,
+    actual_addr: Option<String>,
+    providers: HashMap<String, BridgeProvider>,
+    relay_subscribers: HashMap<String, HashMap<u64, mpsc::UnboundedSender<Value>>>,
+    next_subscription_id: u64,
+    next_sink_id: u64,
+    sinks: HashMap<u64, mpsc::UnboundedSender<Message>>,
+    callbacks: Vec<ProviderChangeCallback>,
+    accept_task: Option<JoinHandle<()>>,
+    running: bool,
+}
+
+impl BridgeServer {
+    pub fn new(addr: &str, path: &str) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(BridgeServerInner {
+                addr: addr.to_string(),
+                path: path.to_string(),
+                actual_addr: None,
+                providers: HashMap::new(),
+                relay_subscribers: HashMap::new(),
+                next_subscription_id: 0,
+                next_sink_id: 0,
+                sinks: HashMap::new(),
+                callbacks: Vec::new(),
+                accept_task: None,
+                running: false,
+            })),
+        }
+    }
+
+    pub async fn start(&self) -> Result<()> {
+        let (addr, path, already_running) = {
+            let inner = self.inner.lock().unwrap();
+            (inner.addr.clone(), inner.path.clone(), inner.running)
+        };
+        if already_running {
+            return Ok(());
+        }
+
+        let listener = TcpListener::bind(&addr)
+            .await
+            .map_err(|e| SlopError::Transport(format!("bridge bind failed: {e}")))?;
+        let actual_addr = listener
+            .local_addr()
+            .map(|addr| addr.to_string())
+            .map_err(|e| SlopError::Transport(format!("bridge local_addr failed: {e}")))?;
+
+        let server = self.clone();
+        let accept_task = tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                let server = server.clone();
+                let path = path.clone();
+                tokio::spawn(async move {
+                    let Ok(ws_stream) = accept_async(stream).await else {
+                        return;
+                    };
+
+                    let (mut write, mut read) = ws_stream.split();
+                    let (sink_tx, mut sink_rx) = mpsc::unbounded_channel::<Message>();
+                    let replay_sink = sink_tx.clone();
+
+                    let (sink_id, providers) = {
+                        let mut inner = server.inner.lock().unwrap();
+                        inner.next_sink_id += 1;
+                        let sink_id = inner.next_sink_id;
+                        inner.sinks.insert(sink_id, sink_tx);
+                        let providers = inner.providers.values().cloned().collect::<Vec<_>>();
+                        (sink_id, providers)
+                    };
+
+                    let writer_task = tokio::spawn(async move {
+                        while let Some(message) = sink_rx.recv().await {
+                            if write.send(message).await.is_err() {
+                                break;
+                            }
+                        }
+                        let _ = write.close().await;
+                    });
+
+                    for provider in providers {
+                        let announce = json!({
+                            "type": "provider-available",
+                            "tabId": provider.tab_id,
+                            "providerKey": provider.provider_key,
+                            "provider": {
+                                "id": provider.id,
+                                "name": provider.name,
+                                "transport": provider.transport,
+                                "url": provider.url,
+                            }
+                        });
+                        if let Ok(text) = serde_json::to_string(&announce) {
+                            let _ = replay_sink.send(Message::Text(text.into()));
+                        }
+                    }
+
+                    while let Some(Ok(message)) = read.next().await {
+                        if let Message::Text(text) = message {
+                            if let Ok(value) = serde_json::from_str::<Value>(&text) {
+                                let _ = server.handle_message(value).await;
+                            }
+                        }
+                    }
+
+                    writer_task.abort();
+                    let callbacks = server.remove_sink(sink_id).await;
+                    fire_callbacks(callbacks);
+                    let _ = path;
+                });
+            }
+        });
+
+        let mut inner = self.inner.lock().unwrap();
+        inner.actual_addr = Some(actual_addr);
+        inner.accept_task = Some(accept_task);
+        inner.running = true;
+        Ok(())
+    }
+
+    pub async fn url(&self) -> String {
+        let inner = self.inner.lock().unwrap();
+        format!(
+            "ws://{}{}",
+            inner
+                .actual_addr
+                .clone()
+                .unwrap_or_else(|| inner.addr.clone()),
+            inner.path
+        )
+    }
+
+    async fn handle_message(&self, message: Value) -> Result<()> {
+        match message["type"].as_str().unwrap_or("") {
+            "provider-available" => {
+                if let Some(provider) = parse_bridge_provider(&message) {
+                    let callbacks = {
+                        let mut inner = self.inner.lock().unwrap();
+                        inner
+                            .providers
+                            .insert(provider.provider_key.clone(), provider);
+                        inner.callbacks.clone()
+                    };
+                    self.broadcast(&message).await?;
+                    fire_callbacks(callbacks);
+                }
+            }
+            "provider-unavailable" => {
+                if let Some(provider_key) = message["providerKey"].as_str() {
+                    let callbacks = {
+                        let mut inner = self.inner.lock().unwrap();
+                        inner.providers.remove(provider_key);
+                        inner.relay_subscribers.remove(provider_key);
+                        inner.callbacks.clone()
+                    };
+                    self.broadcast(&message).await?;
+                    fire_callbacks(callbacks);
+                }
+            }
+            "slop-relay" => {
+                let Some(provider_key) = message["providerKey"].as_str() else {
+                    return Ok(());
+                };
+                let Some(payload) = message.get("message") else {
+                    return Ok(());
+                };
+                self.dispatch_relay(provider_key, payload.clone()).await;
+                self.broadcast(&message).await?;
+            }
+            "relay-open" | "relay-close" => {
+                self.broadcast(&message).await?;
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+
+    async fn broadcast(&self, message: &Value) -> Result<()> {
+        let text = serde_json::to_string(message)?;
+        let sinks = {
+            let inner = self.inner.lock().unwrap();
+            inner
+                .sinks
+                .iter()
+                .map(|(id, sink)| (*id, sink.clone()))
+                .collect::<Vec<_>>()
+        };
+
+        let mut failed = Vec::new();
+        for (sink_id, sink) in sinks {
+            if sink.send(Message::Text(text.clone().into())).is_err() {
+                failed.push(sink_id);
+            }
+        }
+
+        if !failed.is_empty() {
+            let mut inner = self.inner.lock().unwrap();
+            for sink_id in failed {
+                inner.sinks.remove(&sink_id);
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn dispatch_relay(&self, provider_key: &str, message: Value) {
+        let subscribers = {
+            let inner = self.inner.lock().unwrap();
+            inner
+                .relay_subscribers
+                .get(provider_key)
+                .map(|subs| subs.values().cloned().collect::<Vec<_>>())
+                .unwrap_or_default()
+        };
+
+        for subscriber in subscribers {
+            let _ = subscriber.send(message.clone());
+        }
+    }
+
+    async fn remove_sink(&self, sink_id: u64) -> Vec<ProviderChangeCallback> {
+        let mut inner = self.inner.lock().unwrap();
+        inner.sinks.remove(&sink_id);
+        if !inner.sinks.is_empty() {
+            return Vec::new();
+        }
+
+        let providers_changed = !inner.providers.is_empty();
+        inner.providers.clear();
+        inner.relay_subscribers.clear();
+        if providers_changed {
+            inner.callbacks.clone()
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+impl Bridge for BridgeServer {
+    fn running(&self) -> bool {
+        self.inner.lock().unwrap().running
+    }
+
+    fn providers(&self) -> Vec<BridgeProvider> {
+        self.inner
+            .lock()
+            .unwrap()
+            .providers
+            .values()
+            .cloned()
+            .collect()
+    }
+
+    fn on_provider_change(&self, callback: ProviderChangeCallback) {
+        self.inner.lock().unwrap().callbacks.push(callback);
+    }
+
+    fn subscribe_relay(&self, provider_key: &str) -> RelaySubscription {
+        let mut inner = self.inner.lock().unwrap();
+        inner.next_subscription_id += 1;
+        let subscription_id = inner.next_subscription_id;
+        let (tx, rx) = mpsc::unbounded_channel();
+        inner
+            .relay_subscribers
+            .entry(provider_key.to_string())
+            .or_default()
+            .insert(subscription_id, tx);
+
+        RelaySubscription {
+            id: subscription_id,
+            receiver: rx,
+        }
+    }
+
+    fn unsubscribe_relay(&self, provider_key: &str, subscription_id: u64) {
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(subs) = inner.relay_subscribers.get_mut(provider_key) {
+            subs.remove(&subscription_id);
+            if subs.is_empty() {
+                inner.relay_subscribers.remove(provider_key);
+            }
+        }
+    }
+
+    fn send(&self, message: Value) -> BridgeFuture<Result<()>> {
+        let server = self.clone();
+        Box::pin(async move { server.broadcast(&message).await })
+    }
+
+    fn stop(&self) -> BridgeFuture<()> {
+        let server = self.clone();
+        Box::pin(async move {
+            let accept_task = {
+                let mut inner = server.inner.lock().unwrap();
+                inner.running = false;
+                inner.providers.clear();
+                inner.relay_subscribers.clear();
+                inner.sinks.clear();
+                inner.accept_task.take()
+            };
+
+            if let Some(task) = accept_task {
+                task.abort();
+            }
+        })
+    }
+}
+
+fn fire_callbacks(callbacks: Vec<ProviderChangeCallback>) {
+    for callback in callbacks {
+        callback();
+    }
+}
+
+fn parse_bridge_provider(message: &Value) -> Option<BridgeProvider> {
+    let provider_key = message["providerKey"].as_str()?.to_string();
+    let tab_id = message["tabId"].as_u64().unwrap_or(0);
+    let provider = message["provider"].as_object();
+
+    let id = provider
+        .and_then(|provider| provider.get("id"))
+        .and_then(Value::as_str)
+        .unwrap_or(&provider_key)
+        .to_string();
+    let name = provider
+        .and_then(|provider| provider.get("name"))
+        .and_then(Value::as_str)
+        .unwrap_or("Tab")
+        .to_string();
+    let transport = provider
+        .and_then(|provider| provider.get("transport"))
+        .and_then(Value::as_str)
+        .unwrap_or("postmessage")
+        .to_string();
+    let url = provider
+        .and_then(|provider| provider.get("url"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+
+    Some(BridgeProvider {
+        provider_key,
+        tab_id,
+        id,
+        name,
+        transport,
+        url,
+    })
+}

--- a/packages/rust/slop-ai/src/discovery/mod.rs
+++ b/packages/rust/slop-ai/src/discovery/mod.rs
@@ -1,0 +1,23 @@
+mod bridge;
+mod relay_transport;
+mod service;
+mod tools;
+mod types;
+
+pub use bridge::{
+    Bridge, BridgeClient, BridgeProvider, BridgeServer, ProviderChangeCallback, RelaySubscription,
+    DEFAULT_BRIDGE_ADDR, DEFAULT_BRIDGE_PATH, DEFAULT_BRIDGE_URL,
+};
+pub use relay_transport::BridgeRelayTransport;
+pub use service::DiscoveryService;
+pub use tools::{
+    create_dynamic_tools, create_tool_handlers, DynamicToolEntry, DynamicToolResolution,
+    DynamicToolSet, ToolContent, ToolHandlers, ToolResult,
+};
+pub use types::{
+    ConnectedProvider, DiscoveryServiceOptions, ProviderDescriptor, ProviderSource,
+    ProviderStatus, TransportDescriptor,
+};
+
+#[cfg(test)]
+mod tests;

--- a/packages/rust/slop-ai/src/discovery/relay_transport.rs
+++ b/packages/rust/slop-ai/src/discovery/relay_transport.rs
@@ -1,0 +1,111 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+
+use serde_json::{json, Value};
+use tokio::sync::mpsc;
+use tokio::time::{sleep, Duration};
+
+use crate::consumer::ClientTransport;
+use crate::error::{Result, SlopError};
+
+use super::bridge::Bridge;
+
+pub struct BridgeRelayTransport {
+    bridge: Arc<dyn Bridge>,
+    provider_key: String,
+}
+
+impl BridgeRelayTransport {
+    pub fn new(bridge: Arc<dyn Bridge>, provider_key: impl Into<String>) -> Self {
+        Self {
+            bridge,
+            provider_key: provider_key.into(),
+        }
+    }
+}
+
+impl ClientTransport for BridgeRelayTransport {
+    fn connect(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<(mpsc::UnboundedSender<Value>, mpsc::UnboundedReceiver<Value>)>> + Send>> {
+        let bridge = Arc::clone(&self.bridge);
+        let provider_key = self.provider_key.clone();
+
+        Box::pin(async move {
+            let subscription = bridge.subscribe_relay(&provider_key);
+            bridge
+                .send(json!({
+                    "type": "relay-open",
+                    "providerKey": provider_key.clone(),
+                }))
+                .await?;
+
+            let got_response = Arc::new(AtomicBool::new(false));
+
+            let (outgoing_tx, mut outgoing_rx) = mpsc::unbounded_channel::<Value>();
+            let (incoming_tx, incoming_rx) = mpsc::unbounded_channel::<Value>();
+
+            let send_bridge = Arc::clone(&bridge);
+            let send_key = provider_key.clone();
+            let close_key = provider_key.clone();
+            let subscription_id = subscription.id;
+            tokio::spawn(async move {
+                while let Some(msg) = outgoing_rx.recv().await {
+                    let _ = send_bridge
+                        .send(json!({
+                            "type": "slop-relay",
+                            "providerKey": send_key.clone(),
+                            "message": msg,
+                        }))
+                        .await;
+                }
+
+                let _ = send_bridge
+                    .send(json!({
+                        "type": "relay-close",
+                        "providerKey": close_key.clone(),
+                    }))
+                    .await;
+                send_bridge.unsubscribe_relay(&close_key, subscription_id);
+            });
+
+            let recv_bridge = Arc::clone(&bridge);
+            let recv_key = provider_key.clone();
+            let recv_subscription_id = subscription.id;
+            let response_seen = Arc::clone(&got_response);
+            let mut relay_rx = subscription.receiver;
+            tokio::spawn(async move {
+                while let Some(message) = relay_rx.recv().await {
+                    response_seen.store(true, Ordering::SeqCst);
+                    if incoming_tx.send(message).is_err() {
+                        break;
+                    }
+                }
+                recv_bridge.unsubscribe_relay(&recv_key, recv_subscription_id);
+            });
+
+            for _ in 0..=3 {
+                bridge
+                    .send(json!({
+                        "type": "slop-relay",
+                        "providerKey": provider_key.clone(),
+                        "message": {"type": "connect"},
+                    }))
+                    .await?;
+
+                if got_response.load(Ordering::SeqCst) {
+                    break;
+                }
+
+                sleep(Duration::from_millis(300)).await;
+            }
+
+            if outgoing_tx.is_closed() {
+                return Err(SlopError::Transport("relay connection closed".to_string()));
+            }
+
+            Ok((outgoing_tx, incoming_rx))
+        })
+    }
+}

--- a/packages/rust/slop-ai/src/discovery/service.rs
+++ b/packages/rust/slop-ai/src/discovery/service.rs
@@ -1,0 +1,727 @@
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tokio::time::{sleep, timeout};
+
+use crate::consumer::{ClientTransport, SlopConsumer};
+use crate::error::{Result, SlopError};
+use crate::transport::unix_client::UnixClientTransport;
+use crate::transport::ws_client::WsClientTransport;
+use crate::types::PatchOp;
+
+use super::bridge::{Bridge, BridgeClient, BridgeServer, ProviderChangeCallback};
+use super::relay_transport::BridgeRelayTransport;
+use super::types::{
+    ConnectedProvider, DiscoveryServiceOptions, ProviderDescriptor, ProviderSource, ProviderStatus,
+};
+
+#[derive(Clone)]
+pub struct DiscoveryService {
+    inner: Arc<Mutex<DiscoveryInner>>,
+}
+
+struct DiscoveryInner {
+    options: DiscoveryServiceOptions,
+    providers: HashMap<String, ConnectedProvider>,
+    local_descriptors: Vec<ProviderDescriptor>,
+    last_accessed: HashMap<String, Instant>,
+    reconnect_attempts: HashMap<String, u32>,
+    intentional_disconnects: HashSet<String>,
+    bridge: Option<Arc<dyn Bridge>>,
+    callbacks: Vec<ProviderChangeCallback>,
+    started: bool,
+    dir_snapshots: HashMap<PathBuf, Vec<String>>,
+    scan_task: Option<JoinHandle<()>>,
+    watch_task: Option<JoinHandle<()>>,
+    idle_task: Option<JoinHandle<()>>,
+    bridge_task: Option<JoinHandle<()>>,
+    reconnect_tasks: HashMap<String, JoinHandle<()>>,
+}
+
+impl DiscoveryService {
+    pub fn new(options: DiscoveryServiceOptions) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(DiscoveryInner {
+                options,
+                providers: HashMap::new(),
+                local_descriptors: Vec::new(),
+                last_accessed: HashMap::new(),
+                reconnect_attempts: HashMap::new(),
+                intentional_disconnects: HashSet::new(),
+                bridge: None,
+                callbacks: Vec::new(),
+                started: false,
+                dir_snapshots: HashMap::new(),
+                scan_task: None,
+                watch_task: None,
+                idle_task: None,
+                bridge_task: None,
+                reconnect_tasks: HashMap::new(),
+            })),
+        }
+    }
+
+    pub async fn start(&self) {
+        let mut inner = self.inner.lock().await;
+        if inner.started {
+            return;
+        }
+        inner.started = true;
+        let options = inner.options.clone();
+        drop(inner);
+
+        self.scan().await;
+
+        let scan_service = self.clone();
+        let scan_interval = options.scan_interval;
+        let scan_task = tokio::spawn(async move {
+            loop {
+                sleep(scan_interval).await;
+                if !scan_service.is_started().await {
+                    break;
+                }
+                scan_service.scan().await;
+            }
+        });
+
+        let watch_service = self.clone();
+        let watch_interval = options.watch_interval;
+        let watch_task = tokio::spawn(async move {
+            loop {
+                sleep(watch_interval).await;
+                if !watch_service.is_started().await {
+                    break;
+                }
+                watch_service.check_directory_changes().await;
+            }
+        });
+
+        let idle_service = self.clone();
+        let idle_timeout_check = Duration::from_secs(60);
+        let idle_task = tokio::spawn(async move {
+            loop {
+                sleep(idle_timeout_check).await;
+                if !idle_service.is_started().await {
+                    break;
+                }
+                idle_service.check_idle().await;
+            }
+        });
+
+        let bridge_service = self.clone();
+        let bridge_task = tokio::spawn(async move {
+            bridge_service.init_bridge().await;
+        });
+
+        let mut inner = self.inner.lock().await;
+        inner.scan_task = Some(scan_task);
+        inner.watch_task = Some(watch_task);
+        inner.idle_task = Some(idle_task);
+        inner.bridge_task = Some(bridge_task);
+    }
+
+    pub async fn stop(&self) {
+        let (tasks, reconnect_tasks, bridge, providers) = {
+            let mut inner = self.inner.lock().await;
+            if !inner.started {
+                return;
+            }
+            inner.started = false;
+            let tasks = vec![
+                inner.scan_task.take(),
+                inner.watch_task.take(),
+                inner.idle_task.take(),
+                inner.bridge_task.take(),
+            ];
+            let reconnect_tasks = inner.reconnect_tasks.drain().map(|(_, task)| task).collect::<Vec<_>>();
+            let bridge = inner.bridge.take();
+            let providers = inner.providers.drain().map(|(_, provider)| provider).collect::<Vec<_>>();
+            inner.local_descriptors.clear();
+            inner.last_accessed.clear();
+            inner.reconnect_attempts.clear();
+            inner.intentional_disconnects.clear();
+            inner.dir_snapshots.clear();
+            (tasks, reconnect_tasks, bridge, providers)
+        };
+
+        for task in tasks.into_iter().flatten() {
+            task.abort();
+        }
+        for task in reconnect_tasks {
+            task.abort();
+        }
+        if let Some(bridge) = bridge {
+            bridge.stop().await;
+        }
+        for provider in providers {
+            provider.consumer.disconnect().await;
+        }
+    }
+
+    pub async fn on_state_change<F>(&self, callback: F)
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        self.inner.lock().await.callbacks.push(Arc::new(callback));
+    }
+
+    pub async fn get_discovered(&self) -> Vec<ProviderDescriptor> {
+        let (local, bridge) = {
+            let inner = self.inner.lock().await;
+            (inner.local_descriptors.clone(), inner.bridge.clone())
+        };
+
+        let mut descriptors = local;
+        if let Some(bridge) = bridge {
+            if bridge.running() {
+                descriptors.extend(bridge.providers().into_iter().map(|provider| provider.to_descriptor()));
+            }
+        }
+        descriptors
+    }
+
+    pub async fn get_providers(&self) -> Vec<ConnectedProvider> {
+        self.inner
+            .lock()
+            .await
+            .providers
+            .values()
+            .filter(|provider| provider.status == ProviderStatus::Connected)
+            .cloned()
+            .collect()
+    }
+
+    pub async fn get_provider(&self, id: &str) -> Option<ConnectedProvider> {
+        let mut inner = self.inner.lock().await;
+        let provider = inner.providers.get(id).cloned();
+        if provider.as_ref().is_some_and(|provider| provider.status == ProviderStatus::Connected) {
+            inner.last_accessed.insert(id.to_string(), Instant::now());
+        }
+        provider.filter(|provider| provider.status == ProviderStatus::Connected)
+    }
+
+    pub async fn ensure_connected(&self, id_or_name: &str) -> Result<Option<ConnectedProvider>> {
+        if let Some(provider) = self.find_connected_provider(id_or_name).await {
+            return Ok(Some(provider));
+        }
+
+        let descriptor = self.find_descriptor(id_or_name).await;
+        match descriptor {
+            Some(descriptor) => self.connect_provider(descriptor).await,
+            None => Ok(None),
+        }
+    }
+
+    pub async fn disconnect(&self, id_or_name: &str) -> bool {
+        let provider = {
+            let mut inner = self.inner.lock().await;
+            let needle = id_or_name.to_lowercase();
+            let provider_id = inner
+                .providers
+                .iter()
+                .find(|(id, provider)| {
+                    *id == id_or_name || provider.name.to_lowercase().contains(&needle)
+                })
+                .map(|(id, _)| id.clone());
+
+            let Some(provider_id) = provider_id else {
+                return false;
+            };
+
+            inner.intentional_disconnects.insert(provider_id.clone());
+            inner.last_accessed.remove(&provider_id);
+            inner.reconnect_attempts.remove(&provider_id);
+            if let Some(task) = inner.reconnect_tasks.remove(&provider_id) {
+                task.abort();
+            }
+            inner.providers.remove(&provider_id)
+        };
+
+        if let Some(provider) = provider {
+            provider.consumer.disconnect().await;
+            self.fire_state_change().await;
+            true
+        } else {
+            false
+        }
+    }
+
+    async fn is_started(&self) -> bool {
+        self.inner.lock().await.started
+    }
+
+    async fn init_bridge(&self) {
+        let options = self.inner.lock().await.options.clone();
+
+        let client = Arc::new(BridgeClient::new(
+            &options.bridge_url,
+            options.bridge_retry_delay,
+            options.bridge_dial_timeout,
+        ));
+
+        if client.connect_once().await.is_ok() {
+            client.start();
+            self.attach_bridge(client as Arc<dyn Bridge>).await;
+            return;
+        }
+
+        if !options.host_bridge {
+            client.start();
+            self.attach_bridge(client as Arc<dyn Bridge>).await;
+            return;
+        }
+
+        let server = Arc::new(BridgeServer::new(&options.bridge_addr, &options.bridge_path));
+        if server.start().await.is_ok() {
+            self.attach_bridge(server as Arc<dyn Bridge>).await;
+            return;
+        }
+
+        client.start();
+        self.attach_bridge(client as Arc<dyn Bridge>).await;
+    }
+
+    async fn attach_bridge(&self, bridge: Arc<dyn Bridge>) {
+        {
+            let mut inner = self.inner.lock().await;
+            if !inner.started {
+                drop(inner);
+                bridge.stop().await;
+                return;
+            }
+            inner.bridge = Some(bridge.clone());
+        }
+
+        let service = self.clone();
+        bridge.on_provider_change(Arc::new(move || {
+            let service = service.clone();
+            tokio::spawn(async move {
+                service.scan().await;
+            });
+        }));
+
+        self.scan().await;
+    }
+
+    async fn scan(&self) {
+        let descriptors = self.read_descriptors().await;
+        let bridge = self.inner.lock().await.bridge.clone();
+        let bridge_descriptors = bridge
+            .as_ref()
+            .filter(|bridge| bridge.running())
+            .map(|bridge| bridge.providers().into_iter().map(|provider| provider.to_descriptor()).collect::<Vec<_>>())
+            .unwrap_or_default();
+        let all_descriptors = descriptors
+            .iter()
+            .cloned()
+            .chain(bridge_descriptors.iter().cloned())
+            .collect::<Vec<_>>();
+        let all_ids = all_descriptors.iter().map(|descriptor| descriptor.id.clone()).collect::<HashSet<_>>();
+
+        let (removed_providers, callbacks, auto_connect, started) = {
+            let mut inner = self.inner.lock().await;
+            inner.local_descriptors = descriptors;
+
+            let removed_ids = inner
+                .providers
+                .keys()
+                .filter(|id| !all_ids.contains(*id))
+                .cloned()
+                .collect::<Vec<_>>();
+
+            let mut removed = Vec::new();
+            for id in removed_ids {
+                inner.intentional_disconnects.insert(id.clone());
+                inner.last_accessed.remove(&id);
+                inner.reconnect_attempts.remove(&id);
+                if let Some(task) = inner.reconnect_tasks.remove(&id) {
+                    task.abort();
+                }
+                if let Some(provider) = inner.providers.remove(&id) {
+                    removed.push(provider);
+                }
+            }
+
+            (
+                removed,
+                inner.callbacks.clone(),
+                inner.options.auto_connect,
+                inner.started,
+            )
+        };
+
+        for provider in removed_providers {
+            provider.consumer.disconnect().await;
+        }
+        if !callbacks.is_empty() {
+            fire_callbacks(callbacks);
+        }
+
+        if !auto_connect || !started {
+            return;
+        }
+
+        for descriptor in all_descriptors {
+            let should_connect = {
+                let inner = self.inner.lock().await;
+                !inner.providers.contains_key(&descriptor.id)
+            };
+            if should_connect {
+                let service = self.clone();
+                tokio::spawn(async move {
+                    let _ = service.connect_provider(descriptor).await;
+                });
+            }
+        }
+    }
+
+    async fn check_directory_changes(&self) {
+        let dirs = self.inner.lock().await.options.providers_dirs.clone();
+        let mut changed = false;
+        let mut signatures = HashMap::new();
+        for dir in dirs {
+            let signature = directory_signature(&dir);
+            signatures.insert(dir.clone(), signature);
+        }
+
+        {
+            let mut inner = self.inner.lock().await;
+            for (dir, signature) in signatures {
+                let prior = inner.dir_snapshots.get(&dir);
+                if prior != Some(&signature) {
+                    inner.dir_snapshots.insert(dir, signature);
+                    changed = true;
+                }
+            }
+        }
+
+        if changed {
+            self.scan().await;
+        }
+    }
+
+    async fn check_idle(&self) {
+        let (idle_timeout, providers) = {
+            let inner = self.inner.lock().await;
+            let now = Instant::now();
+            let idle_timeout = inner.options.idle_timeout;
+            let providers = inner
+                .last_accessed
+                .iter()
+                .filter(|(_, accessed)| now.duration_since(**accessed) > idle_timeout)
+                .map(|(id, _)| id.clone())
+                .collect::<Vec<_>>();
+            (idle_timeout, providers)
+        };
+        let _ = idle_timeout;
+
+        for provider_id in providers {
+            let provider = {
+                let mut inner = self.inner.lock().await;
+                inner.intentional_disconnects.insert(provider_id.clone());
+                inner.last_accessed.remove(&provider_id);
+                inner.reconnect_attempts.remove(&provider_id);
+                inner.providers.remove(&provider_id)
+            };
+
+            if let Some(provider) = provider {
+                provider.consumer.disconnect().await;
+                self.fire_state_change().await;
+            }
+        }
+    }
+
+    async fn connect_provider(&self, descriptor: ProviderDescriptor) -> Result<Option<ConnectedProvider>> {
+        loop {
+            let mut inner = self.inner.lock().await;
+            if let Some(existing) = inner.providers.get(&descriptor.id).cloned() {
+                match existing.status {
+                    ProviderStatus::Connected => {
+                        inner.last_accessed.insert(descriptor.id.clone(), Instant::now());
+                        return Ok(Some(existing));
+                    }
+                    ProviderStatus::Connecting => {
+                        drop(inner);
+                        sleep(Duration::from_millis(10)).await;
+                        continue;
+                    }
+                    ProviderStatus::Disconnected => {}
+                }
+            }
+
+            let provider = ConnectedProvider {
+                id: descriptor.id.clone(),
+                name: descriptor.name.clone(),
+                descriptor: descriptor.clone(),
+                consumer: Arc::new(SlopConsumer::new()),
+                subscription_id: String::new(),
+                status: ProviderStatus::Connecting,
+            };
+            let consumer = Arc::clone(&provider.consumer);
+            let bridge = inner.bridge.clone();
+            let timeout_duration = inner.options.connect_timeout;
+            inner.providers.insert(descriptor.id.clone(), provider);
+            drop(inner);
+
+            let Some(transport) = create_transport(&descriptor, bridge) else {
+                self.inner.lock().await.providers.remove(&descriptor.id);
+                return Ok(None);
+            };
+
+            let hello = timeout(timeout_duration, consumer.connect(transport.as_ref()))
+                .await
+                .map_err(|_| SlopError::Transport("connection timed out after 10s".to_string()))??;
+
+            let (subscription_id, _tree) = timeout(timeout_duration, consumer.subscribe("/", -1))
+                .await
+                .map_err(|_| SlopError::Transport("subscription timed out after 10s".to_string()))??;
+
+            let provider_name = hello["provider"]["name"]
+                .as_str()
+                .unwrap_or(&descriptor.name)
+                .to_string();
+
+            let service = self.clone();
+            consumer
+                .on_patch(move |_, _: &[PatchOp], _| {
+                    let service = service.clone();
+                    tokio::spawn(async move {
+                        service.fire_state_change().await;
+                    });
+                })
+                .await;
+
+            let service = self.clone();
+            let disconnect_desc = descriptor.clone();
+            let disconnect_name = provider_name.clone();
+            consumer
+                .on_disconnect(move || {
+                    service.spawn_handle_disconnect(disconnect_desc.clone(), disconnect_name.clone());
+                })
+                .await;
+
+            let connected_provider = {
+                let mut inner = self.inner.lock().await;
+                let provider = ConnectedProvider {
+                    id: descriptor.id.clone(),
+                    name: provider_name,
+                    descriptor: descriptor.clone(),
+                    consumer,
+                    subscription_id,
+                    status: ProviderStatus::Connected,
+                };
+                inner.last_accessed.insert(descriptor.id.clone(), Instant::now());
+                inner.reconnect_attempts.remove(&descriptor.id);
+                inner.intentional_disconnects.remove(&descriptor.id);
+                inner.providers.insert(descriptor.id.clone(), provider.clone());
+                provider
+            };
+
+            self.fire_state_change().await;
+            return Ok(Some(connected_provider));
+        }
+    }
+
+    async fn handle_provider_disconnect(&self, descriptor: ProviderDescriptor, name: String) {
+        let (intentional, callbacks, started, attempt, delay) = {
+            let mut inner = self.inner.lock().await;
+            inner.providers.remove(&descriptor.id);
+            inner.last_accessed.remove(&descriptor.id);
+            let intentional = inner.intentional_disconnects.remove(&descriptor.id);
+            let callbacks = inner.callbacks.clone();
+            if intentional || !inner.started {
+                (intentional, callbacks, inner.started, 0, Duration::from_secs(0))
+            } else {
+                let attempt = inner.reconnect_attempts.get(&descriptor.id).copied().unwrap_or(0) + 1;
+                inner.reconnect_attempts.insert(descriptor.id.clone(), attempt);
+                let multiplier = 1u32.checked_shl(attempt - 1).unwrap_or(u32::MAX);
+                let delay = inner
+                    .options
+                    .reconnect_base_delay
+                    .checked_mul(multiplier)
+                    .unwrap_or(inner.options.max_reconnect_delay)
+                    .min(inner.options.max_reconnect_delay);
+                (intentional, callbacks, inner.started, attempt, delay)
+            }
+        };
+
+        fire_callbacks(callbacks);
+
+        if intentional || !started || self.find_descriptor(&descriptor.id).await.is_none() {
+            return;
+        }
+
+        let service = self.clone();
+        let descriptor_id = descriptor.id.clone();
+        let reconnect_key = descriptor_id.clone();
+        let task = tokio::spawn(reconnect_provider_after_delay(
+            service,
+            descriptor,
+            descriptor_id,
+            delay,
+        ));
+
+        let mut inner = self.inner.lock().await;
+        if let Some(old_task) = inner.reconnect_tasks.insert(reconnect_key.clone(), task) {
+            old_task.abort();
+        }
+        let _ = name;
+        let _ = attempt;
+    }
+
+    async fn find_connected_provider(&self, id_or_name: &str) -> Option<ConnectedProvider> {
+        let mut inner = self.inner.lock().await;
+        if let Some(provider) = inner.providers.get(id_or_name).cloned() {
+            if provider.status == ProviderStatus::Connected {
+                inner.last_accessed.insert(provider.id.clone(), Instant::now());
+                return Some(provider);
+            }
+        }
+
+        let needle = id_or_name.to_lowercase();
+        let provider = inner
+            .providers
+            .values()
+            .find(|provider| {
+                provider.status == ProviderStatus::Connected
+                    && provider.name.to_lowercase().contains(&needle)
+            })
+            .cloned();
+        if let Some(provider) = provider.clone() {
+            inner.last_accessed.insert(provider.id.clone(), Instant::now());
+        }
+        provider
+    }
+
+    async fn find_descriptor(&self, id_or_name: &str) -> Option<ProviderDescriptor> {
+        let needle = id_or_name.to_lowercase();
+        self.get_discovered()
+            .await
+            .into_iter()
+            .find(|descriptor| descriptor.id == id_or_name || descriptor.name.to_lowercase().contains(&needle))
+    }
+
+    async fn read_descriptors(&self) -> Vec<ProviderDescriptor> {
+        let dirs = self.inner.lock().await.options.providers_dirs.clone();
+        let mut descriptors = Vec::new();
+        for dir in dirs {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                    continue;
+                }
+
+                let Ok(content) = std::fs::read_to_string(&path) else {
+                    continue;
+                };
+                let Ok(mut descriptor) = serde_json::from_str::<ProviderDescriptor>(&content) else {
+                    continue;
+                };
+                if !is_valid_descriptor(&descriptor) {
+                    continue;
+                }
+                descriptor.source = ProviderSource::Local;
+                descriptors.push(descriptor);
+            }
+        }
+        descriptors
+    }
+
+    async fn fire_state_change(&self) {
+        let callbacks = self.inner.lock().await.callbacks.clone();
+        fire_callbacks(callbacks);
+    }
+
+    fn spawn_handle_disconnect(&self, descriptor: ProviderDescriptor, name: String) {
+        let service = self.clone();
+        tokio::spawn(async move {
+            service.handle_provider_disconnect(descriptor, name).await;
+        });
+    }
+}
+
+async fn reconnect_provider_after_delay(
+    service: DiscoveryService,
+    descriptor: ProviderDescriptor,
+    descriptor_id: String,
+    delay: Duration,
+) {
+    sleep(delay).await;
+    if service.is_started().await && service.find_descriptor(&descriptor_id).await.is_some() {
+        let _ = service.connect_provider(descriptor).await;
+    }
+}
+
+fn create_transport(
+    descriptor: &ProviderDescriptor,
+    bridge: Option<Arc<dyn Bridge>>,
+) -> Option<Box<dyn ClientTransport + Send + Sync>> {
+    match descriptor.transport.transport_type.as_str() {
+        "unix" => descriptor
+            .transport
+            .path
+            .as_ref()
+            .map(|path| Box::new(UnixClientTransport::new(path)) as Box<dyn ClientTransport + Send + Sync>),
+        "ws" => descriptor
+            .transport
+            .url
+            .as_ref()
+            .map(|url| Box::new(WsClientTransport::new(url)) as Box<dyn ClientTransport + Send + Sync>),
+        "relay" => descriptor.provider_key.as_ref().and_then(|provider_key| {
+            bridge.map(|bridge| {
+                Box::new(BridgeRelayTransport::new(bridge, provider_key.clone()))
+                    as Box<dyn ClientTransport + Send + Sync>
+            })
+        }),
+        _ => None,
+    }
+}
+
+fn is_valid_descriptor(descriptor: &ProviderDescriptor) -> bool {
+    !descriptor.id.is_empty()
+        && !descriptor.name.is_empty()
+        && matches!(descriptor.transport.transport_type.as_str(), "unix" | "ws" | "stdio" | "relay")
+}
+
+fn directory_signature(dir: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+
+    let mut signature = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        if let Ok(metadata) = entry.metadata() {
+            let modified = metadata
+                .modified()
+                .ok()
+                .and_then(|time| time.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
+                .map(|duration| duration.as_nanos())
+                .unwrap_or(0);
+            signature.push(format!(
+                "{}:{}:{}",
+                path.file_name().and_then(|name| name.to_str()).unwrap_or_default(),
+                modified,
+                metadata.len()
+            ));
+        }
+    }
+    signature.sort();
+    signature
+}
+
+fn fire_callbacks(callbacks: Vec<ProviderChangeCallback>) {
+    for callback in callbacks {
+        callback();
+    }
+}

--- a/packages/rust/slop-ai/src/discovery/tests.rs
+++ b/packages/rust/slop-ai/src/discovery/tests.rs
@@ -1,0 +1,217 @@
+use std::collections::HashMap;
+use std::future::Future;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite::Message;
+
+use crate::consumer::ClientTransport;
+use crate::error::{Result, SlopError};
+
+use super::bridge::{Bridge, BridgeServer, ProviderChangeCallback, RelaySubscription};
+use super::relay_transport::BridgeRelayTransport;
+use super::service::DiscoveryService;
+use super::types::DiscoveryServiceOptions;
+
+#[tokio::test]
+async fn service_scans_and_prunes_descriptors() {
+    let providers_dir = temp_dir("slop-rust-discovery-scan");
+    std::fs::create_dir_all(&providers_dir).unwrap();
+    let descriptor_path = providers_dir.join("test-app.json");
+    std::fs::write(
+        &descriptor_path,
+        r#"{
+  "id": "test-app",
+  "name": "Test App",
+  "slop_version": "0.1",
+  "transport": {"type": "unix", "path": "/tmp/slop/test-app.sock"},
+  "capabilities": ["state"]
+}"#,
+    )
+    .unwrap();
+
+    let service = DiscoveryService::new(DiscoveryServiceOptions {
+        providers_dirs: vec![providers_dir.clone()],
+        host_bridge: false,
+        bridge_url: "ws://127.0.0.1:1/slop-bridge".to_string(),
+        bridge_dial_timeout: Duration::from_millis(50),
+        bridge_retry_delay: Duration::from_millis(50),
+        scan_interval: Duration::from_millis(50),
+        watch_interval: Duration::from_millis(20),
+        ..DiscoveryServiceOptions::default()
+    });
+
+    service.start().await;
+    wait_until(Duration::from_secs(1), || {
+        let service = service.clone();
+        async move { service.get_discovered().await.len() == 1 }
+    })
+    .await;
+
+    std::fs::remove_file(&descriptor_path).unwrap();
+
+    wait_until(Duration::from_secs(1), || {
+        let service = service.clone();
+        async move { service.get_discovered().await.is_empty() }
+    })
+    .await;
+
+    service.stop().await;
+    let _ = std::fs::remove_dir_all(&providers_dir);
+}
+
+#[tokio::test]
+async fn bridge_server_forwards_relay_control_messages() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+
+    let server = BridgeServer::new(&format!("127.0.0.1:{port}"), "/slop-bridge");
+    server.start().await.unwrap();
+    let url = format!("ws://127.0.0.1:{port}/slop-bridge");
+
+    let (mut client_one, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+    let (mut client_two, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+
+    client_one
+        .send(Message::Text(
+            json!({"type": "relay-open", "providerKey": "tab-1"})
+                .to_string()
+                .into(),
+        ))
+        .await
+        .unwrap();
+    let open = read_text_message(&mut client_two).await;
+    assert_eq!(open["type"], "relay-open");
+
+    client_one
+        .send(Message::Text(
+            json!({"type": "relay-close", "providerKey": "tab-1"})
+                .to_string()
+                .into(),
+        ))
+        .await
+        .unwrap();
+    let close = read_text_message(&mut client_two).await;
+    assert_eq!(close["type"], "relay-close");
+
+    let _ = client_one.close(None).await;
+    let _ = client_two.close(None).await;
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn relay_transport_buffers_early_messages() {
+    let bridge: Arc<dyn Bridge> = Arc::new(FakeBridge::default());
+    let transport = BridgeRelayTransport::new(bridge, "tab-1");
+
+    let (_tx, mut rx) = transport.connect().await.unwrap();
+    let hello = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(hello["type"], "hello");
+}
+
+async fn wait_until<F, Fut>(timeout_duration: Duration, mut check: F)
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = bool>,
+{
+    let deadline = tokio::time::Instant::now() + timeout_duration;
+    loop {
+        if check().await {
+            return;
+        }
+        assert!(tokio::time::Instant::now() < deadline, "condition not met before timeout");
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+async fn read_text_message<S>(stream: &mut S) -> Value
+where
+    S: StreamExt<Item = std::result::Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin,
+{
+    while let Some(Ok(message)) = stream.next().await {
+        if let Message::Text(text) = message {
+            return serde_json::from_str(&text).unwrap();
+        }
+    }
+    panic!("expected text message")
+}
+
+fn temp_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+}
+
+#[derive(Default)]
+struct FakeBridge {
+    subscribers: Mutex<HashMap<String, HashMap<u64, mpsc::UnboundedSender<Value>>>>,
+    next_subscription_id: Mutex<u64>,
+}
+
+impl Bridge for FakeBridge {
+    fn running(&self) -> bool {
+        true
+    }
+
+    fn providers(&self) -> Vec<super::BridgeProvider> {
+        Vec::new()
+    }
+
+    fn on_provider_change(&self, _callback: ProviderChangeCallback) {}
+
+    fn subscribe_relay(&self, provider_key: &str) -> RelaySubscription {
+        let mut next = self.next_subscription_id.lock().unwrap();
+        *next += 1;
+        let subscription_id = *next;
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.subscribers
+            .lock()
+            .unwrap()
+            .entry(provider_key.to_string())
+            .or_default()
+            .insert(subscription_id, tx);
+
+        RelaySubscription {
+            id: subscription_id,
+            receiver: rx,
+        }
+    }
+
+    fn unsubscribe_relay(&self, provider_key: &str, subscription_id: u64) {
+        if let Some(subscribers) = self.subscribers.lock().unwrap().get_mut(provider_key) {
+            subscribers.remove(&subscription_id);
+        }
+    }
+
+    fn send(&self, message: Value) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> {
+        let subscribers = self.subscribers.lock().unwrap().clone();
+        Box::pin(async move {
+            if message["type"] == "slop-relay" && message["message"]["type"] == "connect" {
+                let provider_key = message["providerKey"]
+                    .as_str()
+                    .ok_or_else(|| SlopError::Transport("missing provider key".to_string()))?;
+                if let Some(listeners) = subscribers.get(provider_key) {
+                    for sender in listeners.values() {
+                        let _ = sender.send(json!({"type": "hello", "provider": {"name": "Browser App"}}));
+                    }
+                }
+            }
+            Ok(())
+        })
+    }
+
+    fn stop(&self) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+        Box::pin(async {})
+    }
+}

--- a/packages/rust/slop-ai/src/discovery/tools.rs
+++ b/packages/rust/slop-ai/src/discovery/tools.rs
@@ -1,0 +1,268 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::tools::{affordances_to_tools, format_tree};
+
+use super::service::DiscoveryService;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolContent {
+    #[serde(rename = "type")]
+    pub content_type: String,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolResult {
+    pub content: Vec<ToolContent>,
+    #[serde(skip_serializing_if = "is_false")]
+    pub is_error: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct DynamicToolEntry {
+    pub name: String,
+    pub description: String,
+    pub input_schema: Value,
+    pub provider_id: String,
+    pub path: String,
+    pub action: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct DynamicToolResolution {
+    pub provider_id: String,
+    pub path: String,
+    pub action: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DynamicToolSet {
+    pub tools: Vec<DynamicToolEntry>,
+    resolve_map: HashMap<String, DynamicToolResolution>,
+}
+
+impl DynamicToolSet {
+    pub fn resolve(&self, tool_name: &str) -> Option<&DynamicToolResolution> {
+        self.resolve_map.get(tool_name)
+    }
+}
+
+pub async fn create_dynamic_tools(service: &DiscoveryService) -> DynamicToolSet {
+    let mut entries = Vec::new();
+    let mut resolve_map = HashMap::new();
+
+    for provider in service.get_providers().await {
+        let Some(tree) = provider.consumer.tree(&provider.subscription_id).await else {
+            continue;
+        };
+
+        let app_prefix = sanitize_prefix(&provider.id);
+        let tool_set = affordances_to_tools(&tree, "");
+        for tool in &tool_set.tools {
+            let Some(resolution) = tool_set.resolve(&tool.function.name) else {
+                continue;
+            };
+
+            let name = format!("{app_prefix}__{}", tool.function.name);
+            entries.push(DynamicToolEntry {
+                name: name.clone(),
+                description: format!("[{}] {}", provider.name, tool.function.description),
+                input_schema: tool.function.parameters.clone(),
+                provider_id: provider.id.clone(),
+                path: resolution.path.clone(),
+                action: resolution.action.clone(),
+            });
+            resolve_map.insert(
+                name,
+                DynamicToolResolution {
+                    provider_id: provider.id.clone(),
+                    path: resolution.path.clone(),
+                    action: resolution.action.clone(),
+                },
+            );
+        }
+    }
+
+    DynamicToolSet {
+        tools: entries,
+        resolve_map,
+    }
+}
+
+#[derive(Clone)]
+pub struct ToolHandlers {
+    service: DiscoveryService,
+}
+
+impl ToolHandlers {
+    pub async fn list_apps(&self) -> ToolResult {
+        let discovered = self.service.get_discovered().await;
+        if discovered.is_empty() {
+            return ToolResult {
+                content: vec![ToolContent {
+                    content_type: "text".to_string(),
+                    text: "No applications found. Desktop and web apps that support external control will appear here automatically when they're running.".to_string(),
+                }],
+                is_error: false,
+            };
+        }
+
+        let connected = self.service.get_providers().await;
+        let mut connected_by_id = HashMap::new();
+        for provider in connected {
+            connected_by_id.insert(provider.id.clone(), provider);
+        }
+
+        let mut lines = Vec::new();
+        for descriptor in discovered {
+            let provider = connected_by_id.get(&descriptor.id);
+            let tree = match provider {
+                Some(provider) => provider.consumer.tree(&provider.subscription_id).await,
+                None => None,
+            };
+            let action_count = tree
+                .as_ref()
+                .map(|tree| affordances_to_tools(tree, "").tools.len())
+                .unwrap_or(0);
+            let label = tree
+                .as_ref()
+                .and_then(|tree| tree.properties.as_ref())
+                .and_then(|props| props.get("label"))
+                .and_then(Value::as_str)
+                .unwrap_or(&descriptor.name);
+            let status = if provider.is_some() {
+                format!("connected, {action_count} actions")
+            } else {
+                "available".to_string()
+            };
+            lines.push(format!(
+                "- **{label}** (id: `{}`, {}) - {status}",
+                descriptor.id, descriptor.transport.transport_type
+            ));
+        }
+
+        ToolResult {
+            content: vec![ToolContent {
+                content_type: "text".to_string(),
+                text: format!(
+                    "Applications on this computer:\n{}\n\nUse connect_app with an app name or ID to connect and inspect it.",
+                    lines.join("\n")
+                ),
+            }],
+            is_error: false,
+        }
+    }
+
+    pub async fn connect_app(&self, app: &str) -> ToolResult {
+        match self.service.ensure_connected(app).await {
+            Ok(Some(provider)) => {
+                let Some(tree) = provider.consumer.tree(&provider.subscription_id).await else {
+                    return ToolResult {
+                        content: vec![ToolContent {
+                            content_type: "text".to_string(),
+                            text: format!("{} is connected but has no state yet.", provider.name),
+                        }],
+                        is_error: false,
+                    };
+                };
+
+                let tool_set = affordances_to_tools(&tree, "");
+                let actions = tool_set
+                    .tools
+                    .iter()
+                    .map(|tool| {
+                        let resolution = tool_set.resolve(&tool.function.name);
+                        let action = resolution
+                            .map(|resolution| resolution.action.as_str())
+                            .unwrap_or(tool.function.name.as_str());
+                        let path = resolution
+                            .map(|resolution| resolution.path.as_str())
+                            .unwrap_or("/");
+                        format!("  - **{action}** on `{path}`: {}", tool.function.description)
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+
+                ToolResult {
+                    content: vec![ToolContent {
+                        content_type: "text".to_string(),
+                        text: format!(
+                            "## {}\nID: `{}`\n\n### Current State\n```\n{}\n```\n\n### Available Actions ({})\n{}",
+                            provider.name,
+                            provider.id,
+                            format_tree(&tree, 0),
+                            tool_set.tools.len(),
+                            actions,
+                        ),
+                    }],
+                    is_error: false,
+                }
+            }
+            Ok(None) => {
+                let available = self
+                    .service
+                    .get_discovered()
+                    .await
+                    .into_iter()
+                    .map(|descriptor| format!("{} ({})", descriptor.name, descriptor.id))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+
+                ToolResult {
+                    content: vec![ToolContent {
+                        content_type: "text".to_string(),
+                        text: format!("App \"{app}\" not found. Available: {}", if available.is_empty() { "none" } else { &available }),
+                    }],
+                    is_error: true,
+                }
+            }
+            Err(error) => ToolResult {
+                content: vec![ToolContent {
+                    content_type: "text".to_string(),
+                    text: format!("Failed to connect to \"{app}\": {error}"),
+                }],
+                is_error: true,
+            },
+        }
+    }
+
+    pub async fn disconnect_app(&self, app: &str) -> ToolResult {
+        if !self.service.disconnect(app).await {
+            return ToolResult {
+                content: vec![ToolContent {
+                    content_type: "text".to_string(),
+                    text: format!("App \"{app}\" is not connected. Use list_apps to see available apps."),
+                }],
+                is_error: true,
+            };
+        }
+
+        ToolResult {
+            content: vec![ToolContent {
+                content_type: "text".to_string(),
+                text: format!("Disconnected from \"{app}\". Its tools have been removed."),
+            }],
+            is_error: false,
+        }
+    }
+}
+
+pub fn create_tool_handlers(service: DiscoveryService) -> ToolHandlers {
+    ToolHandlers { service }
+}
+
+fn sanitize_prefix(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect::<String>()
+        .trim_matches('_')
+        .to_string()
+}
+
+fn is_false(value: &bool) -> bool {
+    !value
+}

--- a/packages/rust/slop-ai/src/discovery/types.rs
+++ b/packages/rust/slop-ai/src/discovery/types.rs
@@ -1,0 +1,143 @@
+use std::fmt;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::consumer::SlopConsumer;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ProviderSource {
+    Local,
+    Bridge,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ProviderStatus {
+    Connecting,
+    Connected,
+    Disconnected,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransportDescriptor {
+    #[serde(rename = "type")]
+    pub transport_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProviderDescriptor {
+    pub id: String,
+    pub name: String,
+    pub slop_version: String,
+    pub transport: TransportDescriptor,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pid: Option<u32>,
+    pub capabilities: Vec<String>,
+    #[serde(skip)]
+    pub provider_key: Option<String>,
+    #[serde(skip, default = "default_provider_source")]
+    pub source: ProviderSource,
+}
+
+impl ProviderDescriptor {
+    pub fn address(&self) -> String {
+        match self.transport.transport_type.as_str() {
+            "unix" => self
+                .transport
+                .path
+                .as_ref()
+                .map(|path| format!("unix:{path}"))
+                .unwrap_or_else(|| "unix".to_string()),
+            "ws" => self
+                .transport
+                .url
+                .clone()
+                .unwrap_or_else(|| "ws".to_string()),
+            "relay" => self
+                .provider_key
+                .as_ref()
+                .map(|key| format!("bridge:{key}"))
+                .unwrap_or_else(|| "relay".to_string()),
+            other => other.to_string(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ConnectedProvider {
+    pub id: String,
+    pub name: String,
+    pub descriptor: ProviderDescriptor,
+    pub consumer: Arc<SlopConsumer>,
+    pub subscription_id: String,
+    pub status: ProviderStatus,
+}
+
+impl fmt::Debug for ConnectedProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ConnectedProvider")
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("descriptor", &self.descriptor)
+            .field("subscription_id", &self.subscription_id)
+            .field("status", &self.status)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DiscoveryServiceOptions {
+    pub auto_connect: bool,
+    pub host_bridge: bool,
+    pub providers_dirs: Vec<std::path::PathBuf>,
+    pub bridge_url: String,
+    pub bridge_addr: String,
+    pub bridge_path: String,
+    pub idle_timeout: Duration,
+    pub connect_timeout: Duration,
+    pub scan_interval: Duration,
+    pub watch_interval: Duration,
+    pub reconnect_base_delay: Duration,
+    pub max_reconnect_delay: Duration,
+    pub bridge_dial_timeout: Duration,
+    pub bridge_retry_delay: Duration,
+}
+
+impl Default for DiscoveryServiceOptions {
+    fn default() -> Self {
+        let home = std::env::var_os("HOME")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| std::env::temp_dir());
+
+        Self {
+            auto_connect: false,
+            host_bridge: true,
+            providers_dirs: vec![
+                home.join(".slop").join("providers"),
+                std::env::temp_dir().join("slop").join("providers"),
+            ],
+            bridge_url: super::bridge::DEFAULT_BRIDGE_URL.to_string(),
+            bridge_addr: super::bridge::DEFAULT_BRIDGE_ADDR.to_string(),
+            bridge_path: super::bridge::DEFAULT_BRIDGE_PATH.to_string(),
+            idle_timeout: Duration::from_secs(5 * 60),
+            connect_timeout: Duration::from_secs(10),
+            scan_interval: Duration::from_secs(15),
+            watch_interval: Duration::from_millis(500),
+            reconnect_base_delay: Duration::from_secs(3),
+            max_reconnect_delay: Duration::from_secs(30),
+            bridge_dial_timeout: Duration::from_secs(1),
+            bridge_retry_delay: Duration::from_secs(5),
+        }
+    }
+}
+
+fn default_provider_source() -> ProviderSource {
+    ProviderSource::Local
+}

--- a/packages/rust/slop-ai/src/lib.rs
+++ b/packages/rust/slop-ai/src/lib.rs
@@ -72,6 +72,9 @@ pub mod types;
 #[cfg(feature = "native")]
 pub mod consumer;
 
+#[cfg(feature = "native")]
+pub mod discovery;
+
 // Re-export main types at crate root
 pub use error::{Result, SlopError};
 pub use server::{ActionOptions, Connection, ScopedServer, SlopServer};

--- a/packages/typescript/integrations/discovery/__tests__/bridge-client.test.ts
+++ b/packages/typescript/integrations/discovery/__tests__/bridge-client.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import { WebSocketServer } from "ws";
 import { createBridgeClient } from "../src/bridge-client";
-import { delay, getFreePort, waitUntil } from "./helpers";
+import { closeWebSocketServer, delay, getFreePort, waitUntil } from "./helpers";
 
 describe("createBridgeClient", () => {
   test("mirrors provider announcements", async () => {
@@ -38,7 +38,7 @@ describe("createBridgeClient", () => {
       expect(client.running()).toBe(true);
     } finally {
       client.stop();
-      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+      await closeWebSocketServer(server);
     }
   });
 
@@ -66,7 +66,7 @@ describe("createBridgeClient", () => {
       expect(connectionCount).toBe(1);
     } finally {
       client.stop();
-      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+      await closeWebSocketServer(server);
     }
   });
 
@@ -89,7 +89,7 @@ describe("createBridgeClient", () => {
       expect(connectionCount).toBe(0);
     } finally {
       client.stop();
-      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+      await closeWebSocketServer(server);
     }
   });
 });

--- a/packages/typescript/integrations/discovery/__tests__/bridge-client.test.ts
+++ b/packages/typescript/integrations/discovery/__tests__/bridge-client.test.ts
@@ -1,0 +1,95 @@
+import { describe, test, expect } from "bun:test";
+import { WebSocketServer } from "ws";
+import { createBridgeClient } from "../src/bridge-client";
+import { delay, getFreePort, waitUntil } from "./helpers";
+
+describe("createBridgeClient", () => {
+  test("mirrors provider announcements", async () => {
+    const port = await getFreePort();
+    const server = new WebSocketServer({ host: "127.0.0.1", port, path: "/slop-bridge" });
+    await new Promise<void>((resolve) => server.once("listening", () => resolve()));
+
+    const client = createBridgeClient({
+      url: `ws://127.0.0.1:${port}/slop-bridge`,
+      reconnectIntervalMs: 20,
+    });
+
+    try {
+      await client.connectOnce();
+      await waitUntil(() => server.clients.size === 1);
+      const [socket] = Array.from(server.clients);
+
+      socket.send(JSON.stringify({
+        type: "provider-available",
+        tabId: 1,
+        providerKey: "browser-app",
+        provider: { id: "browser-app", name: "Browser App", transport: "postmessage" },
+      }));
+
+      await waitUntil(() => client.providers().length === 1);
+      expect(client.providers()[0].providerKey).toBe("browser-app");
+
+      socket.send(JSON.stringify({
+        type: "provider-unavailable",
+        providerKey: "browser-app",
+      }));
+
+      await waitUntil(() => client.providers().length === 0);
+      expect(client.running()).toBe(true);
+    } finally {
+      client.stop();
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  });
+
+  test("stop prevents reconnect loop", async () => {
+    const port = await getFreePort();
+    const server = new WebSocketServer({ host: "127.0.0.1", port, path: "/slop-bridge" });
+    let connectionCount = 0;
+    server.on("connection", () => {
+      connectionCount += 1;
+    });
+    await new Promise<void>((resolve) => server.once("listening", () => resolve()));
+
+    const client = createBridgeClient({
+      url: `ws://127.0.0.1:${port}/slop-bridge`,
+      reconnectIntervalMs: 20,
+    });
+
+    try {
+      client.start();
+      await waitUntil(() => connectionCount === 1);
+
+      client.stop();
+      await delay(80);
+
+      expect(connectionCount).toBe(1);
+    } finally {
+      client.stop();
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  });
+
+  test("connectOnce failure does not arm reconnect", async () => {
+    const port = await getFreePort();
+    const url = `ws://127.0.0.1:${port}/slop-bridge`;
+    const client = createBridgeClient({ url, reconnectIntervalMs: 20 });
+
+    await expect(client.connectOnce()).rejects.toBeDefined();
+
+    const server = new WebSocketServer({ host: "127.0.0.1", port, path: "/slop-bridge" });
+    let connectionCount = 0;
+    server.on("connection", () => {
+      connectionCount += 1;
+    });
+    await new Promise<void>((resolve) => server.once("listening", () => resolve()));
+
+    try {
+      await delay(80);
+      expect(connectionCount).toBe(0);
+    } finally {
+      client.stop();
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  });
+});

--- a/packages/typescript/integrations/discovery/__tests__/bridge-server.test.ts
+++ b/packages/typescript/integrations/discovery/__tests__/bridge-server.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { createBridgeServer } from "../src/bridge-server";
-import { connectWebSocket, getFreePort, waitUntil } from "./helpers";
+import { closeWebSocket, connectWebSocket, getFreePort, waitUntil } from "./helpers";
 
 describe("createBridgeServer", () => {
   test("replays providers to newly connected clients", async () => {
@@ -28,10 +28,10 @@ describe("createBridgeServer", () => {
         expect(replay.type).toBe("provider-available");
         expect(replay.providerKey).toBe("browser-app");
       } finally {
-        second.close();
+        await closeWebSocket(second);
       }
     } finally {
-      first.close();
+      await closeWebSocket(first);
       server.stop();
     }
   });
@@ -55,8 +55,8 @@ describe("createBridgeServer", () => {
       first.send(JSON.stringify({ type: "relay-close", providerKey: "browser-app" }));
       await waitUntil(() => received.some((message) => message.type === "relay-close"));
     } finally {
-      first.close();
-      second.close();
+      await closeWebSocket(first);
+      await closeWebSocket(second);
       server.stop();
     }
   });

--- a/packages/typescript/integrations/discovery/__tests__/bridge-server.test.ts
+++ b/packages/typescript/integrations/discovery/__tests__/bridge-server.test.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect } from "bun:test";
+import { createBridgeServer } from "../src/bridge-server";
+import { connectWebSocket, getFreePort, waitUntil } from "./helpers";
+
+describe("createBridgeServer", () => {
+  test("replays providers to newly connected clients", async () => {
+    const port = await getFreePort();
+    const server = createBridgeServer({ host: "127.0.0.1", port, path: "/slop-bridge" });
+    await server.start();
+
+    const first = await connectWebSocket(`ws://127.0.0.1:${port}/slop-bridge`);
+
+    try {
+      first.send(JSON.stringify({
+        type: "provider-available",
+        tabId: 1,
+        providerKey: "browser-app",
+        provider: { id: "browser-app", name: "Browser App", transport: "postmessage" },
+      }));
+
+      await waitUntil(() => server.providers().length === 1);
+
+      const second = await connectWebSocket(`ws://127.0.0.1:${port}/slop-bridge`);
+      try {
+        const replay = await new Promise<Record<string, unknown>>((resolve) => {
+          second.once("message", (data) => resolve(JSON.parse(data.toString())));
+        });
+        expect(replay.type).toBe("provider-available");
+        expect(replay.providerKey).toBe("browser-app");
+      } finally {
+        second.close();
+      }
+    } finally {
+      first.close();
+      server.stop();
+    }
+  });
+
+  test("forwards relay control messages", async () => {
+    const port = await getFreePort();
+    const server = createBridgeServer({ host: "127.0.0.1", port, path: "/slop-bridge" });
+    await server.start();
+
+    const first = await connectWebSocket(`ws://127.0.0.1:${port}/slop-bridge`);
+    const second = await connectWebSocket(`ws://127.0.0.1:${port}/slop-bridge`);
+    const received: Array<Record<string, unknown>> = [];
+    second.on("message", (data) => {
+      received.push(JSON.parse(data.toString()));
+    });
+
+    try {
+      first.send(JSON.stringify({ type: "relay-open", providerKey: "browser-app" }));
+      await waitUntil(() => received.some((message) => message.type === "relay-open"));
+
+      first.send(JSON.stringify({ type: "relay-close", providerKey: "browser-app" }));
+      await waitUntil(() => received.some((message) => message.type === "relay-close"));
+    } finally {
+      first.close();
+      second.close();
+      server.stop();
+    }
+  });
+});

--- a/packages/typescript/integrations/discovery/__tests__/discovery.test.ts
+++ b/packages/typescript/integrations/discovery/__tests__/discovery.test.ts
@@ -1,10 +1,8 @@
 import { describe, test, expect } from "bun:test";
 import { rmSync } from "node:fs";
-import WebSocket from "ws";
 import { createDiscoveryService } from "../src/discovery";
+import type { Bridge, BridgeProvider, RelayHandler } from "../src/bridge-client";
 import {
-  closeWebSocket,
-  connectWebSocket,
   createMockSlopProviderServer,
   createTempDir,
   delay,
@@ -65,56 +63,36 @@ describe("createDiscoveryService", () => {
 
   test("bridge provider removals prune immediately", async () => {
     debugLog("start", "bridge provider removals prune immediately");
-    const port = await getFreePort();
-    const bridgeUrl = `ws://127.0.0.1:${port}/slop-bridge`;
+    const bridge = new FakeBridge();
     const service = createDiscoveryService({
-      hostBridge: true,
-      bridgeUrl,
-      bridgeDialTimeoutMs: 20,
-      bridgeRetryDelayMs: 20,
+      bridge,
+      enableBridge: false,
+      watchProviders: false,
       scanIntervalMs: 1000,
       watchDebounceMs: 20,
     });
 
-    let extension: WebSocket | null = null;
-
     try {
       service.start();
-      debugLog("service started", "bridge prune", { bridgeUrl });
+      debugLog("service started", "bridge prune");
 
-      await waitUntil(async () => {
-        try {
-          extension = await connectWebSocket(bridgeUrl);
-          return true;
-        } catch {
-          return false;
-        }
-      }, { timeoutMs: 1000, intervalMs: 20 });
-
-      extension!.send(JSON.stringify({
-        type: "provider-available",
-        tabId: 1,
+      bridge.setProviders([{
         providerKey: "browser-app",
-        provider: {
-          id: "browser-app",
-          name: "Browser App",
-          transport: "postmessage",
-        },
-      }));
+        tabId: 1,
+        id: "browser-app",
+        name: "Browser App",
+        transport: "postmessage",
+      }]);
 
       await waitUntil(() => service.getDiscovered().some((provider) => provider.id === "browser-app"));
       debugLog("bridge provider discovered");
 
-      extension!.send(JSON.stringify({
-        type: "provider-unavailable",
-        providerKey: "browser-app",
-      }));
+      bridge.setProviders([]);
 
       await waitUntil(() => !service.getDiscovered().some((provider) => provider.id === "browser-app"));
       debugLog("bridge provider pruned");
     } finally {
       debugLog("cleanup start", "bridge prune");
-      await closeWebSocket(extension);
       service.stop();
       debugLog("cleanup done", "bridge prune");
     }
@@ -222,3 +200,45 @@ describe("createDiscoveryService", () => {
     }
   });
 });
+
+class FakeBridge implements Bridge {
+  private currentProviders: BridgeProvider[] = [];
+  private changeCallback: (() => void) | null = null;
+  private relaySubscribers = new Map<string, RelayHandler[]>();
+
+  setProviders(providers: BridgeProvider[]) {
+    this.currentProviders = providers;
+    this.changeCallback?.();
+  }
+
+  running(): boolean {
+    return true;
+  }
+
+  providers(): BridgeProvider[] {
+    return this.currentProviders;
+  }
+
+  onProviderChange(fn: () => void): void {
+    this.changeCallback = fn;
+  }
+
+  subscribeRelay(providerKey: string): RelayHandler[] {
+    const handlers = this.relaySubscribers.get(providerKey) ?? [];
+    this.relaySubscribers.set(providerKey, handlers);
+    return handlers;
+  }
+
+  unsubscribeRelay(providerKey: string, handler: RelayHandler): void {
+    const handlers = this.relaySubscribers.get(providerKey);
+    if (!handlers) return;
+    const index = handlers.indexOf(handler);
+    if (index >= 0) handlers.splice(index, 1);
+  }
+
+  send(): void {}
+
+  start(): void {}
+
+  stop(): void {}
+}

--- a/packages/typescript/integrations/discovery/__tests__/discovery.test.ts
+++ b/packages/typescript/integrations/discovery/__tests__/discovery.test.ts
@@ -19,6 +19,7 @@ describe("createDiscoveryService", () => {
     const providersDir = createTempDir("slop-discovery-ts-scan");
     const service = createDiscoveryService({
       providersDirs: [providersDir],
+      enableBridge: false,
       hostBridge: false,
       bridgeUrl: "ws://127.0.0.1:1/slop-bridge",
       scanIntervalMs: 50,
@@ -104,6 +105,7 @@ describe("createDiscoveryService", () => {
     const providerServer = await createMockSlopProviderServer({ port, providerName: "Test App" });
     const service = createDiscoveryService({
       providersDirs: [providersDir],
+      enableBridge: false,
       hostBridge: false,
       bridgeUrl: "ws://127.0.0.1:1/slop-bridge",
       connectTimeoutMs: 200,
@@ -147,6 +149,7 @@ describe("createDiscoveryService", () => {
     const providerServer = await createMockSlopProviderServer({ port, providerName: "Idle App" });
     const service = createDiscoveryService({
       providersDirs: [providersDir],
+      enableBridge: false,
       hostBridge: false,
       bridgeUrl: "ws://127.0.0.1:1/slop-bridge",
       idleTimeoutMs: 20,

--- a/packages/typescript/integrations/discovery/__tests__/discovery.test.ts
+++ b/packages/typescript/integrations/discovery/__tests__/discovery.test.ts
@@ -12,7 +12,7 @@ import {
   writeDescriptor,
 } from "./helpers";
 
-const DEBUG_DISCOVERY_TESTS = process.env.SLOP_DEBUG_DISCOVERY_TESTS !== "0";
+const DEBUG_DISCOVERY_TESTS = process.env.SLOP_DEBUG_DISCOVERY_TESTS === "1";
 
 function debugLog(...args: unknown[]) {
   if (DEBUG_DISCOVERY_TESTS) {

--- a/packages/typescript/integrations/discovery/__tests__/discovery.test.ts
+++ b/packages/typescript/integrations/discovery/__tests__/discovery.test.ts
@@ -12,17 +12,8 @@ import {
   writeDescriptor,
 } from "./helpers";
 
-const DEBUG_DISCOVERY_TESTS = process.env.SLOP_DEBUG_DISCOVERY_TESTS === "1";
-
-function debugLog(...args: unknown[]) {
-  if (DEBUG_DISCOVERY_TESTS) {
-    console.error("[discovery.test]", ...args);
-  }
-}
-
 describe("createDiscoveryService", () => {
   test("scans local descriptors and prunes removed ones", async () => {
-    debugLog("start", "scans local descriptors and prunes removed ones");
     const providersDir = createTempDir("slop-discovery-ts-scan");
     const service = createDiscoveryService({
       providersDirs: [providersDir],
@@ -46,23 +37,17 @@ describe("createDiscoveryService", () => {
       });
 
       service.start();
-      debugLog("service started", "scan test");
 
       await waitUntil(() => service.getDiscovered().length === 1);
-      debugLog("descriptor discovered", service.getDiscovered().map((provider) => provider.id));
       rmSync(`${providersDir}/test-app.json`);
       await waitUntil(() => service.getDiscovered().length === 0);
-      debugLog("descriptor pruned");
     } finally {
-      debugLog("cleanup start", "scan test");
       service.stop();
       removeTempDir(providersDir);
-      debugLog("cleanup done", "scan test");
     }
   });
 
   test("bridge provider removals prune immediately", async () => {
-    debugLog("start", "bridge provider removals prune immediately");
     const bridge = new FakeBridge();
     const service = createDiscoveryService({
       bridge,
@@ -74,7 +59,6 @@ describe("createDiscoveryService", () => {
 
     try {
       service.start();
-      debugLog("service started", "bridge prune");
 
       bridge.setProviders([{
         providerKey: "browser-app",
@@ -85,21 +69,16 @@ describe("createDiscoveryService", () => {
       }]);
 
       await waitUntil(() => service.getDiscovered().some((provider) => provider.id === "browser-app"));
-      debugLog("bridge provider discovered");
 
       bridge.setProviders([]);
 
       await waitUntil(() => !service.getDiscovered().some((provider) => provider.id === "browser-app"));
-      debugLog("bridge provider pruned");
     } finally {
-      debugLog("cleanup start", "bridge prune");
       service.stop();
-      debugLog("cleanup done", "bridge prune");
     }
   });
 
   test("explicit disconnect does not reconnect", async () => {
-    debugLog("start", "explicit disconnect does not reconnect");
     const providersDir = createTempDir("slop-discovery-ts-disconnect");
     const port = await getFreePort();
     const providerServer = await createMockSlopProviderServer({ port, providerName: "Test App" });
@@ -126,32 +105,25 @@ describe("createDiscoveryService", () => {
       });
 
       service.start();
-      debugLog("service started", "explicit disconnect");
       await waitUntil(() => service.getDiscovered().length === 1);
-      debugLog("descriptor discovered", "explicit disconnect");
 
       const provider = await service.ensureConnected("test-app");
-      debugLog("provider connected", provider?.id);
       expect(provider?.id).toBe("test-app");
       expect(providerServer.getConnectionCount()).toBe(1);
 
       expect(service.disconnect("test-app")).toBe(true);
-      debugLog("provider disconnected explicitly");
       await delay(80);
 
       expect(providerServer.getConnectionCount()).toBe(1);
       expect(service.getProviders()).toHaveLength(0);
     } finally {
-      debugLog("cleanup start", "explicit disconnect");
       service.stop();
       await providerServer.close();
       removeTempDir(providersDir);
-      debugLog("cleanup done", "explicit disconnect");
     }
   });
 
   test("idle disconnect does not reconnect", async () => {
-    debugLog("start", "idle disconnect does not reconnect");
     const providersDir = createTempDir("slop-discovery-ts-idle");
     const port = await getFreePort();
     const providerServer = await createMockSlopProviderServer({ port, providerName: "Idle App" });
@@ -179,24 +151,18 @@ describe("createDiscoveryService", () => {
       });
 
       service.start();
-      debugLog("service started", "idle disconnect");
       await waitUntil(() => service.getDiscovered().length === 1);
-      debugLog("descriptor discovered", "idle disconnect");
       await service.ensureConnected("idle-app");
-      debugLog("provider connected", "idle-app");
       expect(providerServer.getConnectionCount()).toBe(1);
 
       await waitUntil(() => service.getProviders().length === 0, { timeoutMs: 500, intervalMs: 20 });
-      debugLog("provider idled out");
       await delay(80);
 
       expect(providerServer.getConnectionCount()).toBe(1);
     } finally {
-      debugLog("cleanup start", "idle disconnect");
       service.stop();
       await providerServer.close();
       removeTempDir(providersDir);
-      debugLog("cleanup done", "idle disconnect");
     }
   });
 });

--- a/packages/typescript/integrations/discovery/__tests__/discovery.test.ts
+++ b/packages/typescript/integrations/discovery/__tests__/discovery.test.ts
@@ -3,6 +3,7 @@ import { rmSync } from "node:fs";
 import WebSocket from "ws";
 import { createDiscoveryService } from "../src/discovery";
 import {
+  closeWebSocket,
   connectWebSocket,
   createMockSlopProviderServer,
   createTempDir,
@@ -92,7 +93,7 @@ describe("createDiscoveryService", () => {
 
       await waitUntil(() => !service.getDiscovered().some((provider) => provider.id === "browser-app"));
     } finally {
-      extension?.close();
+      await closeWebSocket(extension);
       service.stop();
     }
   });

--- a/packages/typescript/integrations/discovery/__tests__/discovery.test.ts
+++ b/packages/typescript/integrations/discovery/__tests__/discovery.test.ts
@@ -14,12 +14,22 @@ import {
   writeDescriptor,
 } from "./helpers";
 
+const DEBUG_DISCOVERY_TESTS = process.env.SLOP_DEBUG_DISCOVERY_TESTS !== "0";
+
+function debugLog(...args: unknown[]) {
+  if (DEBUG_DISCOVERY_TESTS) {
+    console.error("[discovery.test]", ...args);
+  }
+}
+
 describe("createDiscoveryService", () => {
   test("scans local descriptors and prunes removed ones", async () => {
+    debugLog("start", "scans local descriptors and prunes removed ones");
     const providersDir = createTempDir("slop-discovery-ts-scan");
     const service = createDiscoveryService({
       providersDirs: [providersDir],
       enableBridge: false,
+      watchProviders: false,
       hostBridge: false,
       bridgeUrl: "ws://127.0.0.1:1/slop-bridge",
       scanIntervalMs: 50,
@@ -38,17 +48,23 @@ describe("createDiscoveryService", () => {
       });
 
       service.start();
+      debugLog("service started", "scan test");
 
       await waitUntil(() => service.getDiscovered().length === 1);
+      debugLog("descriptor discovered", service.getDiscovered().map((provider) => provider.id));
       rmSync(`${providersDir}/test-app.json`);
       await waitUntil(() => service.getDiscovered().length === 0);
+      debugLog("descriptor pruned");
     } finally {
+      debugLog("cleanup start", "scan test");
       service.stop();
       removeTempDir(providersDir);
+      debugLog("cleanup done", "scan test");
     }
   });
 
   test("bridge provider removals prune immediately", async () => {
+    debugLog("start", "bridge provider removals prune immediately");
     const port = await getFreePort();
     const bridgeUrl = `ws://127.0.0.1:${port}/slop-bridge`;
     const service = createDiscoveryService({
@@ -64,6 +80,7 @@ describe("createDiscoveryService", () => {
 
     try {
       service.start();
+      debugLog("service started", "bridge prune", { bridgeUrl });
 
       await waitUntil(async () => {
         try {
@@ -86,6 +103,7 @@ describe("createDiscoveryService", () => {
       }));
 
       await waitUntil(() => service.getDiscovered().some((provider) => provider.id === "browser-app"));
+      debugLog("bridge provider discovered");
 
       extension!.send(JSON.stringify({
         type: "provider-unavailable",
@@ -93,19 +111,24 @@ describe("createDiscoveryService", () => {
       }));
 
       await waitUntil(() => !service.getDiscovered().some((provider) => provider.id === "browser-app"));
+      debugLog("bridge provider pruned");
     } finally {
+      debugLog("cleanup start", "bridge prune");
       await closeWebSocket(extension);
       service.stop();
+      debugLog("cleanup done", "bridge prune");
     }
   });
 
   test("explicit disconnect does not reconnect", async () => {
+    debugLog("start", "explicit disconnect does not reconnect");
     const providersDir = createTempDir("slop-discovery-ts-disconnect");
     const port = await getFreePort();
     const providerServer = await createMockSlopProviderServer({ port, providerName: "Test App" });
     const service = createDiscoveryService({
       providersDirs: [providersDir],
       enableBridge: false,
+      watchProviders: false,
       hostBridge: false,
       bridgeUrl: "ws://127.0.0.1:1/slop-bridge",
       connectTimeoutMs: 200,
@@ -125,31 +148,39 @@ describe("createDiscoveryService", () => {
       });
 
       service.start();
+      debugLog("service started", "explicit disconnect");
       await waitUntil(() => service.getDiscovered().length === 1);
+      debugLog("descriptor discovered", "explicit disconnect");
 
       const provider = await service.ensureConnected("test-app");
+      debugLog("provider connected", provider?.id);
       expect(provider?.id).toBe("test-app");
       expect(providerServer.getConnectionCount()).toBe(1);
 
       expect(service.disconnect("test-app")).toBe(true);
+      debugLog("provider disconnected explicitly");
       await delay(80);
 
       expect(providerServer.getConnectionCount()).toBe(1);
       expect(service.getProviders()).toHaveLength(0);
     } finally {
+      debugLog("cleanup start", "explicit disconnect");
       service.stop();
       await providerServer.close();
       removeTempDir(providersDir);
+      debugLog("cleanup done", "explicit disconnect");
     }
   });
 
   test("idle disconnect does not reconnect", async () => {
+    debugLog("start", "idle disconnect does not reconnect");
     const providersDir = createTempDir("slop-discovery-ts-idle");
     const port = await getFreePort();
     const providerServer = await createMockSlopProviderServer({ port, providerName: "Idle App" });
     const service = createDiscoveryService({
       providersDirs: [providersDir],
       enableBridge: false,
+      watchProviders: false,
       hostBridge: false,
       bridgeUrl: "ws://127.0.0.1:1/slop-bridge",
       idleTimeoutMs: 20,
@@ -170,18 +201,24 @@ describe("createDiscoveryService", () => {
       });
 
       service.start();
+      debugLog("service started", "idle disconnect");
       await waitUntil(() => service.getDiscovered().length === 1);
+      debugLog("descriptor discovered", "idle disconnect");
       await service.ensureConnected("idle-app");
+      debugLog("provider connected", "idle-app");
       expect(providerServer.getConnectionCount()).toBe(1);
 
       await waitUntil(() => service.getProviders().length === 0, { timeoutMs: 500, intervalMs: 20 });
+      debugLog("provider idled out");
       await delay(80);
 
       expect(providerServer.getConnectionCount()).toBe(1);
     } finally {
+      debugLog("cleanup start", "idle disconnect");
       service.stop();
       await providerServer.close();
       removeTempDir(providersDir);
+      debugLog("cleanup done", "idle disconnect");
     }
   });
 });

--- a/packages/typescript/integrations/discovery/__tests__/discovery.test.ts
+++ b/packages/typescript/integrations/discovery/__tests__/discovery.test.ts
@@ -1,0 +1,183 @@
+import { describe, test, expect } from "bun:test";
+import { rmSync } from "node:fs";
+import WebSocket from "ws";
+import { createDiscoveryService } from "../src/discovery";
+import {
+  connectWebSocket,
+  createMockSlopProviderServer,
+  createTempDir,
+  delay,
+  getFreePort,
+  removeTempDir,
+  waitUntil,
+  writeDescriptor,
+} from "./helpers";
+
+describe("createDiscoveryService", () => {
+  test("scans local descriptors and prunes removed ones", async () => {
+    const providersDir = createTempDir("slop-discovery-ts-scan");
+    const service = createDiscoveryService({
+      providersDirs: [providersDir],
+      hostBridge: false,
+      bridgeUrl: "ws://127.0.0.1:1/slop-bridge",
+      scanIntervalMs: 50,
+      watchDebounceMs: 20,
+      bridgeDialTimeoutMs: 20,
+      bridgeRetryDelayMs: 20,
+    });
+
+    try {
+      writeDescriptor(providersDir, "test-app.json", {
+        id: "test-app",
+        name: "Test App",
+        slop_version: "0.1",
+        transport: { type: "unix", path: "/tmp/slop/test-app.sock" },
+        capabilities: ["state"],
+      });
+
+      service.start();
+
+      await waitUntil(() => service.getDiscovered().length === 1);
+      rmSync(`${providersDir}/test-app.json`);
+      await waitUntil(() => service.getDiscovered().length === 0);
+    } finally {
+      service.stop();
+      removeTempDir(providersDir);
+    }
+  });
+
+  test("bridge provider removals prune immediately", async () => {
+    const port = await getFreePort();
+    const bridgeUrl = `ws://127.0.0.1:${port}/slop-bridge`;
+    const service = createDiscoveryService({
+      hostBridge: true,
+      bridgeUrl,
+      bridgeDialTimeoutMs: 20,
+      bridgeRetryDelayMs: 20,
+      scanIntervalMs: 1000,
+      watchDebounceMs: 20,
+    });
+
+    let extension: WebSocket | null = null;
+
+    try {
+      service.start();
+
+      await waitUntil(async () => {
+        try {
+          extension = await connectWebSocket(bridgeUrl);
+          return true;
+        } catch {
+          return false;
+        }
+      }, { timeoutMs: 1000, intervalMs: 20 });
+
+      extension!.send(JSON.stringify({
+        type: "provider-available",
+        tabId: 1,
+        providerKey: "browser-app",
+        provider: {
+          id: "browser-app",
+          name: "Browser App",
+          transport: "postmessage",
+        },
+      }));
+
+      await waitUntil(() => service.getDiscovered().some((provider) => provider.id === "browser-app"));
+
+      extension!.send(JSON.stringify({
+        type: "provider-unavailable",
+        providerKey: "browser-app",
+      }));
+
+      await waitUntil(() => !service.getDiscovered().some((provider) => provider.id === "browser-app"));
+    } finally {
+      extension?.close();
+      service.stop();
+    }
+  });
+
+  test("explicit disconnect does not reconnect", async () => {
+    const providersDir = createTempDir("slop-discovery-ts-disconnect");
+    const port = await getFreePort();
+    const providerServer = await createMockSlopProviderServer({ port, providerName: "Test App" });
+    const service = createDiscoveryService({
+      providersDirs: [providersDir],
+      hostBridge: false,
+      bridgeUrl: "ws://127.0.0.1:1/slop-bridge",
+      connectTimeoutMs: 200,
+      reconnectBaseDelayMs: 20,
+      maxReconnectDelayMs: 40,
+      bridgeDialTimeoutMs: 20,
+      bridgeRetryDelayMs: 20,
+    });
+
+    try {
+      writeDescriptor(providersDir, "test-app.json", {
+        id: "test-app",
+        name: "Test App",
+        slop_version: "0.1",
+        transport: { type: "ws", url: providerServer.url },
+        capabilities: ["state"],
+      });
+
+      service.start();
+      await waitUntil(() => service.getDiscovered().length === 1);
+
+      const provider = await service.ensureConnected("test-app");
+      expect(provider?.id).toBe("test-app");
+      expect(providerServer.getConnectionCount()).toBe(1);
+
+      expect(service.disconnect("test-app")).toBe(true);
+      await delay(80);
+
+      expect(providerServer.getConnectionCount()).toBe(1);
+      expect(service.getProviders()).toHaveLength(0);
+    } finally {
+      service.stop();
+      await providerServer.close();
+      removeTempDir(providersDir);
+    }
+  });
+
+  test("idle disconnect does not reconnect", async () => {
+    const providersDir = createTempDir("slop-discovery-ts-idle");
+    const port = await getFreePort();
+    const providerServer = await createMockSlopProviderServer({ port, providerName: "Idle App" });
+    const service = createDiscoveryService({
+      providersDirs: [providersDir],
+      hostBridge: false,
+      bridgeUrl: "ws://127.0.0.1:1/slop-bridge",
+      idleTimeoutMs: 20,
+      idleCheckIntervalMs: 20,
+      reconnectBaseDelayMs: 20,
+      maxReconnectDelayMs: 40,
+      bridgeDialTimeoutMs: 20,
+      bridgeRetryDelayMs: 20,
+    });
+
+    try {
+      writeDescriptor(providersDir, "idle-app.json", {
+        id: "idle-app",
+        name: "Idle App",
+        slop_version: "0.1",
+        transport: { type: "ws", url: providerServer.url },
+        capabilities: ["state"],
+      });
+
+      service.start();
+      await waitUntil(() => service.getDiscovered().length === 1);
+      await service.ensureConnected("idle-app");
+      expect(providerServer.getConnectionCount()).toBe(1);
+
+      await waitUntil(() => service.getProviders().length === 0, { timeoutMs: 500, intervalMs: 20 });
+      await delay(80);
+
+      expect(providerServer.getConnectionCount()).toBe(1);
+    } finally {
+      service.stop();
+      await providerServer.close();
+      removeTempDir(providersDir);
+    }
+  });
+});

--- a/packages/typescript/integrations/discovery/__tests__/helpers.ts
+++ b/packages/typescript/integrations/discovery/__tests__/helpers.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import net from "node:net";
 import WebSocket, { WebSocketServer } from "ws";
 
-const DEBUG_DISCOVERY_TESTS = process.env.SLOP_DEBUG_DISCOVERY_TESTS !== "0";
+const DEBUG_DISCOVERY_TESTS = process.env.SLOP_DEBUG_DISCOVERY_TESTS === "1";
 
 function debugLog(...args: unknown[]) {
   if (DEBUG_DISCOVERY_TESTS) {

--- a/packages/typescript/integrations/discovery/__tests__/helpers.ts
+++ b/packages/typescript/integrations/discovery/__tests__/helpers.ts
@@ -4,6 +4,14 @@ import { tmpdir } from "node:os";
 import net from "node:net";
 import WebSocket, { WebSocketServer } from "ws";
 
+const DEBUG_DISCOVERY_TESTS = process.env.SLOP_DEBUG_DISCOVERY_TESTS !== "0";
+
+function debugLog(...args: unknown[]) {
+  if (DEBUG_DISCOVERY_TESTS) {
+    console.error("[discovery.helper]", ...args);
+  }
+}
+
 export function createTempDir(prefix: string): string {
   return mkdtempSync(join(tmpdir(), `${prefix}-`));
 }
@@ -55,20 +63,24 @@ export async function getFreePort(): Promise<number> {
 }
 
 export async function connectWebSocket(url: string, timeoutMs = 200): Promise<WebSocket> {
+  debugLog("connectWebSocket:start", { url, timeoutMs });
   return new Promise((resolve, reject) => {
     const ws = new WebSocket(url);
     const timer = setTimeout(() => {
+      debugLog("connectWebSocket:timeout", { url });
       ws.terminate();
       reject(new Error(`Timed out connecting to ${url}`));
     }, timeoutMs);
 
     const handleOpen = () => {
       clearTimeout(timer);
+      debugLog("connectWebSocket:open", { url });
       ws.off("error", handleError);
       resolve(ws);
     };
     const handleError = (error: Error) => {
       clearTimeout(timer);
+      debugLog("connectWebSocket:error", { url, message: error.message });
       ws.off("open", handleOpen);
       reject(error);
     };
@@ -81,14 +93,18 @@ export async function closeWebSocket(ws: WebSocket | null | undefined) {
   if (!ws) return;
   if (ws.readyState === WebSocket.CLOSED) return;
 
+  debugLog("closeWebSocket:start", { readyState: ws.readyState });
+
   await new Promise<void>((resolve) => {
     const timer = setTimeout(() => {
+      debugLog("closeWebSocket:terminate");
       ws.terminate();
       resolve();
     }, 100);
 
     ws.once("close", () => {
       clearTimeout(timer);
+      debugLog("closeWebSocket:closed");
       resolve();
     });
 
@@ -97,6 +113,7 @@ export async function closeWebSocket(ws: WebSocket | null | undefined) {
 }
 
 export async function closeWebSocketServer(server: WebSocketServer) {
+  debugLog("closeWebSocketServer:start", { clients: server.clients.size });
   for (const client of server.clients) {
     client.terminate();
   }
@@ -104,6 +121,7 @@ export async function closeWebSocketServer(server: WebSocketServer) {
     const timer = setTimeout(() => resolve(), 100);
     server.close((error) => {
       clearTimeout(timer);
+      debugLog("closeWebSocketServer:closed", { error: error?.message });
       if (error) reject(error);
       else resolve();
     });
@@ -122,6 +140,7 @@ export async function createMockSlopProviderServer(options: {
     providerName = "Test Provider",
     helloDelayMs = 0,
   } = options;
+  debugLog("createMockSlopProviderServer:start", { port, providerId, providerName, helloDelayMs });
   const clients = new Set<WebSocket>();
   let connectionCount = 0;
 
@@ -180,10 +199,12 @@ export async function createMockSlopProviderServer(options: {
     url: `ws://127.0.0.1:${port}/slop`,
     getConnectionCount: () => connectionCount,
     async close() {
+      debugLog("createMockSlopProviderServer:close:start", { port, clients: clients.size });
       for (const client of clients) {
         client.terminate();
       }
       await closeWebSocketServer(wss);
+      debugLog("createMockSlopProviderServer:close:done", { port });
     },
   };
 }

--- a/packages/typescript/integrations/discovery/__tests__/helpers.ts
+++ b/packages/typescript/integrations/discovery/__tests__/helpers.ts
@@ -54,14 +54,21 @@ export async function getFreePort(): Promise<number> {
   });
 }
 
-export async function connectWebSocket(url: string): Promise<WebSocket> {
+export async function connectWebSocket(url: string, timeoutMs = 200): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
     const ws = new WebSocket(url);
+    const timer = setTimeout(() => {
+      ws.terminate();
+      reject(new Error(`Timed out connecting to ${url}`));
+    }, timeoutMs);
+
     const handleOpen = () => {
+      clearTimeout(timer);
       ws.off("error", handleError);
       resolve(ws);
     };
     const handleError = (error: Error) => {
+      clearTimeout(timer);
       ws.off("open", handleOpen);
       reject(error);
     };

--- a/packages/typescript/integrations/discovery/__tests__/helpers.ts
+++ b/packages/typescript/integrations/discovery/__tests__/helpers.ts
@@ -57,8 +57,49 @@ export async function getFreePort(): Promise<number> {
 export async function connectWebSocket(url: string): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
     const ws = new WebSocket(url);
-    ws.once("open", () => resolve(ws));
-    ws.once("error", reject);
+    const handleOpen = () => {
+      ws.off("error", handleError);
+      resolve(ws);
+    };
+    const handleError = (error: Error) => {
+      ws.off("open", handleOpen);
+      reject(error);
+    };
+    ws.once("open", handleOpen);
+    ws.once("error", handleError);
+  });
+}
+
+export async function closeWebSocket(ws: WebSocket | null | undefined) {
+  if (!ws) return;
+  if (ws.readyState === WebSocket.CLOSED) return;
+
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      ws.terminate();
+      resolve();
+    }, 100);
+
+    ws.once("close", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+
+    ws.close();
+  });
+}
+
+export async function closeWebSocketServer(server: WebSocketServer) {
+  for (const client of server.clients) {
+    client.terminate();
+  }
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => resolve(), 100);
+    server.close((error) => {
+      clearTimeout(timer);
+      if (error) reject(error);
+      else resolve();
+    });
   });
 }
 
@@ -135,12 +176,7 @@ export async function createMockSlopProviderServer(options: {
       for (const client of clients) {
         client.terminate();
       }
-      await new Promise<void>((resolve, reject) => {
-        wss.close((error) => {
-          if (error) reject(error);
-          else resolve();
-        });
-      });
+      await closeWebSocketServer(wss);
     },
   };
 }

--- a/packages/typescript/integrations/discovery/__tests__/helpers.ts
+++ b/packages/typescript/integrations/discovery/__tests__/helpers.ts
@@ -4,14 +4,6 @@ import { tmpdir } from "node:os";
 import net from "node:net";
 import WebSocket, { WebSocketServer } from "ws";
 
-const DEBUG_DISCOVERY_TESTS = process.env.SLOP_DEBUG_DISCOVERY_TESTS === "1";
-
-function debugLog(...args: unknown[]) {
-  if (DEBUG_DISCOVERY_TESTS) {
-    console.error("[discovery.helper]", ...args);
-  }
-}
-
 export function createTempDir(prefix: string): string {
   return mkdtempSync(join(tmpdir(), `${prefix}-`));
 }
@@ -63,24 +55,20 @@ export async function getFreePort(): Promise<number> {
 }
 
 export async function connectWebSocket(url: string, timeoutMs = 200): Promise<WebSocket> {
-  debugLog("connectWebSocket:start", { url, timeoutMs });
   return new Promise((resolve, reject) => {
     const ws = new WebSocket(url);
     const timer = setTimeout(() => {
-      debugLog("connectWebSocket:timeout", { url });
       ws.terminate();
       reject(new Error(`Timed out connecting to ${url}`));
     }, timeoutMs);
 
     const handleOpen = () => {
       clearTimeout(timer);
-      debugLog("connectWebSocket:open", { url });
       ws.off("error", handleError);
       resolve(ws);
     };
     const handleError = (error: Error) => {
       clearTimeout(timer);
-      debugLog("connectWebSocket:error", { url, message: error.message });
       ws.off("open", handleOpen);
       reject(error);
     };
@@ -93,18 +81,14 @@ export async function closeWebSocket(ws: WebSocket | null | undefined) {
   if (!ws) return;
   if (ws.readyState === WebSocket.CLOSED) return;
 
-  debugLog("closeWebSocket:start", { readyState: ws.readyState });
-
   await new Promise<void>((resolve) => {
     const timer = setTimeout(() => {
-      debugLog("closeWebSocket:terminate");
       ws.terminate();
       resolve();
     }, 100);
 
     ws.once("close", () => {
       clearTimeout(timer);
-      debugLog("closeWebSocket:closed");
       resolve();
     });
 
@@ -113,7 +97,6 @@ export async function closeWebSocket(ws: WebSocket | null | undefined) {
 }
 
 export async function closeWebSocketServer(server: WebSocketServer) {
-  debugLog("closeWebSocketServer:start", { clients: server.clients.size });
   for (const client of server.clients) {
     client.terminate();
   }
@@ -121,7 +104,6 @@ export async function closeWebSocketServer(server: WebSocketServer) {
     const timer = setTimeout(() => resolve(), 100);
     server.close((error) => {
       clearTimeout(timer);
-      debugLog("closeWebSocketServer:closed", { error: error?.message });
       if (error) reject(error);
       else resolve();
     });
@@ -140,7 +122,6 @@ export async function createMockSlopProviderServer(options: {
     providerName = "Test Provider",
     helloDelayMs = 0,
   } = options;
-  debugLog("createMockSlopProviderServer:start", { port, providerId, providerName, helloDelayMs });
   const clients = new Set<WebSocket>();
   let connectionCount = 0;
 
@@ -199,12 +180,10 @@ export async function createMockSlopProviderServer(options: {
     url: `ws://127.0.0.1:${port}/slop`,
     getConnectionCount: () => connectionCount,
     async close() {
-      debugLog("createMockSlopProviderServer:close:start", { port, clients: clients.size });
       for (const client of clients) {
         client.terminate();
       }
       await closeWebSocketServer(wss);
-      debugLog("createMockSlopProviderServer:close:done", { port });
     },
   };
 }

--- a/packages/typescript/integrations/discovery/__tests__/helpers.ts
+++ b/packages/typescript/integrations/discovery/__tests__/helpers.ts
@@ -1,0 +1,146 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import net from "node:net";
+import WebSocket, { WebSocketServer } from "ws";
+
+export function createTempDir(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), `${prefix}-`));
+}
+
+export function removeTempDir(path: string) {
+  rmSync(path, { recursive: true, force: true });
+}
+
+export function writeDescriptor(dir: string, fileName: string, descriptor: unknown) {
+  writeFileSync(join(dir, fileName), JSON.stringify(descriptor, null, 2));
+}
+
+export async function waitUntil(
+  fn: () => boolean | Promise<boolean>,
+  options: { timeoutMs?: number; intervalMs?: number } = {},
+) {
+  const timeoutMs = options.timeoutMs ?? 1000;
+  const intervalMs = options.intervalMs ?? 10;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (await fn()) return;
+    await delay(intervalMs);
+  }
+
+  throw new Error("Condition not met before timeout");
+}
+
+export function delay(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+export async function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Failed to allocate port"));
+        return;
+      }
+      const { port } = address;
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve(port);
+      });
+    });
+  });
+}
+
+export async function connectWebSocket(url: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    ws.once("open", () => resolve(ws));
+    ws.once("error", reject);
+  });
+}
+
+export async function createMockSlopProviderServer(options: {
+  port: number;
+  providerId?: string;
+  providerName?: string;
+  helloDelayMs?: number;
+}) {
+  const {
+    port,
+    providerId = "test-provider",
+    providerName = "Test Provider",
+    helloDelayMs = 0,
+  } = options;
+  const clients = new Set<WebSocket>();
+  let connectionCount = 0;
+
+  const wss = new WebSocketServer({ host: "127.0.0.1", port, path: "/slop" });
+  wss.on("connection", (ws) => {
+    clients.add(ws);
+    connectionCount += 1;
+
+    setTimeout(() => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({
+          type: "hello",
+          provider: {
+            id: providerId,
+            name: providerName,
+            slop_version: "0.1",
+            capabilities: [],
+          },
+        }));
+      }
+    }, helloDelayMs);
+
+    ws.on("message", (raw) => {
+      const message = JSON.parse(raw.toString()) as Record<string, unknown>;
+      if (message.type === "subscribe") {
+        ws.send(JSON.stringify({
+          type: "snapshot",
+          id: message.id,
+          version: 1,
+          tree: {
+            id: providerId,
+            type: "root",
+            properties: { label: providerName },
+            children: [],
+            affordances: [],
+          },
+        }));
+      }
+      if (message.type === "invoke") {
+        ws.send(JSON.stringify({
+          type: "result",
+          id: message.id,
+          status: "ok",
+        }));
+      }
+    });
+
+    ws.on("close", () => {
+      clients.delete(ws);
+    });
+  });
+
+  await new Promise<void>((resolve) => wss.once("listening", () => resolve()));
+
+  return {
+    url: `ws://127.0.0.1:${port}/slop`,
+    getConnectionCount: () => connectionCount,
+    async close() {
+      for (const client of clients) {
+        client.terminate();
+      }
+      await new Promise<void>((resolve, reject) => {
+        wss.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    },
+  };
+}

--- a/packages/typescript/integrations/discovery/__tests__/relay-transport.test.ts
+++ b/packages/typescript/integrations/discovery/__tests__/relay-transport.test.ts
@@ -1,0 +1,70 @@
+import { describe, test, expect } from "bun:test";
+import { BridgeRelayTransport } from "../src/relay-transport";
+import type { Bridge, BridgeProvider, RelayHandler } from "../src/bridge-client";
+import { delay } from "./helpers";
+
+describe("BridgeRelayTransport", () => {
+  test("buffers early hello messages until onMessage is registered", async () => {
+    const bridge = new FakeBridge();
+    const transport = new BridgeRelayTransport(bridge, "tab-1");
+
+    const connection = await transport.connect();
+    const received: Array<Record<string, unknown>> = [];
+
+    connection.onMessage((message) => {
+      received.push(message as Record<string, unknown>);
+    });
+
+    await delay(0);
+
+    expect(received[0]?.type).toBe("hello");
+    expect(bridge.sent[0]).toEqual({ type: "relay-open", providerKey: "tab-1" });
+
+    connection.close();
+  });
+});
+
+class FakeBridge implements Bridge {
+  sent: Record<string, unknown>[] = [];
+  private subscribers = new Map<string, RelayHandler[]>();
+
+  running(): boolean {
+    return true;
+  }
+
+  providers(): BridgeProvider[] {
+    return [];
+  }
+
+  onProviderChange(): void {}
+
+  subscribeRelay(providerKey: string): RelayHandler[] {
+    const handlers = this.subscribers.get(providerKey) ?? [];
+    this.subscribers.set(providerKey, handlers);
+    return handlers;
+  }
+
+  unsubscribeRelay(providerKey: string, handler: RelayHandler): void {
+    const handlers = this.subscribers.get(providerKey);
+    if (!handlers) return;
+    const index = handlers.indexOf(handler);
+    if (index >= 0) handlers.splice(index, 1);
+  }
+
+  send(msg: Record<string, unknown>): void {
+    this.sent.push(msg);
+    if (msg.type === "slop-relay" && (msg.message as Record<string, unknown>)?.type === "connect") {
+      const handlers = this.subscribers.get(msg.providerKey as string) ?? [];
+      for (const handler of handlers) {
+        handler({
+          type: "hello",
+          provider: { id: "tab-1", name: "Browser App", slop_version: "0.1", capabilities: [] },
+        });
+      }
+    }
+  }
+
+  start(): void {}
+
+  stop(): void {}
+}

--- a/packages/typescript/integrations/discovery/__tests__/tools.test.ts
+++ b/packages/typescript/integrations/discovery/__tests__/tools.test.ts
@@ -1,0 +1,89 @@
+import { describe, test, expect } from "bun:test";
+import type { DiscoveryService } from "../src/discovery";
+import { createDynamicTools, createToolHandlers } from "../src/tools";
+
+const tree = {
+  id: "root",
+  type: "root",
+  properties: { label: "Test App" },
+  children: [{
+    id: "todo-1",
+    type: "item",
+    properties: { label: "Todo 1" },
+    affordances: [{ action: "complete", description: "Complete item" }],
+  }],
+};
+
+describe("discovery tools", () => {
+  test("createDynamicTools prefixes provider ids and resolves actions", () => {
+    const discovery = createFakeDiscovery();
+    const toolSet = createDynamicTools(discovery);
+
+    expect(toolSet.tools).toHaveLength(1);
+    expect(toolSet.tools[0].name).toBe("todo_app__todo_1__complete");
+    expect(toolSet.tools[0].description).toContain("[Todo App]");
+    expect(toolSet.resolve("todo_app__todo_1__complete")).toEqual({
+      providerId: "todo-app",
+      path: "/todo-1",
+      action: "complete",
+      targets: undefined,
+    });
+  });
+
+  test("createToolHandlers list, connect, and disconnect apps", async () => {
+    const discovery = createFakeDiscovery();
+    const handlers = createToolHandlers(discovery);
+
+    const list = await handlers.listApps();
+    expect(list.content[0].text).toContain("Test App");
+
+    const connect = await handlers.connectApp({ app: "todo-app" });
+    expect(connect.content[0].text).toContain("## Todo App");
+    expect(connect.content[0].text).toContain("complete");
+
+    const disconnect = await handlers.disconnectApp({ app: "todo-app" });
+    expect(disconnect.content[0].text).toContain('Disconnected from "todo-app"');
+  });
+});
+
+function createFakeDiscovery(): DiscoveryService {
+  const provider = {
+    id: "todo-app",
+    name: "Todo App",
+    descriptor: {
+      id: "todo-app",
+      name: "Todo App",
+      slop_version: "0.1",
+      transport: { type: "ws", url: "ws://example.test/slop" },
+      capabilities: [],
+    },
+    consumer: {
+      getTree() {
+        return tree;
+      },
+    },
+    subscriptionId: "sub-1",
+    status: "connected",
+  };
+
+  return {
+    getDiscovered() {
+      return [provider.descriptor];
+    },
+    getProviders() {
+      return [provider as any];
+    },
+    getProvider() {
+      return provider as any;
+    },
+    async ensureConnected() {
+      return provider as any;
+    },
+    disconnect() {
+      return true;
+    },
+    onStateChange() {},
+    start() {},
+    stop() {},
+  };
+}

--- a/packages/typescript/integrations/discovery/src/bridge-client.ts
+++ b/packages/typescript/integrations/discovery/src/bridge-client.ts
@@ -62,13 +62,13 @@ export function parseBridgeProvider(msg: Record<string, unknown>): BridgeProvide
 // ---------------------------------------------------------------------------
 
 export function createBridgeClient(
-  optionsOrLogger?: BridgeClientOptions | Logger,
+  options: BridgeClientOptions = {},
 ): Bridge & { connectOnce(): Promise<void> } {
   const {
     logger: log,
     url,
     reconnectIntervalMs,
-  } = normalizeOptions(optionsOrLogger);
+  } = normalizeOptions(options);
 
   let ws: WebSocket | null = null;
   let isRunning = false;
@@ -250,12 +250,7 @@ export function createBridgeClient(
   };
 }
 
-function normalizeOptions(optionsOrLogger?: BridgeClientOptions | Logger): Required<BridgeClientOptions> {
-  const options =
-    optionsOrLogger && ("url" in optionsOrLogger || "logger" in optionsOrLogger || "reconnectIntervalMs" in optionsOrLogger)
-      ? optionsOrLogger as BridgeClientOptions
-      : { logger: optionsOrLogger as Logger | undefined };
-
+function normalizeOptions(options: BridgeClientOptions = {}): Required<BridgeClientOptions> {
   return {
     logger: options.logger ?? { info: console.error, error: console.error },
     url: options.url ?? DEFAULT_BRIDGE_URL,

--- a/packages/typescript/integrations/discovery/src/bridge-client.ts
+++ b/packages/typescript/integrations/discovery/src/bridge-client.ts
@@ -240,7 +240,7 @@ export function createBridgeClient(
         reconnectTimer = null;
       }
       if (ws) {
-        ws.close();
+        ws.terminate();
         ws = null;
       }
       isRunning = false;

--- a/packages/typescript/integrations/discovery/src/bridge-client.ts
+++ b/packages/typescript/integrations/discovery/src/bridge-client.ts
@@ -148,10 +148,10 @@ export function createBridgeClient(
 
   function scheduleReconnect() {
     if (!started || reconnectTimer) return;
-    reconnectTimer = setTimeout(() => {
+    reconnectTimer = unrefTimer(setTimeout(() => {
       reconnectTimer = null;
       void doConnect().catch(() => {});
-    }, reconnectIntervalMs);
+    }, reconnectIntervalMs));
   }
 
   function handleMessage(msg: Record<string, unknown>) {
@@ -256,4 +256,9 @@ function normalizeOptions(options: BridgeClientOptions = {}): Required<BridgeCli
     url: options.url ?? DEFAULT_BRIDGE_URL,
     reconnectIntervalMs: options.reconnectIntervalMs ?? DEFAULT_RECONNECT_INTERVAL,
   };
+}
+
+function unrefTimer<T extends { unref?: () => unknown }>(timer: T): T {
+  timer.unref?.();
+  return timer;
 }

--- a/packages/typescript/integrations/discovery/src/bridge-client.ts
+++ b/packages/typescript/integrations/discovery/src/bridge-client.ts
@@ -1,7 +1,15 @@
 import WebSocket from "ws";
 
-const BRIDGE_URL = "ws://127.0.0.1:9339/slop-bridge";
-const RECONNECT_INTERVAL = 5000;
+export const DEFAULT_BRIDGE_URL = "ws://127.0.0.1:9339/slop-bridge";
+const DEFAULT_RECONNECT_INTERVAL = 5000;
+
+type Logger = { info: (...args: any[]) => void; error: (...args: any[]) => void };
+
+export interface BridgeClientOptions {
+  logger?: Logger;
+  url?: string;
+  reconnectIntervalMs?: number;
+}
 
 // ---------------------------------------------------------------------------
 // Shared types
@@ -54,66 +62,96 @@ export function parseBridgeProvider(msg: Record<string, unknown>): BridgeProvide
 // ---------------------------------------------------------------------------
 
 export function createBridgeClient(
-  logger?: { info: (...args: any[]) => void; error: (...args: any[]) => void },
+  optionsOrLogger?: BridgeClientOptions | Logger,
 ): Bridge & { connectOnce(): Promise<void> } {
-  const log = logger ?? { info: console.error, error: console.error };
+  const {
+    logger: log,
+    url,
+    reconnectIntervalMs,
+  } = normalizeOptions(optionsOrLogger);
 
   let ws: WebSocket | null = null;
   let isRunning = false;
+  let started = false;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let connectPromise: Promise<void> | null = null;
   let changeCallback: (() => void) | null = null;
 
   const providerMap = new Map<string, BridgeProvider>();
   const relaySubscribers = new Map<string, RelayHandler[]>();
 
-  function doConnect(
-    onSuccess?: () => void,
-    onFailure?: (err: Error) => void,
-  ) {
-    if (ws) return;
+  function doConnect(): Promise<void> {
+    if (connectPromise) return connectPromise;
+    if (ws?.readyState === WebSocket.OPEN) return Promise.resolve();
 
-    try {
-      ws = new WebSocket(BRIDGE_URL);
-    } catch (e: any) {
-      onFailure?.(e);
-      return;
-    }
+    connectPromise = new Promise((resolve, reject) => {
+      let settled = false;
+      let socket: WebSocket;
 
-    ws.on("open", () => {
-      isRunning = true;
-      log.info("[slop-bridge] Connected to extension bridge");
-      onSuccess?.();
-    });
-
-    ws.on("message", (data: WebSocket.Data) => {
       try {
-        const msg = JSON.parse(data.toString());
-        handleMessage(msg);
-      } catch {}
-    });
-
-    ws.on("close", () => {
-      isRunning = false;
-      ws = null;
-      if (providerMap.size > 0) {
-        providerMap.clear();
-        changeCallback?.();
+        socket = new WebSocket(url);
+      } catch (error: any) {
+        connectPromise = null;
+        reject(error);
+        return;
       }
-      scheduleReconnect();
+
+      ws = socket;
+
+      const settle = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        connectPromise = null;
+        fn();
+      };
+
+      socket.on("open", () => {
+        if (ws !== socket) {
+          socket.close();
+          settle(resolve);
+          return;
+        }
+        isRunning = true;
+        log.info("[slop-bridge] Connected to extension bridge");
+        settle(resolve);
+      });
+
+      socket.on("message", (data: WebSocket.Data) => {
+        try {
+          const msg = JSON.parse(data.toString());
+          handleMessage(msg);
+        } catch {}
+      });
+
+      socket.on("close", () => {
+        if (ws === socket) {
+          isRunning = false;
+          ws = null;
+          if (providerMap.size > 0) {
+            providerMap.clear();
+            changeCallback?.();
+          }
+          if (started) {
+            scheduleReconnect();
+          }
+        }
+        settle(() => reject(new Error("Bridge connection closed")));
+      });
+
+      socket.on("error", (err: Error) => {
+        settle(() => reject(err));
+      });
     });
 
-    ws.on("error", (err: Error) => {
-      onFailure?.(err);
-      // Error will trigger close, which handles reconnect
-    });
+    return connectPromise;
   }
 
   function scheduleReconnect() {
-    if (reconnectTimer) return;
+    if (!started || reconnectTimer) return;
     reconnectTimer = setTimeout(() => {
       reconnectTimer = null;
-      doConnect();
-    }, RECONNECT_INTERVAL);
+      void doConnect().catch(() => {});
+    }, reconnectIntervalMs);
   }
 
   function handleMessage(msg: Record<string, unknown>) {
@@ -155,9 +193,7 @@ export function createBridgeClient(
   return {
     /** Single connection attempt — resolves on open, rejects on error. */
     connectOnce(): Promise<void> {
-      return new Promise((resolve, reject) => {
-        doConnect(resolve, reject);
-      });
+      return doConnect();
     },
 
     running() {
@@ -193,10 +229,12 @@ export function createBridgeClient(
     },
 
     start() {
-      doConnect();
+      started = true;
+      void doConnect().catch(() => {});
     },
 
     stop() {
+      started = false;
       if (reconnectTimer) {
         clearTimeout(reconnectTimer);
         reconnectTimer = null;
@@ -209,5 +247,18 @@ export function createBridgeClient(
       providerMap.clear();
       relaySubscribers.clear();
     },
+  };
+}
+
+function normalizeOptions(optionsOrLogger?: BridgeClientOptions | Logger): Required<BridgeClientOptions> {
+  const options =
+    optionsOrLogger && ("url" in optionsOrLogger || "logger" in optionsOrLogger || "reconnectIntervalMs" in optionsOrLogger)
+      ? optionsOrLogger as BridgeClientOptions
+      : { logger: optionsOrLogger as Logger | undefined };
+
+  return {
+    logger: options.logger ?? { info: console.error, error: console.error },
+    url: options.url ?? DEFAULT_BRIDGE_URL,
+    reconnectIntervalMs: options.reconnectIntervalMs ?? DEFAULT_RECONNECT_INTERVAL,
   };
 }

--- a/packages/typescript/integrations/discovery/src/bridge-server.ts
+++ b/packages/typescript/integrations/discovery/src/bridge-server.ts
@@ -2,8 +2,18 @@ import WebSocket, { WebSocketServer } from "ws";
 import type { Bridge, BridgeProvider, RelayHandler } from "./bridge-client";
 import { parseBridgeProvider } from "./bridge-client";
 
-const BRIDGE_PORT = 9339;
-const BRIDGE_PATH = "/slop-bridge";
+export const DEFAULT_BRIDGE_HOST = "127.0.0.1";
+export const DEFAULT_BRIDGE_PORT = 9339;
+export const DEFAULT_BRIDGE_PATH = "/slop-bridge";
+
+type Logger = { info: (...args: any[]) => void; error: (...args: any[]) => void };
+
+export interface BridgeServerOptions {
+  logger?: Logger;
+  host?: string;
+  port?: number;
+  path?: string;
+}
 
 /**
  * Bridge WebSocket server — hosts the extension bridge at ws://127.0.0.1:9339/slop-bridge.
@@ -13,9 +23,14 @@ const BRIDGE_PATH = "/slop-bridge";
  * tracks provider announcements, and relays SLOP messages for postMessage providers.
  */
 export function createBridgeServer(
-  logger?: { info: (...args: any[]) => void; error: (...args: any[]) => void },
+  optionsOrLogger?: BridgeServerOptions | Logger,
 ): Bridge & { start(): Promise<void> } {
-  const log = logger ?? { info: console.error, error: console.error };
+  const {
+    logger: log,
+    host,
+    port,
+    path,
+  } = normalizeOptions(optionsOrLogger);
 
   let wss: WebSocketServer | null = null;
   let isRunning = false;
@@ -109,14 +124,14 @@ export function createBridgeServer(
     start(): Promise<void> {
       return new Promise((resolve, reject) => {
         wss = new WebSocketServer({
-          host: "127.0.0.1",
-          port: BRIDGE_PORT,
-          path: BRIDGE_PATH,
+          host,
+          port,
+          path,
         });
 
         wss.on("listening", () => {
           isRunning = true;
-          log.info(`[slop-bridge] Bridge server running on ws://127.0.0.1:${BRIDGE_PORT}${BRIDGE_PATH}`);
+          log.info(`[slop-bridge] Bridge server running on ws://${host}:${port}${path}`);
           resolve();
         });
 
@@ -198,5 +213,19 @@ export function createBridgeServer(
         wss = null;
       }
     },
+  };
+}
+
+function normalizeOptions(optionsOrLogger?: BridgeServerOptions | Logger): Required<BridgeServerOptions> {
+  const options =
+    optionsOrLogger && ("host" in optionsOrLogger || "port" in optionsOrLogger || "path" in optionsOrLogger || "logger" in optionsOrLogger)
+      ? optionsOrLogger as BridgeServerOptions
+      : { logger: optionsOrLogger as Logger | undefined };
+
+  return {
+    logger: options.logger ?? { info: console.error, error: console.error },
+    host: options.host ?? DEFAULT_BRIDGE_HOST,
+    port: options.port ?? DEFAULT_BRIDGE_PORT,
+    path: options.path ?? DEFAULT_BRIDGE_PATH,
   };
 }

--- a/packages/typescript/integrations/discovery/src/bridge-server.ts
+++ b/packages/typescript/integrations/discovery/src/bridge-server.ts
@@ -23,14 +23,14 @@ export interface BridgeServerOptions {
  * tracks provider announcements, and relays SLOP messages for postMessage providers.
  */
 export function createBridgeServer(
-  optionsOrLogger?: BridgeServerOptions | Logger,
+  options: BridgeServerOptions = {},
 ): Bridge & { start(): Promise<void> } {
   const {
     logger: log,
     host,
     port,
     path,
-  } = normalizeOptions(optionsOrLogger);
+  } = normalizeOptions(options);
 
   let wss: WebSocketServer | null = null;
   let isRunning = false;
@@ -216,12 +216,7 @@ export function createBridgeServer(
   };
 }
 
-function normalizeOptions(optionsOrLogger?: BridgeServerOptions | Logger): Required<BridgeServerOptions> {
-  const options =
-    optionsOrLogger && ("host" in optionsOrLogger || "port" in optionsOrLogger || "path" in optionsOrLogger || "logger" in optionsOrLogger)
-      ? optionsOrLogger as BridgeServerOptions
-      : { logger: optionsOrLogger as Logger | undefined };
-
+function normalizeOptions(options: BridgeServerOptions = {}): Required<BridgeServerOptions> {
   return {
     logger: options.logger ?? { info: console.error, error: console.error },
     host: options.host ?? DEFAULT_BRIDGE_HOST,

--- a/packages/typescript/integrations/discovery/src/bridge-server.ts
+++ b/packages/typescript/integrations/discovery/src/bridge-server.ts
@@ -204,11 +204,14 @@ export function createBridgeServer(
 
     stop() {
       isRunning = false;
-      for (const sink of sinks) sink.close();
+      for (const sink of sinks) sink.terminate();
       sinks.clear();
       providerMap.clear();
       relaySubscribers.clear();
       if (wss) {
+        for (const client of wss.clients) {
+          client.terminate();
+        }
         wss.close();
         wss = null;
       }

--- a/packages/typescript/integrations/discovery/src/discovery.ts
+++ b/packages/typescript/integrations/discovery/src/discovery.ts
@@ -7,15 +7,35 @@ import {
   NodeSocketClientTransport,
   type ClientTransport,
 } from "@slop-ai/consumer";
-import { createBridgeClient, type Bridge, type BridgeProvider } from "./bridge-client";
-import { createBridgeServer } from "./bridge-server";
+import {
+  DEFAULT_BRIDGE_URL,
+  createBridgeClient,
+  type Bridge,
+  type BridgeProvider,
+} from "./bridge-client";
+import {
+  DEFAULT_BRIDGE_HOST,
+  DEFAULT_BRIDGE_PATH,
+  DEFAULT_BRIDGE_PORT,
+  createBridgeServer,
+} from "./bridge-server";
 import { BridgeRelayTransport } from "./relay-transport";
 
-const PROVIDERS_DIRS = [
+const DEFAULT_PROVIDERS_DIRS = [
   join(homedir(), ".slop", "providers"),  // persistent user-level
   "/tmp/slop/providers",                   // session-level ephemeral
 ];
-const IDLE_TIMEOUT = 5 * 60 * 1000; // 5 minutes
+const DEFAULT_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
+const DEFAULT_SCAN_INTERVAL_MS = 15_000;
+const DEFAULT_WATCH_DEBOUNCE_MS = 500;
+const DEFAULT_IDLE_CHECK_INTERVAL_MS = 60_000;
+const DEFAULT_RECONNECT_BASE_DELAY_MS = 3000;
+const DEFAULT_MAX_RECONNECT_DELAY_MS = 30_000;
+const DEFAULT_BRIDGE_DIAL_TIMEOUT_MS = 1000;
+const DEFAULT_BRIDGE_RETRY_DELAY_MS = 5000;
+
+type Logger = { info: (...args: any[]) => void; error: (...args: any[]) => void };
 
 export interface ProviderDescriptor {
   id: string;
@@ -44,11 +64,22 @@ export interface ConnectedProvider {
 }
 
 export interface DiscoveryOptions {
-  logger?: { info: (...args: any[]) => void; error: (...args: any[]) => void };
+  logger?: Logger;
   /** Auto-connect all discovered providers instead of lazy-connecting */
   autoConnect?: boolean;
   /** Start a bridge server if no existing bridge is found (default: true) */
   hostBridge?: boolean;
+  providersDirs?: string[];
+  bridgeUrl?: string;
+  idleTimeoutMs?: number;
+  idleCheckIntervalMs?: number;
+  connectTimeoutMs?: number;
+  scanIntervalMs?: number;
+  watchDebounceMs?: number;
+  reconnectBaseDelayMs?: number;
+  maxReconnectDelayMs?: number;
+  bridgeDialTimeoutMs?: number;
+  bridgeRetryDelayMs?: number;
 }
 
 export interface DiscoveryService {
@@ -65,27 +96,45 @@ export interface DiscoveryService {
 }
 
 export function createDiscoveryService(
-  optionsOrLogger?: DiscoveryOptions | { info: (...args: any[]) => void; error: (...args: any[]) => void }
+  optionsOrLogger?: DiscoveryOptions | Logger,
 ): DiscoveryService {
-  // Support both old signature (logger) and new (options)
-  const opts: DiscoveryOptions =
-    optionsOrLogger && ("autoConnect" in optionsOrLogger || "logger" in optionsOrLogger)
-      ? optionsOrLogger as DiscoveryOptions
-      : { logger: optionsOrLogger as any };
-  const log = opts.logger ?? { info: console.error, error: console.error };
-  const autoConnect = opts.autoConnect ?? false;
-  const hostBridge = opts.hostBridge ?? true;
+  // Support both old signature (logger) and new (options).
+  // TODO: deprecate the logger-only overload after downstream integrations migrate.
+  const opts = normalizeOptions(optionsOrLogger);
+  const {
+    log,
+    autoConnect,
+    hostBridge,
+    providersDirs,
+    bridgeUrl,
+    bridgeHost,
+    bridgePort,
+    bridgePath,
+    idleTimeoutMs,
+    idleCheckIntervalMs,
+    connectTimeoutMs,
+    scanIntervalMs,
+    watchDebounceMs,
+    reconnectBaseDelayMs,
+    maxReconnectDelayMs,
+    bridgeDialTimeoutMs,
+    bridgeRetryDelayMs,
+  } = opts;
   const providers = new Map<string, ConnectedProvider>();
+  const connecting = new Map<string, Promise<ConnectedProvider | null>>();
   const lastAccessed = new Map<string, number>();
   const reconnectAttempts = new Map<string, number>();
-  const MAX_RECONNECT_DELAY = 30000;
+  const reconnectTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const intentionalDisconnects = new Set<string>();
   let watchers: FSWatcher[] = [];
   let scanTimer: ReturnType<typeof setInterval> | null = null;
   let idleTimer: ReturnType<typeof setInterval> | null = null;
+  let watchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
   let lastLocalDescriptors: ProviderDescriptor[] = [];
   let bridge: Bridge | null = null;
   let stateChangeCallback: (() => void) | null = null;
   let started = false;
+  let lifecycleVersion = 0;
 
   // --- Local discovery (file-based) ---
 
@@ -105,7 +154,7 @@ export function createDiscoveryService(
 
   function readDescriptors(): ProviderDescriptor[] {
     const descriptors: ProviderDescriptor[] = [];
-    for (const dir of PROVIDERS_DIRS) {
+    for (const dir of providersDirs) {
       if (!existsSync(dir)) continue;
       for (const file of readdirSync(dir)) {
         if (!file.endsWith(".json")) continue;
@@ -173,75 +222,111 @@ export function createDiscoveryService(
   // --- Connection management ---
 
   async function connectProvider(desc: ProviderDescriptor): Promise<ConnectedProvider | null> {
-    if (providers.has(desc.id) && providers.get(desc.id)!.status === "connected") {
-      return providers.get(desc.id)!;
+    const existing = providers.get(desc.id);
+    if (existing?.status === "connected") {
+      return existing;
     }
 
-    const transport = createTransport(desc);
-    if (!transport) {
-      log.info(`[slop] Skipping ${desc.name}: unsupported transport ${desc.transport.type}`);
-      return null;
+    const inFlight = connecting.get(desc.id);
+    if (inFlight) {
+      return inFlight;
     }
 
-    const entry: ConnectedProvider = {
-      id: desc.id,
-      name: desc.name,
-      descriptor: desc,
-      consumer: new SlopConsumer(transport),
-      subscriptionId: "",
-      status: "connecting",
-    };
-    providers.set(desc.id, entry);
+    const generation = lifecycleVersion;
+    const trackedPromise = Promise.resolve().then(async () => {
+      const transport = createTransport(desc);
+      if (!transport) {
+        log.info(`[slop] Skipping ${desc.name}: unsupported transport ${desc.transport.type}`);
+        return null;
+      }
 
-    try {
-      const CONNECT_TIMEOUT = 10_000;
-      const hello = await Promise.race([
-        entry.consumer.connect(),
-        new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error("Connection timed out after 10s")), CONNECT_TIMEOUT),
-        ),
-      ]);
-      entry.name = hello.provider.name;
-      const { id: subId } = await entry.consumer.subscribe("/", -1);
-      entry.subscriptionId = subId;
-      entry.status = "connected";
-      lastAccessed.set(desc.id, Date.now());
-      reconnectAttempts.delete(desc.id);
-      log.info(`[slop] Connected to ${entry.name} (${desc.id}) via ${desc.transport.type}`);
-      stateChangeCallback?.();
+      clearReconnectTimer(desc.id);
 
-      entry.consumer.on("patch", () => {
-        stateChangeCallback?.();
-      });
+      const entry: ConnectedProvider = {
+        id: desc.id,
+        name: desc.name,
+        descriptor: desc,
+        consumer: new SlopConsumer(transport),
+        subscriptionId: "",
+        status: "connecting",
+      };
+      providers.set(desc.id, entry);
 
-      entry.consumer.on("disconnect", () => {
-        log.info(`[slop] Disconnected from ${entry.name}`);
-        entry.status = "disconnected";
-        providers.delete(desc.id);
-        lastAccessed.delete(desc.id);
-        stateChangeCallback?.();
+      try {
+        const hello = await withTimeout(
+          entry.consumer.connect(),
+          connectTimeoutMs,
+          `Connection timed out after ${Math.round(connectTimeoutMs / 1000)}s`,
+        );
+        const { id: subId } = await withTimeout(
+          entry.consumer.subscribe("/", -1),
+          connectTimeoutMs,
+          `Subscription timed out after ${Math.round(connectTimeoutMs / 1000)}s`,
+        );
 
-        // Exponential backoff reconnection (only if descriptor still exists)
-        const allDescs = getAllDescriptors();
-        if (allDescs.some(d => d.id === desc.id)) {
-          const attempt = (reconnectAttempts.get(desc.id) ?? 0) + 1;
-          reconnectAttempts.set(desc.id, attempt);
-          const delay = Math.min(3000 * Math.pow(2, attempt - 1), MAX_RECONNECT_DELAY);
-          log.info(`[slop] Will reconnect to ${entry.name} in ${delay / 1000}s (attempt ${attempt})`);
-          setTimeout(() => {
-            if (!providers.has(desc.id)) {
-              connectProvider(desc).catch(() => {});
-            }
-          }, delay);
+        if (lifecycleVersion !== generation || !providers.has(desc.id)) {
+          entry.consumer.disconnect();
+          return null;
         }
-      });
 
-      return entry;
-    } catch (err: any) {
-      log.error(`[slop] Failed to connect to ${desc.name}: ${err.message}`);
-      providers.delete(desc.id);
-      return null;
-    }
+        entry.name = hello.provider.name;
+        entry.subscriptionId = subId;
+        entry.status = "connected";
+        lastAccessed.set(desc.id, Date.now());
+        reconnectAttempts.delete(desc.id);
+        intentionalDisconnects.delete(desc.id);
+        log.info(`[slop] Connected to ${entry.name} (${desc.id}) via ${desc.transport.type}`);
+        stateChangeCallback?.();
+
+        entry.consumer.on("patch", () => {
+          stateChangeCallback?.();
+        });
+
+        entry.consumer.on("disconnect", () => {
+          const wasIntentional = intentionalDisconnects.delete(desc.id);
+          log.info(`[slop] Disconnected from ${entry.name}`);
+          entry.status = "disconnected";
+          providers.delete(desc.id);
+          lastAccessed.delete(desc.id);
+          stateChangeCallback?.();
+
+          if (wasIntentional || lifecycleVersion !== generation) {
+            reconnectAttempts.delete(desc.id);
+            clearReconnectTimer(desc.id);
+            return;
+          }
+
+          if (getAllDescriptors().some(d => d.id === desc.id)) {
+            const attempt = (reconnectAttempts.get(desc.id) ?? 0) + 1;
+            reconnectAttempts.set(desc.id, attempt);
+            const delay = Math.min(
+              reconnectBaseDelayMs * Math.pow(2, attempt - 1),
+              maxReconnectDelayMs,
+            );
+            log.info(`[slop] Will reconnect to ${entry.name} in ${delay / 1000}s (attempt ${attempt})`);
+            clearReconnectTimer(desc.id);
+            reconnectTimers.set(desc.id, setTimeout(() => {
+              reconnectTimers.delete(desc.id);
+              if (lifecycleVersion === generation && !providers.has(desc.id) && getAllDescriptors().some(d => d.id === desc.id)) {
+                void connectProvider(desc).catch(() => {});
+              }
+            }, delay));
+          }
+        });
+
+        return entry;
+      } catch (err: any) {
+        log.error(`[slop] Failed to connect to ${desc.name}: ${err.message}`);
+        providers.delete(desc.id);
+        return null;
+      }
+    }).finally(() => {
+      if (connecting.get(desc.id) === trackedPromise) {
+        connecting.delete(desc.id);
+      }
+    });
+    connecting.set(desc.id, trackedPromise);
+    return trackedPromise;
   }
 
   // --- Scan & cleanup ---
@@ -249,16 +334,23 @@ export function createDiscoveryService(
   function scan() {
     lastLocalDescriptors = readDescriptors();
     const allIds = new Set(getAllDescriptors().map(d => d.id));
+    let changed = false;
 
     // Clean up connected providers whose descriptors are gone
     for (const [id, entry] of providers) {
       if (!allIds.has(id)) {
         log.info(`[slop] Provider ${entry.name} unregistered, disconnecting`);
+        markIntentionalDisconnect(id);
         entry.consumer.disconnect();
         providers.delete(id);
         lastAccessed.delete(id);
         reconnectAttempts.delete(id);
+        changed = true;
       }
+    }
+
+    if (changed) {
+      stateChangeCallback?.();
     }
 
     // Auto-connect new providers when in plugin mode
@@ -275,13 +367,15 @@ export function createDiscoveryService(
   function checkIdle() {
     const now = Date.now();
     for (const [id, ts] of lastAccessed) {
-      if (now - ts > IDLE_TIMEOUT && providers.has(id)) {
+      if (now - ts > idleTimeoutMs && providers.has(id)) {
         const entry = providers.get(id)!;
         log.info(`[slop] Idle timeout: disconnecting ${entry.name}`);
+        markIntentionalDisconnect(id);
         entry.consumer.disconnect();
         providers.delete(id);
         lastAccessed.delete(id);
         reconnectAttempts.delete(id);
+        stateChangeCallback?.();
       }
     }
   }
@@ -289,12 +383,20 @@ export function createDiscoveryService(
   // --- Lookup ---
 
   async function initBridge(
-    logger: { info: (...args: any[]) => void; error: (...args: any[]) => void },
+    logger: Logger,
   ): Promise<Bridge> {
     // 1. Try connecting as a client (Desktop or another consumer hosts the bridge)
-    const client = createBridgeClient(logger);
+    const client = createBridgeClient({
+      logger,
+      url: bridgeUrl,
+      reconnectIntervalMs: bridgeRetryDelayMs,
+    });
     try {
-      await client.connectOnce();
+      await withTimeout(
+        client.connectOnce(),
+        bridgeDialTimeoutMs,
+        `Bridge connection timed out after ${bridgeDialTimeoutMs}ms`,
+      );
       client.start(); // enable retry loop for future disconnects
       logger.info("[slop-bridge] Connected as client to existing bridge");
       return client;
@@ -305,13 +407,17 @@ export function createDiscoveryService(
     // 2. If hosting is disabled, just start client with retry loop
     if (!hostBridge) {
       logger.info("[slop-bridge] No bridge found, will keep retrying as client");
-      const retryClient = createBridgeClient(logger);
+      const retryClient = createBridgeClient({
+        logger,
+        url: bridgeUrl,
+        reconnectIntervalMs: bridgeRetryDelayMs,
+      });
       retryClient.start();
       return retryClient;
     }
 
     // 3. No bridge running — start our own server
-    const server = createBridgeServer(logger);
+    const server = createBridgeServer({ logger, host: bridgeHost, port: bridgePort, path: bridgePath });
     try {
       await server.start();
       return server;
@@ -322,9 +428,36 @@ export function createDiscoveryService(
 
     // 4. Retry as client (port race fallback)
     logger.info("[slop-bridge] Port taken, retrying as client");
-    const retryClient = createBridgeClient(logger);
+    const retryClient = createBridgeClient({
+      logger,
+      url: bridgeUrl,
+      reconnectIntervalMs: bridgeRetryDelayMs,
+    });
     retryClient.start();
     return retryClient;
+  }
+
+  function scheduleScan() {
+    if (watchDebounceTimer) {
+      clearTimeout(watchDebounceTimer);
+    }
+    watchDebounceTimer = setTimeout(() => {
+      watchDebounceTimer = null;
+      scan();
+    }, watchDebounceMs);
+  }
+
+  function clearReconnectTimer(id: string) {
+    const timer = reconnectTimers.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      reconnectTimers.delete(id);
+    }
+  }
+
+  function markIntentionalDisconnect(id: string) {
+    intentionalDisconnects.add(id);
+    clearReconnectTimer(id);
   }
 
   function findDescriptor(idOrName: string): ProviderDescriptor | null {
@@ -377,6 +510,7 @@ export function createDiscoveryService(
       if (!entry) return false;
 
       log.info(`[slop] Disconnecting ${entry.name}`);
+      markIntentionalDisconnect(id);
       entry.consumer.disconnect();
       providers.delete(id);
       lastAccessed.delete(id);
@@ -412,50 +546,134 @@ export function createDiscoveryService(
     start() {
       if (started) return;
       started = true;
+      const generation = ++lifecycleVersion;
 
       // Start local file discovery
       scan();
 
-      for (const dir of PROVIDERS_DIRS) {
+      for (const dir of providersDirs) {
         try {
           if (existsSync(dir)) {
-            watchers.push(watch(dir, () => setTimeout(scan, 500)));
+            watchers.push(watch(dir, scheduleScan));
           }
         } catch {}
       }
 
-      scanTimer = setInterval(scan, 15000);
-      idleTimer = setInterval(checkIdle, 60000);
+      scanTimer = setInterval(scan, scanIntervalMs);
+      idleTimer = setInterval(checkIdle, idleCheckIntervalMs);
 
       // Start bridge: try client first, fall back to server
       initBridge(log).then((b) => {
+        if (!started || lifecycleVersion !== generation) {
+          b.stop();
+          return;
+        }
         bridge = b;
         bridge.onProviderChange(() => {
           log.info(`[slop-bridge] Provider list changed (${bridge!.providers().length} browser tabs)`);
-          if (autoConnect) {
-            for (const desc of getBridgeDescriptors()) {
-              if (!providers.has(desc.id)) {
-                connectProvider(desc).catch(() => {});
-              }
-            }
-          }
+          scan();
         });
       });
     },
 
     stop() {
+      started = false;
+      lifecycleVersion += 1;
       for (const w of watchers) w.close();
       watchers = [];
       if (scanTimer) { clearInterval(scanTimer); scanTimer = null; }
       if (idleTimer) { clearInterval(idleTimer); idleTimer = null; }
+      if (watchDebounceTimer) { clearTimeout(watchDebounceTimer); watchDebounceTimer = null; }
       if (bridge) { bridge.stop(); bridge = null; }
+      for (const [, promise] of connecting) {
+        void promise.catch(() => {});
+      }
+      connecting.clear();
+      for (const [id, timer] of reconnectTimers) {
+        markIntentionalDisconnect(id);
+        clearTimeout(timer);
+      }
+      reconnectTimers.clear();
       for (const [, entry] of providers) {
+        intentionalDisconnects.add(entry.id);
         entry.consumer.disconnect();
       }
       providers.clear();
       lastAccessed.clear();
       reconnectAttempts.clear();
-      started = false;
+      intentionalDisconnects.clear();
     },
   };
+}
+
+function normalizeOptions(optionsOrLogger?: DiscoveryOptions | Logger) {
+  const options: DiscoveryOptions =
+    optionsOrLogger && isDiscoveryOptions(optionsOrLogger)
+      ? optionsOrLogger
+      : { logger: optionsOrLogger as Logger | undefined };
+  const bridgeUrl = options.bridgeUrl ?? DEFAULT_BRIDGE_URL;
+  const bridgeConfig = resolveBridgeConfig(bridgeUrl);
+
+  return {
+    log: options.logger ?? { info: console.error, error: console.error },
+    autoConnect: options.autoConnect ?? false,
+    hostBridge: options.hostBridge ?? true,
+    providersDirs: options.providersDirs ?? DEFAULT_PROVIDERS_DIRS,
+    bridgeUrl,
+    bridgeHost: bridgeConfig.host,
+    bridgePort: bridgeConfig.port,
+    bridgePath: bridgeConfig.path,
+    idleTimeoutMs: options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS,
+    idleCheckIntervalMs: options.idleCheckIntervalMs ?? DEFAULT_IDLE_CHECK_INTERVAL_MS,
+    connectTimeoutMs: options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS,
+    scanIntervalMs: options.scanIntervalMs ?? DEFAULT_SCAN_INTERVAL_MS,
+    watchDebounceMs: options.watchDebounceMs ?? DEFAULT_WATCH_DEBOUNCE_MS,
+    reconnectBaseDelayMs: options.reconnectBaseDelayMs ?? DEFAULT_RECONNECT_BASE_DELAY_MS,
+    maxReconnectDelayMs: options.maxReconnectDelayMs ?? DEFAULT_MAX_RECONNECT_DELAY_MS,
+    bridgeDialTimeoutMs: options.bridgeDialTimeoutMs ?? DEFAULT_BRIDGE_DIAL_TIMEOUT_MS,
+    bridgeRetryDelayMs: options.bridgeRetryDelayMs ?? DEFAULT_BRIDGE_RETRY_DELAY_MS,
+  };
+}
+
+function isDiscoveryOptions(optionsOrLogger: DiscoveryOptions | Logger): optionsOrLogger is DiscoveryOptions {
+  return (
+    "autoConnect" in optionsOrLogger ||
+    "hostBridge" in optionsOrLogger ||
+    "logger" in optionsOrLogger ||
+    "providersDirs" in optionsOrLogger ||
+    "bridgeUrl" in optionsOrLogger ||
+    "idleTimeoutMs" in optionsOrLogger ||
+    "idleCheckIntervalMs" in optionsOrLogger ||
+    "connectTimeoutMs" in optionsOrLogger ||
+    "scanIntervalMs" in optionsOrLogger ||
+    "watchDebounceMs" in optionsOrLogger ||
+    "reconnectBaseDelayMs" in optionsOrLogger ||
+    "maxReconnectDelayMs" in optionsOrLogger ||
+    "bridgeDialTimeoutMs" in optionsOrLogger ||
+    "bridgeRetryDelayMs" in optionsOrLogger
+  );
+}
+
+function resolveBridgeConfig(bridgeUrl: string) {
+  try {
+    const parsed = new URL(bridgeUrl);
+    return {
+      host: parsed.hostname || DEFAULT_BRIDGE_HOST,
+      port: parsed.port ? Number(parsed.port) : DEFAULT_BRIDGE_PORT,
+      path: parsed.pathname || DEFAULT_BRIDGE_PATH,
+    };
+  } catch {
+    return {
+      host: DEFAULT_BRIDGE_HOST,
+      port: DEFAULT_BRIDGE_PORT,
+      path: DEFAULT_BRIDGE_PATH,
+    };
+  }
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error(message)), timeoutMs)),
+  ]);
 }

--- a/packages/typescript/integrations/discovery/src/discovery.ts
+++ b/packages/typescript/integrations/discovery/src/discovery.ts
@@ -71,6 +71,8 @@ export interface DiscoveryOptions {
   enableBridge?: boolean;
   /** Disable provider directory watchers and rely on periodic scans only */
   watchProviders?: boolean;
+  /** Inject a bridge implementation directly instead of starting one */
+  bridge?: Bridge;
   /** Start a bridge server if no existing bridge is found (default: true) */
   hostBridge?: boolean;
   providersDirs?: string[];
@@ -108,6 +110,7 @@ export function createDiscoveryService(
     autoConnect,
     enableBridge,
     watchProviders,
+    bridge: bridgeOverride,
     hostBridge,
     providersDirs,
     bridgeUrl,
@@ -568,8 +571,15 @@ export function createDiscoveryService(
       scanTimer = unrefTimer(setInterval(scan, scanIntervalMs));
       idleTimer = unrefTimer(setInterval(checkIdle, idleCheckIntervalMs));
 
-      // Start bridge: try client first, fall back to server
-      if (enableBridge) {
+      // Start bridge: use provided bridge, or try client first and fall back to server.
+      if (bridgeOverride) {
+        bridge = bridgeOverride;
+        bridge.start();
+        bridge.onProviderChange(() => {
+          log.info(`[slop-bridge] Provider list changed (${bridge!.providers().length} browser tabs)`);
+          scan();
+        });
+      } else if (enableBridge) {
         initBridge(log).then((b) => {
           if (!started || lifecycleVersion !== generation) {
             b.stop();
@@ -623,6 +633,7 @@ function normalizeOptions(options: DiscoveryOptions = {}) {
     autoConnect: options.autoConnect ?? false,
     enableBridge: options.enableBridge ?? true,
     watchProviders: options.watchProviders ?? true,
+    bridge: options.bridge ?? null,
     hostBridge: options.hostBridge ?? true,
     providersDirs: options.providersDirs ?? DEFAULT_PROVIDERS_DIRS,
     bridgeUrl,

--- a/packages/typescript/integrations/discovery/src/discovery.ts
+++ b/packages/typescript/integrations/discovery/src/discovery.ts
@@ -69,6 +69,8 @@ export interface DiscoveryOptions {
   autoConnect?: boolean;
   /** Disable bridge startup entirely (useful for environments that only need local discovery) */
   enableBridge?: boolean;
+  /** Disable provider directory watchers and rely on periodic scans only */
+  watchProviders?: boolean;
   /** Start a bridge server if no existing bridge is found (default: true) */
   hostBridge?: boolean;
   providersDirs?: string[];
@@ -105,6 +107,7 @@ export function createDiscoveryService(
     log,
     autoConnect,
     enableBridge,
+    watchProviders,
     hostBridge,
     providersDirs,
     bridgeUrl,
@@ -306,12 +309,12 @@ export function createDiscoveryService(
             );
             log.info(`[slop] Will reconnect to ${entry.name} in ${delay / 1000}s (attempt ${attempt})`);
             clearReconnectTimer(desc.id);
-            reconnectTimers.set(desc.id, setTimeout(() => {
+            reconnectTimers.set(desc.id, unrefTimer(setTimeout(() => {
               reconnectTimers.delete(desc.id);
               if (lifecycleVersion === generation && !providers.has(desc.id) && getAllDescriptors().some(d => d.id === desc.id)) {
                 void connectProvider(desc).catch(() => {});
               }
-            }, delay));
+            }, delay)));
           }
         });
 
@@ -442,10 +445,10 @@ export function createDiscoveryService(
     if (watchDebounceTimer) {
       clearTimeout(watchDebounceTimer);
     }
-    watchDebounceTimer = setTimeout(() => {
+    watchDebounceTimer = unrefTimer(setTimeout(() => {
       watchDebounceTimer = null;
       scan();
-    }, watchDebounceMs);
+    }, watchDebounceMs));
   }
 
   function clearReconnectTimer(id: string) {
@@ -552,16 +555,18 @@ export function createDiscoveryService(
       // Start local file discovery
       scan();
 
-      for (const dir of providersDirs) {
-        try {
-          if (existsSync(dir)) {
-            watchers.push(watch(dir, scheduleScan));
-          }
-        } catch {}
+      if (watchProviders) {
+        for (const dir of providersDirs) {
+          try {
+            if (existsSync(dir)) {
+              watchers.push(watch(dir, scheduleScan));
+            }
+          } catch {}
+        }
       }
 
-      scanTimer = setInterval(scan, scanIntervalMs);
-      idleTimer = setInterval(checkIdle, idleCheckIntervalMs);
+      scanTimer = unrefTimer(setInterval(scan, scanIntervalMs));
+      idleTimer = unrefTimer(setInterval(checkIdle, idleCheckIntervalMs));
 
       // Start bridge: try client first, fall back to server
       if (enableBridge) {
@@ -617,6 +622,7 @@ function normalizeOptions(options: DiscoveryOptions = {}) {
     log: options.logger ?? { info: console.error, error: console.error },
     autoConnect: options.autoConnect ?? false,
     enableBridge: options.enableBridge ?? true,
+    watchProviders: options.watchProviders ?? true,
     hostBridge: options.hostBridge ?? true,
     providersDirs: options.providersDirs ?? DEFAULT_PROVIDERS_DIRS,
     bridgeUrl,
@@ -655,6 +661,13 @@ function resolveBridgeConfig(bridgeUrl: string) {
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
   return Promise.race([
     promise,
-    new Promise<never>((_, reject) => setTimeout(() => reject(new Error(message)), timeoutMs)),
+    new Promise<never>((_, reject) => {
+      unrefTimer(setTimeout(() => reject(new Error(message)), timeoutMs));
+    }),
   ]);
+}
+
+function unrefTimer<T extends { unref?: () => unknown }>(timer: T): T {
+  timer.unref?.();
+  return timer;
 }

--- a/packages/typescript/integrations/discovery/src/discovery.ts
+++ b/packages/typescript/integrations/discovery/src/discovery.ts
@@ -67,6 +67,8 @@ export interface DiscoveryOptions {
   logger?: Logger;
   /** Auto-connect all discovered providers instead of lazy-connecting */
   autoConnect?: boolean;
+  /** Disable bridge startup entirely (useful for environments that only need local discovery) */
+  enableBridge?: boolean;
   /** Start a bridge server if no existing bridge is found (default: true) */
   hostBridge?: boolean;
   providersDirs?: string[];
@@ -102,6 +104,7 @@ export function createDiscoveryService(
   const {
     log,
     autoConnect,
+    enableBridge,
     hostBridge,
     providersDirs,
     bridgeUrl,
@@ -561,17 +564,19 @@ export function createDiscoveryService(
       idleTimer = setInterval(checkIdle, idleCheckIntervalMs);
 
       // Start bridge: try client first, fall back to server
-      initBridge(log).then((b) => {
-        if (!started || lifecycleVersion !== generation) {
-          b.stop();
-          return;
-        }
-        bridge = b;
-        bridge.onProviderChange(() => {
-          log.info(`[slop-bridge] Provider list changed (${bridge!.providers().length} browser tabs)`);
-          scan();
+      if (enableBridge) {
+        initBridge(log).then((b) => {
+          if (!started || lifecycleVersion !== generation) {
+            b.stop();
+            return;
+          }
+          bridge = b;
+          bridge.onProviderChange(() => {
+            log.info(`[slop-bridge] Provider list changed (${bridge!.providers().length} browser tabs)`);
+            scan();
+          });
         });
-      });
+      }
     },
 
     stop() {
@@ -611,6 +616,7 @@ function normalizeOptions(options: DiscoveryOptions = {}) {
   return {
     log: options.logger ?? { info: console.error, error: console.error },
     autoConnect: options.autoConnect ?? false,
+    enableBridge: options.enableBridge ?? true,
     hostBridge: options.hostBridge ?? true,
     providersDirs: options.providersDirs ?? DEFAULT_PROVIDERS_DIRS,
     bridgeUrl,

--- a/packages/typescript/integrations/discovery/src/discovery.ts
+++ b/packages/typescript/integrations/discovery/src/discovery.ts
@@ -96,11 +96,9 @@ export interface DiscoveryService {
 }
 
 export function createDiscoveryService(
-  optionsOrLogger?: DiscoveryOptions | Logger,
+  options: DiscoveryOptions = {},
 ): DiscoveryService {
-  // Support both old signature (logger) and new (options).
-  // TODO: deprecate the logger-only overload after downstream integrations migrate.
-  const opts = normalizeOptions(optionsOrLogger);
+  const opts = normalizeOptions(options);
   const {
     log,
     autoConnect,
@@ -606,11 +604,7 @@ export function createDiscoveryService(
   };
 }
 
-function normalizeOptions(optionsOrLogger?: DiscoveryOptions | Logger) {
-  const options: DiscoveryOptions =
-    optionsOrLogger && isDiscoveryOptions(optionsOrLogger)
-      ? optionsOrLogger
-      : { logger: optionsOrLogger as Logger | undefined };
+function normalizeOptions(options: DiscoveryOptions = {}) {
   const bridgeUrl = options.bridgeUrl ?? DEFAULT_BRIDGE_URL;
   const bridgeConfig = resolveBridgeConfig(bridgeUrl);
 
@@ -633,25 +627,6 @@ function normalizeOptions(optionsOrLogger?: DiscoveryOptions | Logger) {
     bridgeDialTimeoutMs: options.bridgeDialTimeoutMs ?? DEFAULT_BRIDGE_DIAL_TIMEOUT_MS,
     bridgeRetryDelayMs: options.bridgeRetryDelayMs ?? DEFAULT_BRIDGE_RETRY_DELAY_MS,
   };
-}
-
-function isDiscoveryOptions(optionsOrLogger: DiscoveryOptions | Logger): optionsOrLogger is DiscoveryOptions {
-  return (
-    "autoConnect" in optionsOrLogger ||
-    "hostBridge" in optionsOrLogger ||
-    "logger" in optionsOrLogger ||
-    "providersDirs" in optionsOrLogger ||
-    "bridgeUrl" in optionsOrLogger ||
-    "idleTimeoutMs" in optionsOrLogger ||
-    "idleCheckIntervalMs" in optionsOrLogger ||
-    "connectTimeoutMs" in optionsOrLogger ||
-    "scanIntervalMs" in optionsOrLogger ||
-    "watchDebounceMs" in optionsOrLogger ||
-    "reconnectBaseDelayMs" in optionsOrLogger ||
-    "maxReconnectDelayMs" in optionsOrLogger ||
-    "bridgeDialTimeoutMs" in optionsOrLogger ||
-    "bridgeRetryDelayMs" in optionsOrLogger
-  );
 }
 
 function resolveBridgeConfig(bridgeUrl: string) {

--- a/packages/typescript/integrations/discovery/src/index.ts
+++ b/packages/typescript/integrations/discovery/src/index.ts
@@ -9,9 +9,10 @@ export {
   type Bridge,
   type BridgeProvider,
   type RelayHandler,
+  type BridgeClientOptions,
   createBridgeClient,
 } from "./bridge-client";
-export { createBridgeServer } from "./bridge-server";
+export { createBridgeServer, type BridgeServerOptions } from "./bridge-server";
 export { BridgeRelayTransport } from "./relay-transport";
 
 /** Agent-agnostic tool handlers and dynamic affordance→tool mapping (OpenClaw, MCP bridges, etc.). */

--- a/packages/typescript/integrations/discovery/src/index.ts
+++ b/packages/typescript/integrations/discovery/src/index.ts
@@ -1,26 +1,35 @@
-export {
-  createDiscoveryService,
-  type DiscoveryService,
-  type DiscoveryOptions,
-  type ProviderDescriptor,
-  type ConnectedProvider,
+import { createDiscoveryService as createDiscoveryServiceImpl } from "./discovery";
+import { createBridgeClient as createBridgeClientImpl } from "./bridge-client";
+import { createBridgeServer as createBridgeServerImpl } from "./bridge-server";
+import { BridgeRelayTransport as BridgeRelayTransportImpl } from "./relay-transport";
+import { createToolHandlers as createToolHandlersImpl, createDynamicTools as createDynamicToolsImpl } from "./tools";
+import { createStateCache as createStateCacheImpl } from "./state-cache";
+
+export const createDiscoveryService = createDiscoveryServiceImpl;
+export type {
+  DiscoveryService,
+  DiscoveryOptions,
+  ProviderDescriptor,
+  ConnectedProvider,
 } from "./discovery";
-export {
-  type Bridge,
-  type BridgeProvider,
-  type RelayHandler,
-  type BridgeClientOptions,
-  createBridgeClient,
+export const createBridgeClient = createBridgeClientImpl;
+export type {
+  Bridge,
+  BridgeProvider,
+  RelayHandler,
+  BridgeClientOptions,
 } from "./bridge-client";
-export { createBridgeServer, type BridgeServerOptions } from "./bridge-server";
-export { BridgeRelayTransport } from "./relay-transport";
+export const createBridgeServer = createBridgeServerImpl;
+export type { BridgeServerOptions } from "./bridge-server";
+export const BridgeRelayTransport = BridgeRelayTransportImpl;
 
 /** Agent-agnostic tool handlers and dynamic affordance→tool mapping (OpenClaw, MCP bridges, etc.). */
-export {
-  createToolHandlers,
-  createDynamicTools,
-  type ToolResult,
-  type DynamicToolSet,
-  type DynamicToolEntry,
+export const createToolHandlers = createToolHandlersImpl;
+export const createDynamicTools = createDynamicToolsImpl;
+export type {
+  ToolResult,
+  DynamicToolSet,
+  DynamicToolEntry,
 } from "./tools";
-export { createStateCache, type StateCache } from "./state-cache";
+export const createStateCache = createStateCacheImpl;
+export type { StateCache } from "./state-cache";

--- a/packages/typescript/sdk/consumer/package.json
+++ b/packages/typescript/sdk/consumer/package.json
@@ -10,8 +10,8 @@
       "types": "./dist/index.d.ts"
     },
     "./browser": {
-      "import": "./src/browser.ts",
-      "types": "./src/browser.ts"
+      "import": "./dist/browser.js",
+      "types": "./dist/browser.d.ts"
     }
   },
   "files": ["src", "dist"],
@@ -21,7 +21,7 @@
   "homepage": "https://docs.slopai.dev/api/consumer",
   "bugs": "https://github.com/devteapot/slop/issues",
   "scripts": {
-    "build": "rm -rf dist && bunx tsc",
+    "build": "bun build src/index.ts src/browser.ts --outdir dist --target node --format esm && bunx tsc --emitDeclarationOnly --outDir dist",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/packages/typescript/sdk/consumer/package.json
+++ b/packages/typescript/sdk/consumer/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://docs.slopai.dev/api/consumer",
   "bugs": "https://github.com/devteapot/slop/issues",
   "scripts": {
-    "build": "bun build src/index.ts --outdir dist --target node --format esm && bunx tsc --emitDeclarationOnly --outDir dist",
+    "build": "rm -rf dist && bunx tsc",
     "clean": "rm -rf dist"
   },
   "repository": {

--- a/packages/typescript/sdk/consumer/package.json
+++ b/packages/typescript/sdk/consumer/package.json
@@ -10,8 +10,8 @@
       "types": "./dist/index.d.ts"
     },
     "./browser": {
-      "import": "./dist/browser.js",
-      "types": "./dist/browser.d.ts"
+      "import": "./src/browser.ts",
+      "types": "./src/browser.ts"
     }
   },
   "files": ["src", "dist"],

--- a/packages/typescript/sdk/consumer/src/browser.ts
+++ b/packages/typescript/sdk/consumer/src/browser.ts
@@ -1,24 +1,32 @@
 // Browser-safe entry point — excludes Node.js transports
 
+import { SlopConsumer as SlopConsumerImpl } from "./consumer";
+import { StateMirror as StateMirrorImpl } from "./state-mirror";
+import { WebSocketClientTransport as WebSocketClientTransportImpl } from "./transport-ws";
+import { PostMessageClientTransport as PostMessageClientTransportImpl } from "./transport-pm";
+import { affordancesToTools as affordancesToToolsImpl, formatTree as formatTreeImpl } from "./tools";
+import { Emitter as EmitterImpl } from "./emitter";
+
 // Consumer
-export { SlopConsumer } from "./consumer";
-export { StateMirror } from "./state-mirror";
+export const SlopConsumer = SlopConsumerImpl;
+export const StateMirror = StateMirrorImpl;
+export type SlopConsumer = InstanceType<typeof SlopConsumerImpl>;
+export type StateMirror = InstanceType<typeof StateMirrorImpl>;
 
 // Browser transports only
-export { WebSocketClientTransport } from "./transport-ws";
-export { PostMessageClientTransport } from "./transport-pm";
+export const WebSocketClientTransport = WebSocketClientTransportImpl;
+export const PostMessageClientTransport = PostMessageClientTransportImpl;
+export type WebSocketClientTransport = InstanceType<typeof WebSocketClientTransportImpl>;
+export type PostMessageClientTransport = InstanceType<typeof PostMessageClientTransportImpl>;
 
 // LLM tool utilities
-export {
-  affordancesToTools,
-  formatTree,
-  type LlmTool,
-  type ToolSet,
-  type ChatMessage,
-} from "./tools";
+export const affordancesToTools = affordancesToToolsImpl;
+export const formatTree = formatTreeImpl;
+export type { LlmTool, ToolSet, ChatMessage } from "./tools";
 
 // Emitter
-export { Emitter } from "./emitter";
+export const Emitter = EmitterImpl;
+export type Emitter = InstanceType<typeof EmitterImpl>;
 
 // Types
 export type {

--- a/packages/typescript/sdk/consumer/src/index.ts
+++ b/packages/typescript/sdk/consumer/src/index.ts
@@ -1,23 +1,33 @@
+import { SlopConsumer as SlopConsumerImpl } from "./consumer";
+import { StateMirror as StateMirrorImpl } from "./state-mirror";
+import { WebSocketClientTransport as WebSocketClientTransportImpl } from "./transport-ws";
+import { PostMessageClientTransport as PostMessageClientTransportImpl } from "./transport-pm";
+import { NodeSocketClientTransport as NodeSocketClientTransportImpl } from "./transport-node-socket";
+import { affordancesToTools as affordancesToToolsImpl, formatTree as formatTreeImpl } from "./tools";
+import { Emitter as EmitterImpl } from "./emitter";
+
 // Consumer
-export { SlopConsumer } from "./consumer";
-export { StateMirror } from "./state-mirror";
+export const SlopConsumer = SlopConsumerImpl;
+export const StateMirror = StateMirrorImpl;
+export type SlopConsumer = InstanceType<typeof SlopConsumerImpl>;
+export type StateMirror = InstanceType<typeof StateMirrorImpl>;
 
 // Transports
-export { WebSocketClientTransport } from "./transport-ws";
-export { PostMessageClientTransport } from "./transport-pm";
-export { NodeSocketClientTransport } from "./transport-node-socket";
+export const WebSocketClientTransport = WebSocketClientTransportImpl;
+export const PostMessageClientTransport = PostMessageClientTransportImpl;
+export const NodeSocketClientTransport = NodeSocketClientTransportImpl;
+export type WebSocketClientTransport = InstanceType<typeof WebSocketClientTransportImpl>;
+export type PostMessageClientTransport = InstanceType<typeof PostMessageClientTransportImpl>;
+export type NodeSocketClientTransport = InstanceType<typeof NodeSocketClientTransportImpl>;
 
 // LLM tool utilities
-export {
-  affordancesToTools,
-  formatTree,
-  type LlmTool,
-  type ToolSet,
-  type ChatMessage,
-} from "./tools";
+export const affordancesToTools = affordancesToToolsImpl;
+export const formatTree = formatTreeImpl;
+export type { LlmTool, ToolSet, ChatMessage } from "./tools";
 
 // Emitter (for custom transports)
-export { Emitter } from "./emitter";
+export const Emitter = EmitterImpl;
+export type Emitter = InstanceType<typeof EmitterImpl>;
 
 // Types
 export type {

--- a/website/docs/src/content/docs/guides/go.md
+++ b/website/docs/src/content/docs/guides/go.md
@@ -89,6 +89,31 @@ _, _ = consumer.Invoke(context.Background(), "/status", "restart", nil)
 fmt.Println(hello["provider"], subID, snapshot.ID)
 ```
 
+## Discovery layer
+
+The Go SDK also includes the core discovery layer in the `discovery` subpackage:
+
+```go
+import (
+	"context"
+	"fmt"
+
+	"github.com/devteapot/slop/packages/go/slop-ai/discovery"
+)
+
+svc := discovery.NewService(discovery.ServiceOptions{})
+svc.Start(context.Background())
+defer svc.Stop()
+
+provider, err := svc.EnsureConnected(context.Background(), "my-app")
+if err != nil {
+	panic(err)
+}
+if provider != nil {
+	fmt.Println(provider.Name)
+}
+```
+
 ## Next Steps
 
 - [Go package API](/api/go)

--- a/website/docs/src/content/docs/guides/python.md
+++ b/website/docs/src/content/docs/guides/python.md
@@ -97,6 +97,32 @@ asyncio.run(main())
 
 Unix consumer connections are available via `slop_ai.transports.unix_client.UnixClientTransport`.
 
+## Discovery layer
+
+The Python SDK also includes the core discovery layer in `slop_ai.discovery`:
+
+```python
+import asyncio
+
+from slop_ai.discovery import DiscoveryOptions, create_discovery_service
+
+
+async def main() -> None:
+    service = create_discovery_service(DiscoveryOptions())
+    await service.start()
+    try:
+        provider = await service.ensure_connected("my-app")
+        if provider is not None:
+            print(provider.name)
+    finally:
+        await service.stop()
+
+
+asyncio.run(main())
+```
+
+Install `slop-ai[websocket]` when discovery needs browser bridge support or direct WebSocket providers.
+
 ## Utilities
 
 The package also exports:

--- a/website/docs/src/content/docs/guides/rust.md
+++ b/website/docs/src/content/docs/guides/rust.md
@@ -256,6 +256,26 @@ let node = consumer.query("/todos", 1).await?;
 consumer.disconnect();
 ```
 
+## Discovery layer
+
+The Rust SDK also includes the core discovery layer in `slop_ai::discovery` under the default `native` feature set:
+
+```rust
+use slop_ai::discovery::{DiscoveryService, DiscoveryServiceOptions};
+
+#[tokio::main]
+async fn main() {
+    let service = DiscoveryService::new(DiscoveryServiceOptions::default());
+    service.start().await;
+
+    if let Ok(Some(provider)) = service.ensure_connected("my-app").await {
+        println!("{}", provider.name);
+    }
+
+    service.stop().await;
+}
+```
+
 ## Scaling
 
 Prepare trees for output with depth truncation, salience filtering, and node-budget compaction:

--- a/website/docs/src/content/docs/sdk/discovery.md
+++ b/website/docs/src/content/docs/sdk/discovery.md
@@ -40,6 +40,55 @@ Integrations (Claude Code plugin, OpenClaw plugin, VS Code extension, custom age
 
 Integrations that only need discovery + MCP (e.g. `slop-bridge` with the MCP SDK) import from the **default** export and do not need `anthropic-agent-sdk`.
 
+## Phase 1: Core Discovery Layer
+
+The current cross-SDK parity target is the **core discovery layer**. The TypeScript implementation is the behavioral reference, but other SDKs do **not** need to copy its package topology.
+
+- TypeScript reference files: `packages/typescript/integrations/discovery/src/discovery.ts`, `bridge-client.ts`, `bridge-server.ts`, `relay-transport.ts`, and `tools.ts`
+- Python target module: `slop_ai.discovery`
+- Go target package: `github.com/devteapot/slop/packages/go/slop-ai/discovery`
+- Rust target module: `slop_ai::discovery`
+
+Python, Go, and Rust keep discovery inside their existing SDK artifact. Only TypeScript publishes discovery as a separate package.
+
+### Phase 1 scope
+
+Phase 1 includes:
+
+- Local provider scanning (`~/.slop/providers/` + `/tmp/slop/providers/`)
+- Descriptor validation and pruning when descriptors disappear
+- Directory watching with periodic fallback scan
+- Bridge client
+- Bridge server
+- "Try client first, fall back to server" bridge startup
+- Relay transport for `postmessage` providers
+- Discovery service / connection orchestration
+- Lazy connect with `ensureConnected()`
+- Auto-connect mode
+- Idle timeout (5 minutes default)
+- Exponential backoff reconnection
+- Connection timeout (10 seconds)
+- State change callback
+- `formatTree()`
+- `affordancesToTools()`
+- `createToolHandlers()`
+- `createDynamicTools()`
+
+Phase 1 explicitly excludes:
+
+- Host-specific wrappers such as `cli.ts` and `anthropic-agent-sdk.ts`
+- Prompt/hook integration glue for Claude Code, Codex, OpenClaw, or other hosts
+- File-cache helpers such as `createStateCache()`
+
+### Status labels
+
+| Label | Meaning |
+|---|---|
+| `Shipped` | Implemented in the SDK artifact with the current contract |
+| `Partial` | Code exists, but only in app code or with behavior drift from the contract |
+| `Planned` | Not implemented yet |
+| `Out of scope` | Intentionally excluded from phase 1 |
+
 ## Provider Discovery
 
 ### Local providers
@@ -237,16 +286,62 @@ Consumers can use this to maintain a cache, update a UI, or trigger context inje
 
 ## SDK Implementations
 
-| Language | Consumer SDK | Discovery Layer | Status |
+| Language | Consumer SDK | Core discovery module | Current status |
 |---|---|---|---|
-| TypeScript | `@slop-ai/consumer` | `@slop-ai/discovery` | Bridge client + server, relay, auto-connect, state cache |
-| Python | `slop-ai` | — | Planned |
-| Go | `slop-ai` | `apps/cli/bridge` + `apps/cli/provider` (to be extracted) | Bridge client + server exist in CLI, not packaged as library |
-| Rust | `slop-ai` | `apps/desktop/src-tauri/src/bridge` (to be extracted) | Bridge server exists in Desktop, not packaged as library |
+| TypeScript | `@slop-ai/consumer` | `@slop-ai/discovery` | Reference implementation for phase 1, plus host-specific helpers outside the shared contract |
+| Python | `slop-ai` | `slop_ai.discovery` | Planned |
+| Go | `slop-ai` | `github.com/devteapot/slop/packages/go/slop-ai/discovery` | Initial phase-1 implementation shipped in the SDK and normalized to the shared contract |
+| Rust | `slop-ai` | `slop_ai::discovery` | Planned extraction from `apps/desktop`, then normalization to the TypeScript contract |
+
+### Phase 1 capability matrix
+
+| Capability | TypeScript | Python | Go | Rust |
+|---|---|---|---|---|
+| Local provider scanning | Shipped | Planned | Shipped | Partial |
+| Descriptor validation and pruning | Shipped | Planned | Shipped | Partial |
+| Directory watch + 15s fallback scan | Shipped | Planned | Shipped | Partial |
+| Bridge client | Shipped | Planned | Shipped | Planned |
+| Bridge server | Shipped | Planned | Shipped | Partial |
+| Client-first / server-fallback startup | Shipped | Planned | Shipped | Planned |
+| Relay transport | Shipped | Planned | Shipped | Partial |
+| Discovery service / connection orchestration | Shipped | Planned | Shipped | Partial |
+| Lazy connect + `ensureConnected()` | Shipped | Planned | Shipped | Partial |
+| Auto-connect mode | Shipped | Planned | Shipped | Planned |
+| Idle timeout | Shipped | Planned | Shipped | Planned |
+| Reconnect backoff | Shipped | Planned | Shipped | Planned |
+| Connection timeout | Shipped | Planned | Shipped | Partial |
+| State change callback | Shipped | Planned | Shipped | Partial |
+| `formatTree()` | Shipped | Shipped | Shipped | Shipped |
+| `affordancesToTools()` | Shipped | Shipped | Shipped | Shipped |
+| `createToolHandlers()` | Shipped | Planned | Shipped | Planned |
+| `createDynamicTools()` | Shipped | Planned | Shipped | Planned |
+| Host wrappers and prompt injection glue | Shipped | Out of scope | Out of scope | Out of scope |
+| State cache / shared file helpers | Shipped | Out of scope | Out of scope | Out of scope |
+
+### Known donor-code drift
+
+The Go CLI and Rust Desktop codebases are useful donor implementations, but they are **not** the behavioral contract. New SDK modules should match the TypeScript phase-1 semantics above, even when that means changing extracted code.
+
+#### Go donor drift (`apps/cli`)
+
+- `apps/cli/bridge/server.go` forwards `provider-available`, `provider-unavailable`, and `slop-relay`, but does not yet forward `relay-open` and `relay-close`
+- `apps/cli/bridge/client.go` does not maintain a reconnect loop after bridge disconnects
+- `apps/cli/main.go` tries client first, but on bind failure it disables the bridge instead of retrying as a client after a port race
+- `apps/cli/bridge/relay.go` opens the relay and returns immediately; it does not yet match the TypeScript relay handshake retry and early-message buffering behavior
+- `apps/cli/tui/discovery.go` refreshes via TUI polling instead of a reusable discovery service with directory watchers, pruning, idle timeout, and reconnect backoff
+- `apps/cli/provider/discovery.go` filters dead PIDs today; extraction should keep only behavior that is explicitly part of the shared contract
+
+#### Rust donor drift (`apps/desktop/src-tauri`)
+
+- `apps/desktop/src-tauri/src/bridge/mod.rs` is coupled to `tauri::AppHandle`, app events, and desktop registry state, so it cannot be extracted as-is into the SDK
+- `apps/desktop/src-tauri/src/provider/mod.rs` sends `relay-open` and a single `connect`, but does not yet match the TypeScript relay handshake retry and early-message buffering behavior
+- `apps/desktop/src-tauri/src/provider/discovery.rs` only scans descriptor files; it does not yet implement the full watcher, fallback-rescan, validation, and pruning behavior
+- `apps/desktop/src-tauri/src/provider/mod.rs` ingests discovered and bridge providers additively; extraction should also handle descriptor disappearance and bridge provider removal using the shared contract
+- The desktop app currently hosts a bridge server, but it does not provide a reusable bridge client or the full client-first / server-fallback startup flow
 
 ### Implementation checklist for new SDKs
 
-A complete discovery layer implementation provides:
+A complete phase-1 discovery layer implementation provides:
 
 - [ ] Local provider scanning (`~/.slop/providers/` + `/tmp/slop/providers/`)
 - [ ] Directory watching with periodic fallback scan
@@ -263,7 +358,8 @@ A complete discovery layer implementation provides:
 - [ ] Connection timeout (10 seconds)
 - [ ] State change callback
 - [ ] Dynamic tool generation (`createDynamicTools()` equivalent)
-- [ ] State injection for host context (hook or prompt prepend)
+
+Host-specific wrappers and prompt injection are intentionally outside phase 1.
 
 ## Integrations
 

--- a/website/docs/src/content/docs/sdk/discovery.md
+++ b/website/docs/src/content/docs/sdk/discovery.md
@@ -289,32 +289,32 @@ Consumers can use this to maintain a cache, update a UI, or trigger context inje
 | Language | Consumer SDK | Core discovery module | Current status |
 |---|---|---|---|
 | TypeScript | `@slop-ai/consumer` | `@slop-ai/discovery` | Reference implementation for phase 1, plus host-specific helpers outside the shared contract |
-| Python | `slop-ai` | `slop_ai.discovery` | Planned |
+| Python | `slop-ai` | `slop_ai.discovery` | Initial phase-1 implementation shipped in the SDK and normalized to the shared contract |
 | Go | `slop-ai` | `github.com/devteapot/slop/packages/go/slop-ai/discovery` | Initial phase-1 implementation shipped in the SDK and normalized to the shared contract |
-| Rust | `slop-ai` | `slop_ai::discovery` | Planned extraction from `apps/desktop`, then normalization to the TypeScript contract |
+| Rust | `slop-ai` | `slop_ai::discovery` | Initial phase-1 implementation shipped in the SDK and normalized to the shared contract |
 
 ### Phase 1 capability matrix
 
 | Capability | TypeScript | Python | Go | Rust |
 |---|---|---|---|---|
-| Local provider scanning | Shipped | Planned | Shipped | Partial |
-| Descriptor validation and pruning | Shipped | Planned | Shipped | Partial |
-| Directory watch + 15s fallback scan | Shipped | Planned | Shipped | Partial |
-| Bridge client | Shipped | Planned | Shipped | Planned |
-| Bridge server | Shipped | Planned | Shipped | Partial |
-| Client-first / server-fallback startup | Shipped | Planned | Shipped | Planned |
-| Relay transport | Shipped | Planned | Shipped | Partial |
-| Discovery service / connection orchestration | Shipped | Planned | Shipped | Partial |
-| Lazy connect + `ensureConnected()` | Shipped | Planned | Shipped | Partial |
-| Auto-connect mode | Shipped | Planned | Shipped | Planned |
-| Idle timeout | Shipped | Planned | Shipped | Planned |
-| Reconnect backoff | Shipped | Planned | Shipped | Planned |
-| Connection timeout | Shipped | Planned | Shipped | Partial |
-| State change callback | Shipped | Planned | Shipped | Partial |
+| Local provider scanning | Shipped | Shipped | Shipped | Shipped |
+| Descriptor validation and pruning | Shipped | Shipped | Shipped | Shipped |
+| Directory watch + 15s fallback scan | Shipped | Shipped | Shipped | Shipped |
+| Bridge client | Shipped | Shipped | Shipped | Shipped |
+| Bridge server | Shipped | Shipped | Shipped | Shipped |
+| Client-first / server-fallback startup | Shipped | Shipped | Shipped | Shipped |
+| Relay transport | Shipped | Shipped | Shipped | Shipped |
+| Discovery service / connection orchestration | Shipped | Shipped | Shipped | Shipped |
+| Lazy connect + `ensureConnected()` | Shipped | Shipped | Shipped | Shipped |
+| Auto-connect mode | Shipped | Shipped | Shipped | Shipped |
+| Idle timeout | Shipped | Shipped | Shipped | Shipped |
+| Reconnect backoff | Shipped | Shipped | Shipped | Shipped |
+| Connection timeout | Shipped | Shipped | Shipped | Shipped |
+| State change callback | Shipped | Shipped | Shipped | Shipped |
 | `formatTree()` | Shipped | Shipped | Shipped | Shipped |
 | `affordancesToTools()` | Shipped | Shipped | Shipped | Shipped |
-| `createToolHandlers()` | Shipped | Planned | Shipped | Planned |
-| `createDynamicTools()` | Shipped | Planned | Shipped | Planned |
+| `createToolHandlers()` | Shipped | Shipped | Shipped | Shipped |
+| `createDynamicTools()` | Shipped | Shipped | Shipped | Shipped |
 | Host wrappers and prompt injection glue | Shipped | Out of scope | Out of scope | Out of scope |
 | State cache / shared file helpers | Shipped | Out of scope | Out of scope | Out of scope |
 


### PR DESCRIPTION
## Summary
- add the phase-1 core discovery layer to the Go, Python, and Rust SDKs, including bridge, relay, lazy/auto-connect, tool helpers, and focused package-local tests
- harden the TypeScript discovery runtime, add package-local Bun coverage for discovery behavior, and remove the deprecated logger-only constructor overloads
- document the shared discovery parity contract across SDKs, update language guides/READMEs, and check in the repository `AGENTS.md` guide

## Validation
- `cd packages/go/slop-ai && go test ./...`
- `cd packages/python/slop-ai && .venv/bin/python -m pytest tests`
- `cd packages/rust/slop-ai && cargo test`
- `cd packages/typescript/integrations/discovery && bun test`
- `cd packages/typescript/integrations/discovery && bun run build`
- `cd website/docs && bun run generate:content && bun run check:content`
- `cd /Users/carlid/dev/slop-slop-slop && bun run test`