### PR TITLE
Adopt Biome formatting for the TypeScript codebase

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -8,6 +8,21 @@ permissions:
   contents: read
 
 jobs:
+  biome-format:
+    name: Biome Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install workspace dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Check TypeScript formatting
+        run: bun run format:check
+
   typescript-packages:
     name: TypeScript Packages
     runs-on: ubuntu-latest

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -12,14 +12,17 @@ export function App() {
   const [treeOpen, setTreeOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
 
-  const initialized = useAppStore(s => s.initialized);
-  const activeWorkspaceId = useAppStore(s => s.activeWorkspaceId);
+  const initialized = useAppStore((s) => s.initialized);
+  const activeWorkspaceId = useAppStore((s) => s.activeWorkspaceId);
 
   useEffect(() => {
-    useAppStore.getState().init().then(() => {
-      const wsId = useAppStore.getState().activeWorkspaceId;
-      useChatStore.getState().init(wsId);
-    });
+    useAppStore
+      .getState()
+      .init()
+      .then(() => {
+        const wsId = useAppStore.getState().activeWorkspaceId;
+        useChatStore.getState().init(wsId);
+      });
     return () => {
       useAppStore.getState().destroy();
       useChatStore.getState().destroy();
@@ -36,9 +39,7 @@ export function App() {
   if (!initialized) {
     return (
       <div className="app" style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
-        <span style={{ color: "#6e7681", fontFamily: "JetBrains Mono, monospace", fontSize: "12px" }}>
-          Loading...
-        </span>
+        <span style={{ color: "#6e7681", fontFamily: "JetBrains Mono, monospace", fontSize: "12px" }}>Loading...</span>
       </div>
     );
   }

--- a/apps/desktop/src/components/ChatPanel.tsx
+++ b/apps/desktop/src/components/ChatPanel.tsx
@@ -5,16 +5,16 @@ import { useChatStore } from "../stores/chat-store";
 const EMPTY_MESSAGES: never[] = [];
 
 export function ChatPanel() {
-  const activeWorkspaceId = useAppStore(s => s.activeWorkspaceId);
-  const providers = useAppStore(s => s.providers);
+  const activeWorkspaceId = useAppStore((s) => s.activeWorkspaceId);
+  const providers = useAppStore((s) => s.providers);
 
-  const rawMessages = useChatStore(s => s.messages[activeWorkspaceId]);
+  const rawMessages = useChatStore((s) => s.messages[activeWorkspaceId]);
   const messages = rawMessages ?? EMPTY_MESSAGES;
-  const processing = useChatStore(s => !!s.processing[activeWorkspaceId]);
-  const sendMessage = useChatStore(s => s.sendMessage);
-  const clearChat = useChatStore(s => s.clearChat);
+  const processing = useChatStore((s) => !!s.processing[activeWorkspaceId]);
+  const sendMessage = useChatStore((s) => s.sendMessage);
+  const clearChat = useChatStore((s) => s.clearChat);
 
-  const connectedCount = providers.filter(p => p.status === "connected").length;
+  const connectedCount = providers.filter((p) => p.status === "connected").length;
   const connected = connectedCount > 0;
 
   const [text, setText] = useState("");
@@ -60,14 +60,12 @@ export function ChatPanel() {
         </div>
       ) : (
         <div className="chat-messages">
-          {messages.map(msg => (
+          {messages.map((msg) => (
             <div key={msg.id} className={`msg ${msg.role}`}>
               {msg.content}
             </div>
           ))}
-          {processing && (
-            <div className="msg tool-progress">Thinking...</div>
-          )}
+          {processing && <div className="msg tool-progress">Thinking...</div>}
           <div ref={messagesEndRef} />
         </div>
       )}
@@ -76,8 +74,8 @@ export function ChatPanel() {
           ref={inputRef}
           placeholder={connected ? "Ask about the app..." : "Connect to a provider first"}
           value={text}
-          onChange={e => setText(e.target.value)}
-          onKeyDown={e => {
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={(e) => {
             if (e.key === "Enter" && !e.shiftKey) {
               e.preventDefault();
               handleSubmit(e);
@@ -86,7 +84,9 @@ export function ChatPanel() {
           disabled={!connected || processing}
           rows={1}
         />
-        <button type="submit" disabled={!canSend}>Send</button>
+        <button type="submit" disabled={!canSend}>
+          Send
+        </button>
       </form>
     </div>
   );

--- a/apps/desktop/src/components/Settings.tsx
+++ b/apps/desktop/src/components/Settings.tsx
@@ -21,12 +21,12 @@ const DEFAULT_ENDPOINTS: Record<string, string> = {
 };
 
 export function Settings({ onClose }: SettingsProps) {
-  const profiles = useAppStore(s => s.profiles);
-  const activeProfileId = useAppStore(s => s.activeProfileId);
-  const addProfile = useAppStore(s => s.addProfile);
-  const updateProfile = useAppStore(s => s.updateProfile);
-  const deleteProfile = useAppStore(s => s.deleteProfile);
-  const setActiveProfile = useAppStore(s => s.setActiveProfile);
+  const profiles = useAppStore((s) => s.profiles);
+  const activeProfileId = useAppStore((s) => s.activeProfileId);
+  const addProfile = useAppStore((s) => s.addProfile);
+  const updateProfile = useAppStore((s) => s.updateProfile);
+  const deleteProfile = useAppStore((s) => s.deleteProfile);
+  const setActiveProfile = useAppStore((s) => s.setActiveProfile);
 
   const [editing, setEditing] = useState<LlmProfile | null>(null);
   const [isNew, setIsNew] = useState(false);
@@ -74,7 +74,7 @@ export function Settings({ onClose }: SettingsProps) {
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal" onClick={e => e.stopPropagation()}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <span>LLM Profiles</span>
           <button onClick={onClose}>&times;</button>
@@ -84,11 +84,8 @@ export function Settings({ onClose }: SettingsProps) {
             + New Profile
           </button>
 
-          {profiles.map(p => (
-            <div
-              key={p.id}
-              className={`profile-list-item${p.id === activeProfileId ? " active" : ""}`}
-            >
+          {profiles.map((p) => (
+            <div key={p.id} className={`profile-list-item${p.id === activeProfileId ? " active" : ""}`}>
               <div className="info">
                 <div className="name">
                   {p.name} {p.id === activeProfileId && "(active)"}
@@ -97,12 +94,12 @@ export function Settings({ onClose }: SettingsProps) {
                   {p.provider} &middot; {p.model || "no model"} &middot; {p.endpoint}
                 </div>
               </div>
-              {p.id !== activeProfileId && (
-                <button onClick={() => setActiveProfile(p.id)}>Use</button>
-              )}
+              {p.id !== activeProfileId && <button onClick={() => setActiveProfile(p.id)}>Use</button>}
               <button onClick={() => startEdit(p)}>Edit</button>
               {profiles.length > 1 && (
-                <button className="danger" onClick={() => deleteProfile(p.id)}>Del</button>
+                <button className="danger" onClick={() => deleteProfile(p.id)}>
+                  Del
+                </button>
               )}
             </div>
           ))}
@@ -112,24 +109,23 @@ export function Settings({ onClose }: SettingsProps) {
               <label>Name</label>
               <input
                 value={editing.name}
-                onChange={e => setEditing({ ...editing, name: e.target.value })}
+                onChange={(e) => setEditing({ ...editing, name: e.target.value })}
                 placeholder="My Profile"
               />
 
               <label>Provider</label>
-              <select
-                value={editing.provider}
-                onChange={e => handleProviderChange(e.target.value)}
-              >
-                {PROVIDERS.map(p => (
-                  <option key={p.value} value={p.value}>{p.label}</option>
+              <select value={editing.provider} onChange={(e) => handleProviderChange(e.target.value)}>
+                {PROVIDERS.map((p) => (
+                  <option key={p.value} value={p.value}>
+                    {p.label}
+                  </option>
                 ))}
               </select>
 
               <label>Endpoint</label>
               <input
                 value={editing.endpoint}
-                onChange={e => setEditing({ ...editing, endpoint: e.target.value })}
+                onChange={(e) => setEditing({ ...editing, endpoint: e.target.value })}
                 placeholder={DEFAULT_ENDPOINTS[editing.provider]}
               />
 
@@ -139,7 +135,7 @@ export function Settings({ onClose }: SettingsProps) {
                   <input
                     type="password"
                     value={editing.api_key}
-                    onChange={e => setEditing({ ...editing, api_key: e.target.value })}
+                    onChange={(e) => setEditing({ ...editing, api_key: e.target.value })}
                     placeholder="sk-..."
                   />
                 </>
@@ -148,13 +144,17 @@ export function Settings({ onClose }: SettingsProps) {
               <label>Default Model</label>
               <input
                 value={editing.model}
-                onChange={e => setEditing({ ...editing, model: e.target.value })}
+                onChange={(e) => setEditing({ ...editing, model: e.target.value })}
                 placeholder={editing.provider === "ollama" ? "qwen2.5:14b" : "gpt-4o"}
               />
 
               <div className="actions">
-                <button className="btn-secondary" onClick={() => setEditing(null)}>Cancel</button>
-                <button className="btn-primary" onClick={handleSave}>Save</button>
+                <button className="btn-secondary" onClick={() => setEditing(null)}>
+                  Cancel
+                </button>
+                <button className="btn-primary" onClick={handleSave}>
+                  Save
+                </button>
               </div>
             </div>
           )}

--- a/apps/desktop/src/components/Sidebar.tsx
+++ b/apps/desktop/src/components/Sidebar.tsx
@@ -4,26 +4,29 @@ import type { ProviderSummary } from "../lib/types";
 
 function transportLabel(p: ProviderSummary): string {
   switch (p.transport_type) {
-    case "unix": return "sock";
-    case "relay": return "pm";
-    default: return "ws";
+    case "unix":
+      return "sock";
+    case "relay":
+      return "pm";
+    default:
+      return "ws";
   }
 }
 
 export function Sidebar() {
-  const providers = useAppStore(s => s.providers);
-  const workspaces = useAppStore(s => s.workspaces);
-  const activeWorkspaceId = useAppStore(s => s.activeWorkspaceId);
-  const bridgeConnected = useAppStore(s => s.bridgeConnected);
-  const connectProvider = useAppStore(s => s.connectProvider);
-  const disconnectProvider = useAppStore(s => s.disconnectProvider);
-  const addManualProvider = useAppStore(s => s.addManualProvider);
-  const removeProvider = useAppStore(s => s.removeProvider);
+  const providers = useAppStore((s) => s.providers);
+  const workspaces = useAppStore((s) => s.workspaces);
+  const activeWorkspaceId = useAppStore((s) => s.activeWorkspaceId);
+  const bridgeConnected = useAppStore((s) => s.bridgeConnected);
+  const connectProvider = useAppStore((s) => s.connectProvider);
+  const disconnectProvider = useAppStore((s) => s.disconnectProvider);
+  const addManualProvider = useAppStore((s) => s.addManualProvider);
+  const removeProvider = useAppStore((s) => s.removeProvider);
 
   const [url, setUrl] = useState("");
   const [browserCollapsed, setBrowserCollapsed] = useState(false);
 
-  const activeWorkspace = workspaces.find(w => w.id === activeWorkspaceId);
+  const activeWorkspace = workspaces.find((w) => w.id === activeWorkspaceId);
   const workspaceProviderIds = useMemo(
     () => new Set(activeWorkspace?.provider_ids ?? []),
     [activeWorkspace?.provider_ids],
@@ -37,18 +40,9 @@ export function Sidebar() {
     return p.status;
   }
 
-  const localEntries = useMemo(
-    () => providers.filter(p => p.source === "discovered"),
-    [providers],
-  );
-  const browserEntries = useMemo(
-    () => providers.filter(p => p.source === "bridge"),
-    [providers],
-  );
-  const manualEntries = useMemo(
-    () => providers.filter(p => p.source === "manual"),
-    [providers],
-  );
+  const localEntries = useMemo(() => providers.filter((p) => p.source === "discovered"), [providers]);
+  const browserEntries = useMemo(() => providers.filter((p) => p.source === "bridge"), [providers]);
+  const manualEntries = useMemo(() => providers.filter((p) => p.source === "manual"), [providers]);
 
   function handleAdd(e: React.FormEvent) {
     e.preventDefault();
@@ -90,17 +84,16 @@ export function Sidebar() {
             <button
               className="remove-btn"
               title="Disconnect"
-              onClick={(e) => { e.stopPropagation(); disconnectProvider(p.id); }}
+              onClick={(e) => {
+                e.stopPropagation();
+                disconnectProvider(p.id);
+              }}
             >
               &#x23FB;
             </button>
           )}
           {p.source === "manual" && status === "disconnected" && (
-            <button
-              className="remove-btn"
-              title="Remove"
-              onClick={(e) => handleRemove(e, p.id)}
-            >
+            <button className="remove-btn" title="Remove" onClick={(e) => handleRemove(e, p.id)}>
               &times;
             </button>
           )}
@@ -133,9 +126,7 @@ export function Sidebar() {
         {localEntries.length > 0 && (
           <div className="sidebar-group">
             <div className="sidebar-group-header">Local Apps</div>
-            <div className="sidebar-group-content">
-              {localEntries.map(renderItem)}
-            </div>
+            <div className="sidebar-group-content">{localEntries.map(renderItem)}</div>
           </div>
         )}
 
@@ -143,24 +134,20 @@ export function Sidebar() {
           <div className={`sidebar-group${browserCollapsed ? " collapsed" : ""}`}>
             <div
               className="sidebar-group-header"
-              onClick={() => setBrowserCollapsed(c => !c)}
+              onClick={() => setBrowserCollapsed((c) => !c)}
               style={{ cursor: "pointer" }}
             >
               <span>{browserCollapsed ? "\u25B8" : "\u25BE"} Browser Tabs</span>
               <span className="badge">{browserEntries.length}</span>
             </div>
-            <div className="sidebar-group-content">
-              {browserEntries.map(renderItem)}
-            </div>
+            <div className="sidebar-group-content">{browserEntries.map(renderItem)}</div>
           </div>
         )}
 
         {manualEntries.length > 0 && (
           <div className="sidebar-group">
             <div className="sidebar-group-header">Manual</div>
-            <div className="sidebar-group-content">
-              {manualEntries.map(renderItem)}
-            </div>
+            <div className="sidebar-group-content">{manualEntries.map(renderItem)}</div>
           </div>
         )}
       </div>
@@ -171,7 +158,7 @@ export function Sidebar() {
             type="text"
             placeholder="ws://... or /tmp/slop/..."
             value={url}
-            onChange={e => setUrl(e.target.value)}
+            onChange={(e) => setUrl(e.target.value)}
           />
           <button type="submit">Add</button>
         </form>

--- a/apps/desktop/src/components/StateTree.tsx
+++ b/apps/desktop/src/components/StateTree.tsx
@@ -36,12 +36,12 @@ function formatNode(node: SlopNode, indent: number = 0): string {
 }
 
 export function StateTree() {
-  const providerTrees = useAppStore(s => s.providerTrees);
-  const providers = useAppStore(s => s.providers);
+  const providerTrees = useAppStore((s) => s.providerTrees);
+  const providers = useAppStore((s) => s.providers);
 
-  const connected = providers.filter(p => p.status === "connected");
+  const connected = providers.filter((p) => p.status === "connected");
   const treePairs = connected
-    .map(p => ({ provider: p, tree: providerTrees[p.id] }))
+    .map((p) => ({ provider: p, tree: providerTrees[p.id] }))
     .filter((x): x is { provider: typeof x.provider; tree: SlopNode } => !!x.tree);
 
   const totalAffordances = treePairs.reduce((sum, { tree }) => {

--- a/apps/desktop/src/components/TopBar.tsx
+++ b/apps/desktop/src/components/TopBar.tsx
@@ -8,26 +8,26 @@ interface TopBarProps {
 }
 
 export function TopBar({ treeOpen, onToggleTree, onOpenSettings }: TopBarProps) {
-  const workspaces = useAppStore(s => s.workspaces);
-  const activeWorkspaceId = useAppStore(s => s.activeWorkspaceId);
-  const profiles = useAppStore(s => s.profiles);
-  const activeProfileId = useAppStore(s => s.activeProfileId);
-  const models = useAppStore(s => s.models);
-  const modelsLoading = useAppStore(s => s.modelsLoading);
+  const workspaces = useAppStore((s) => s.workspaces);
+  const activeWorkspaceId = useAppStore((s) => s.activeWorkspaceId);
+  const profiles = useAppStore((s) => s.profiles);
+  const activeProfileId = useAppStore((s) => s.activeProfileId);
+  const models = useAppStore((s) => s.models);
+  const modelsLoading = useAppStore((s) => s.modelsLoading);
 
-  const createWorkspace = useAppStore(s => s.createWorkspace);
-  const renameWorkspace = useAppStore(s => s.renameWorkspace);
-  const deleteWorkspace = useAppStore(s => s.deleteWorkspace);
-  const setActiveWorkspace = useAppStore(s => s.setActiveWorkspace);
-  const setActiveProfile = useAppStore(s => s.setActiveProfile);
-  const setModel = useAppStore(s => s.setModel);
-  const fetchModels = useAppStore(s => s.fetchModels);
+  const createWorkspace = useAppStore((s) => s.createWorkspace);
+  const renameWorkspace = useAppStore((s) => s.renameWorkspace);
+  const deleteWorkspace = useAppStore((s) => s.deleteWorkspace);
+  const setActiveWorkspace = useAppStore((s) => s.setActiveWorkspace);
+  const setActiveProfile = useAppStore((s) => s.setActiveProfile);
+  const setModel = useAppStore((s) => s.setModel);
+  const fetchModels = useAppStore((s) => s.fetchModels);
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editName, setEditName] = useState("");
   const editRef = useRef<HTMLInputElement>(null);
 
-  const activeProfile = profiles.find(p => p.id === activeProfileId) ?? profiles[0];
+  const activeProfile = profiles.find((p) => p.id === activeProfileId) ?? profiles[0];
 
   useEffect(() => {
     fetchModels();
@@ -60,12 +60,15 @@ export function TopBar({ treeOpen, onToggleTree, onOpenSettings }: TopBarProps) 
   return (
     <>
       <div className="workspace-bar">
-        {workspaces.map(ws => (
+        {workspaces.map((ws) => (
           <div
             key={ws.id}
             className={`workspace-tab${ws.id === activeWorkspaceId ? " active" : ""}`}
             onClick={() => setActiveWorkspace(ws.id)}
-            onContextMenu={e => { e.preventDefault(); startRename(ws.id, ws.name); }}
+            onContextMenu={(e) => {
+              e.preventDefault();
+              startRename(ws.id, ws.name);
+            }}
             onDoubleClick={() => startRename(ws.id, ws.name)}
           >
             {editingId === ws.id ? (
@@ -73,11 +76,14 @@ export function TopBar({ treeOpen, onToggleTree, onOpenSettings }: TopBarProps) 
                 ref={editRef}
                 className="workspace-tab-edit"
                 value={editName}
-                onChange={e => setEditName(e.target.value)}
+                onChange={(e) => setEditName(e.target.value)}
                 onBlur={commitRename}
-                onKeyDown={e => {
+                onKeyDown={(e) => {
                   if (e.key === "Enter") commitRename();
-                  if (e.key === "Escape") { setEditingId(null); setEditName(""); }
+                  if (e.key === "Escape") {
+                    setEditingId(null);
+                    setEditName("");
+                  }
                 }}
               />
             ) : (
@@ -86,47 +92,48 @@ export function TopBar({ treeOpen, onToggleTree, onOpenSettings }: TopBarProps) 
             {workspaces.length > 1 && (
               <button
                 className="close"
-                onClick={e => { e.stopPropagation(); deleteWorkspace(ws.id); }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  deleteWorkspace(ws.id);
+                }}
               >
                 ×
               </button>
             )}
           </div>
         ))}
-        <button className="workspace-add" onClick={handleAddWorkspace}>+</button>
+        <button className="workspace-add" onClick={handleAddWorkspace}>
+          +
+        </button>
       </div>
 
       <div className="top-bar">
         <span className="title">SLOP Desktop</span>
 
-        <select
-          value={activeProfileId}
-          onChange={e => setActiveProfile(e.target.value)}
-        >
-          {profiles.map(p => (
-            <option key={p.id} value={p.id}>{p.name}</option>
+        <select value={activeProfileId} onChange={(e) => setActiveProfile(e.target.value)}>
+          {profiles.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
           ))}
         </select>
 
-        <select
-          value={activeProfile?.model ?? ""}
-          onChange={e => setModel(e.target.value)}
-        >
+        <select value={activeProfile?.model ?? ""} onChange={(e) => setModel(e.target.value)}>
           {modelsLoading && <option value="">Loading models...</option>}
           {!modelsLoading && models.length === 0 && (
             <option value={activeProfile?.model ?? ""}>{activeProfile?.model || "No models"}</option>
           )}
-          {models.map(m => (
-            <option key={m} value={m}>{m}</option>
+          {models.map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
           ))}
           {!modelsLoading && activeProfile?.model && !models.includes(activeProfile.model) && (
             <option value={activeProfile.model}>{activeProfile.model}</option>
           )}
         </select>
 
-        <button onClick={onToggleTree}>
-          {treeOpen ? "Hide Tree" : "Show Tree"}
-        </button>
+        <button onClick={onToggleTree}>{treeOpen ? "Hide Tree" : "Show Tree"}</button>
 
         <button onClick={onOpenSettings}>Settings</button>
       </div>

--- a/apps/desktop/src/lib/commands.ts
+++ b/apps/desktop/src/lib/commands.ts
@@ -1,31 +1,20 @@
 import { invoke } from "@tauri-apps/api/core";
-import type {
-  WorkspaceSummary,
-  WorkspaceDetail,
-  ProviderSummary,
-  ProviderConnectResult,
-  LlmProfile,
-} from "./types";
+import type { WorkspaceSummary, WorkspaceDetail, ProviderSummary, ProviderConnectResult, LlmProfile } from "./types";
 
 // Workspace commands
 export const listWorkspaces = () => invoke<WorkspaceSummary[]>("list_workspaces");
-export const getWorkspace = (workspaceId: string) =>
-  invoke<WorkspaceDetail>("get_workspace", { workspaceId });
-export const createWorkspace = (name: string) =>
-  invoke<WorkspaceSummary>("create_workspace", { name });
+export const getWorkspace = (workspaceId: string) => invoke<WorkspaceDetail>("get_workspace", { workspaceId });
+export const createWorkspace = (name: string) => invoke<WorkspaceSummary>("create_workspace", { name });
 export const renameWorkspace = (workspaceId: string, name: string) =>
   invoke<void>("rename_workspace", { workspaceId, name });
-export const deleteWorkspace = (workspaceId: string) =>
-  invoke<void>("delete_workspace", { workspaceId });
-export const setActiveWorkspace = (workspaceId: string) =>
-  invoke<void>("set_active_workspace", { workspaceId });
+export const deleteWorkspace = (workspaceId: string) => invoke<void>("delete_workspace", { workspaceId });
+export const setActiveWorkspace = (workspaceId: string) => invoke<void>("set_active_workspace", { workspaceId });
 
 // Provider commands
 export const listProviders = () => invoke<ProviderSummary[]>("list_providers");
 export const addManualProvider = (url: string, name?: string) =>
   invoke<ProviderSummary>("add_manual_provider", { url, name });
-export const removeProvider = (providerId: string) =>
-  invoke<void>("remove_provider", { providerId });
+export const removeProvider = (providerId: string) => invoke<void>("remove_provider", { providerId });
 export const connectProvider = (providerId: string, workspaceId: string) =>
   invoke<void>("connect_provider", { providerId, workspaceId });
 export const disconnectProvider = (providerId: string, workspaceId: string) =>
@@ -33,26 +22,19 @@ export const disconnectProvider = (providerId: string, workspaceId: string) =>
 export const refreshDiscovery = () => invoke<ProviderSummary[]>("refresh_discovery");
 
 // Chat commands
-export const sendMessage = (workspaceId: string, text: string) =>
-  invoke<void>("send_message", { workspaceId, text });
-export const clearChat = (workspaceId: string) =>
-  invoke<void>("clear_chat", { workspaceId });
+export const sendMessage = (workspaceId: string, text: string) => invoke<void>("send_message", { workspaceId, text });
+export const clearChat = (workspaceId: string) => invoke<void>("clear_chat", { workspaceId });
 
 // LLM profile commands
 export const listProfiles = () => invoke<LlmProfile[]>("list_profiles");
 export const getActiveProfile = () => invoke<LlmProfile>("get_active_profile");
-export const addProfile = (profile: LlmProfile) =>
-  invoke<void>("add_profile", { profile });
+export const addProfile = (profile: LlmProfile) => invoke<void>("add_profile", { profile });
 export const updateProfile = (id: string, updates: Partial<LlmProfile>) =>
   invoke<void>("update_profile", { id, updates });
-export const deleteProfile = (id: string) =>
-  invoke<void>("delete_profile", { id });
-export const setActiveProfile = (id: string) =>
-  invoke<void>("set_active_profile", { id });
-export const setModel = (model: string) =>
-  invoke<void>("set_model", { model });
+export const deleteProfile = (id: string) => invoke<void>("delete_profile", { id });
+export const setActiveProfile = (id: string) => invoke<void>("set_active_profile", { id });
+export const setModel = (model: string) => invoke<void>("set_model", { model });
 export const fetchModels = () => invoke<string[]>("fetch_models");
 
 // Bridge commands
-export const bridgeSend = (message: unknown) =>
-  invoke<void>("bridge_send", { message });
+export const bridgeSend = (message: unknown) => invoke<void>("bridge_send", { message });

--- a/apps/desktop/src/stores/app-store.ts
+++ b/apps/desktop/src/stores/app-store.ts
@@ -1,10 +1,5 @@
 import { create } from "zustand";
-import type {
-  WorkspaceSummary,
-  ProviderSummary,
-  LlmProfile,
-  SlopNode,
-} from "../lib/types";
+import type { WorkspaceSummary, ProviderSummary, LlmProfile, SlopNode } from "../lib/types";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import * as commands from "../lib/commands";
 import { setupEvents, cleanup } from "../lib/events";
@@ -105,7 +100,7 @@ export const useAppStore = create<AppState>((set, get) => ({
                   status: payload.status,
                   provider_name: payload.provider_name ?? p.provider_name,
                 }
-              : p
+              : p,
           );
           let providerTrees = state.providerTrees;
           if (payload.tree) {
@@ -154,7 +149,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     // workspaces-changed event will update the list + active
     const state = get();
     if (state.activeWorkspaceId === id) {
-      const remaining = state.workspaces.filter(w => w.id !== id);
+      const remaining = state.workspaces.filter((w) => w.id !== id);
       set({ activeWorkspaceId: remaining[0]?.id ?? "" });
     }
   },

--- a/apps/extension/src/background/bridge-client.ts
+++ b/apps/extension/src/background/bridge-client.ts
@@ -100,9 +100,7 @@ export async function start(): Promise<void> {
 
   chrome.storage.onChanged.addListener((changes, area) => {
     if (area === "local" && changes.prefs) {
-      const newPrefs = isExtensionPrefsPatch(changes.prefs.newValue)
-        ? changes.prefs.newValue
-        : undefined;
+      const newPrefs = isExtensionPrefsPatch(changes.prefs.newValue) ? changes.prefs.newValue : undefined;
       const shouldBeEnabled = (newPrefs?.active ?? true) && (newPrefs?.bridgeEnabled ?? false);
       if (shouldBeEnabled && !enabled) {
         enabled = true;

--- a/apps/extension/src/background/chat-engine.ts
+++ b/apps/extension/src/background/chat-engine.ts
@@ -75,7 +75,7 @@ export async function runTurn(
         const params = tc.function.arguments ? JSON.parse(tc.function.arguments) : {};
 
         // For grouped tools (path is null), extract target from params
-        const invokePath = path ?? params.target as string | undefined;
+        const invokePath = path ?? (params.target as string | undefined);
         if (!invokePath) {
           conversation.push({
             role: "tool",
@@ -102,11 +102,12 @@ export async function runTurn(
 
         try {
           const result = await entry.consumer.invoke(invokePath, action, params);
-          await new Promise(r => setTimeout(r, 150));
+          await new Promise((r) => setTimeout(r, 150));
 
-          const resultStr = result.status === "ok"
-            ? `OK${result.data ? ": " + JSON.stringify(result.data) : ""}`
-            : `Error [${result.error?.code}]: ${result.error?.message}`;
+          const resultStr =
+            result.status === "ok"
+              ? `OK${result.data ? ": " + JSON.stringify(result.data) : ""}`
+              : `Error [${result.error?.code}]: ${result.error?.message}`;
 
           conversation.push({ role: "tool", content: resultStr, tool_call_id: tc.id });
         } catch (err: unknown) {

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -78,7 +78,6 @@ chrome.runtime.onConnect.addListener((port) => {
         await setActiveModel(msg.model);
         port.postMessage({ type: "models", models: [], active: msg.model });
         break;
-
     }
   };
 
@@ -105,7 +104,5 @@ bridge.onMessage((msg) => tabRegistry.handleBridgeMessage(msg));
 bridge.onConnect(() => tabRegistry.reannounceAll());
 
 function isPortMessageFromContent(value: unknown): value is PortMessageFromContent {
-  return !!value
-    && typeof value === "object"
-    && typeof (value as { type?: unknown }).type === "string";
+  return !!value && typeof value === "object" && typeof (value as { type?: unknown }).type === "string";
 }

--- a/apps/extension/src/background/llm/gemini.ts
+++ b/apps/extension/src/background/llm/gemini.ts
@@ -87,9 +87,7 @@ function parseArguments(raw: string | undefined): Record<string, unknown> {
   if (!raw) return {};
   try {
     const parsed = JSON.parse(raw);
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? parsed as Record<string, unknown>
-      : {};
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
   } catch {
     return {};
   }
@@ -98,7 +96,7 @@ function parseArguments(raw: string | undefined): Record<string, unknown> {
 export async function geminiChatCompletion(
   profile: LlmProfile,
   messages: ChatMessage[],
-  tools: LlmTool[]
+  tools: LlmTool[],
 ): Promise<ChatMessage> {
   const baseUrl = profile.endpoint || "https://generativelanguage.googleapis.com";
   const url = `${baseUrl}/v1beta/models/${profile.model}:generateContent?key=${profile.apiKey}`;
@@ -215,8 +213,7 @@ export async function geminiChatCompletion(
     .filter((part): part is { text: string } => typeof part.text === "string")
     .map((part) => part.text);
   const functionCalls = parts.filter(
-    (part): part is { functionCall: { name: string; args?: Record<string, unknown> } } =>
-      !!part.functionCall,
+    (part): part is { functionCall: { name: string; args?: Record<string, unknown> } } => !!part.functionCall,
   );
 
   const result: ChatMessage = {
@@ -236,8 +233,10 @@ export async function geminiChatCompletion(
         const responseSorted = geminiName.split("_").filter(Boolean).sort();
         for (const [gname, original] of geminiToName) {
           const candidateSorted = gname.split("_").filter(Boolean).sort();
-          if (candidateSorted.length === responseSorted.length &&
-              candidateSorted.every((s, i) => s === responseSorted[i])) {
+          if (
+            candidateSorted.length === responseSorted.length &&
+            candidateSorted.every((s, i) => s === responseSorted[i])
+          ) {
             originalName = original;
             break;
           }
@@ -251,13 +250,13 @@ export async function geminiChatCompletion(
 
       return {
         id: originalName,
-          type: "function" as const,
-          function: {
-            name: originalName,
-            arguments: JSON.stringify(fc.functionCall.args ?? {}),
-          },
-        };
-      });
+        type: "function" as const,
+        function: {
+          name: originalName,
+          arguments: JSON.stringify(fc.functionCall.args ?? {}),
+        },
+      };
+    });
   }
 
   return result;

--- a/apps/extension/src/background/llm/index.ts
+++ b/apps/extension/src/background/llm/index.ts
@@ -4,10 +4,7 @@ import { getStorage } from "./storage";
 import { openaiChatCompletion } from "./openai";
 import { geminiChatCompletion } from "./gemini";
 
-export async function chatCompletion(
-  messages: ChatMessage[],
-  tools: LlmTool[]
-): Promise<ChatMessage> {
+export async function chatCompletion(messages: ChatMessage[], tools: LlmTool[]): Promise<ChatMessage> {
   const storage = await getStorage();
   const profile = getActiveProfile(storage);
 

--- a/apps/extension/src/background/llm/models.ts
+++ b/apps/extension/src/background/llm/models.ts
@@ -1,11 +1,7 @@
 import type { LlmProfile } from "../../types";
 import { getActiveProfile } from "../../types";
 import { getStorage } from "./storage";
-import {
-  parseGeminiModelNames,
-  parseOllamaModelNames,
-  parseOpenAIModelNames,
-} from "./parsers";
+import { parseGeminiModelNames, parseOllamaModelNames, parseOpenAIModelNames } from "./parsers";
 
 export async function fetchModels(): Promise<string[]> {
   const storage = await getStorage();

--- a/apps/extension/src/background/llm/openai.ts
+++ b/apps/extension/src/background/llm/openai.ts
@@ -5,11 +5,9 @@ import { parseChatMessage } from "./parsers";
 export async function openaiChatCompletion(
   profile: LlmProfile,
   messages: ChatMessage[],
-  tools: LlmTool[]
+  tools: LlmTool[],
 ): Promise<ChatMessage> {
-  const endpoint = profile.llmProvider === "openrouter"
-    ? "https://openrouter.ai/api"
-    : profile.endpoint;
+  const endpoint = profile.llmProvider === "openrouter" ? "https://openrouter.ai/api" : profile.endpoint;
   const url = `${endpoint}/v1/chat/completions`;
 
   const headers: Record<string, string> = { "Content-Type": "application/json" };

--- a/apps/extension/src/background/llm/parsers.ts
+++ b/apps/extension/src/background/llm/parsers.ts
@@ -51,8 +51,7 @@ export function parseGeminiModelNames(payload: unknown): string[] {
   return asArray(root.models, "Gemini model list response.models")
     .map((model, index) => asObject(model, `Gemini model ${index + 1}`))
     .filter((model) => asOptionalStringArray(model.supportedGenerationMethods).includes("generateContent"))
-    .map((model, index) =>
-      asString(model.name, `Gemini model ${index + 1}.name`).replace("models/", ""))
+    .map((model, index) => asString(model.name, `Gemini model ${index + 1}.name`).replace("models/", ""))
     .sort();
 }
 
@@ -88,10 +87,7 @@ function parseToolCall(value: unknown, index: number): NonNullable<ChatMessage["
     type: "function",
     function: {
       name: asString(fn.name, `tool call ${index + 1}.function.name`),
-      arguments:
-        typeof argumentsValue === "string"
-          ? argumentsValue
-          : JSON.stringify(argumentsValue ?? {}),
+      arguments: typeof argumentsValue === "string" ? argumentsValue : JSON.stringify(argumentsValue ?? {}),
     },
   };
 }
@@ -118,9 +114,7 @@ export function parseGeminiResponseParts(payload: unknown): GeminiResponsePart[]
     }
 
     if (isObject(rawPart.functionCall)) {
-      const args = isObject(rawPart.functionCall.args)
-        ? rawPart.functionCall.args
-        : undefined;
+      const args = isObject(rawPart.functionCall.args) ? rawPart.functionCall.args : undefined;
       parsed.functionCall = {
         name: asString(rawPart.functionCall.name, `Gemini response part ${index + 1}.functionCall.name`),
         ...(args ? { args } : {}),

--- a/apps/extension/src/background/llm/storage.ts
+++ b/apps/extension/src/background/llm/storage.ts
@@ -2,7 +2,7 @@ import type { SlopStorage, SlopStorageRecord } from "../../types";
 import { DEFAULT_STORAGE, getActiveProfile } from "../../types";
 
 export async function getStorage(): Promise<SlopStorage> {
-  const result = await chrome.storage.sync.get("slopStorage") as SlopStorageRecord;
+  const result = (await chrome.storage.sync.get("slopStorage")) as SlopStorageRecord;
   return result.slopStorage ?? DEFAULT_STORAGE;
 }
 
@@ -12,7 +12,7 @@ export async function saveStorage(storage: SlopStorage): Promise<void> {
 
 export async function setActiveModel(model: string): Promise<void> {
   const storage = await getStorage();
-  const profile = storage.profiles.find(p => p.id === storage.activeProfileId);
+  const profile = storage.profiles.find((p) => p.id === storage.activeProfileId);
   if (profile) {
     profile.model = model;
     await saveStorage(storage);

--- a/apps/extension/src/background/session.ts
+++ b/apps/extension/src/background/session.ts
@@ -1,9 +1,5 @@
 import type { SlopNode } from "@slop-ai/consumer/browser";
-import {
-  SlopConsumer,
-  WebSocketClientTransport,
-  PostMessageClientTransport,
-} from "@slop-ai/consumer/browser";
+import { SlopConsumer, WebSocketClientTransport, PostMessageClientTransport } from "@slop-ai/consumer/browser";
 import type { ProviderSpec, BackgroundMessage } from "../types";
 
 export interface ProviderEntry {
@@ -29,12 +25,7 @@ export class Session {
   private onStatusChange: StatusHandler;
   private onTreeUpdate: TreeHandler;
 
-  constructor(
-    tabId: number,
-    port: chrome.runtime.Port,
-    onStatusChange: StatusHandler,
-    onTreeUpdate: TreeHandler,
-  ) {
+  constructor(tabId: number, port: chrome.runtime.Port, onStatusChange: StatusHandler, onTreeUpdate: TreeHandler) {
     this.tabId = tabId;
     this.port = port;
     this.onStatusChange = onStatusChange;
@@ -69,8 +60,7 @@ export class Session {
   }
 
   async sync(specs: ProviderSpec[]): Promise<void> {
-    const keyFor = (s: { transport: string; endpoint?: string }) =>
-      `${s.transport}:${s.endpoint ?? ""}`;
+    const keyFor = (s: { transport: string; endpoint?: string }) => `${s.transport}:${s.endpoint ?? ""}`;
 
     const nextKeys = new Set(specs.map(keyFor));
 
@@ -139,9 +129,10 @@ export class Session {
     this.onStatusChange();
 
     try {
-      const transport = entry.transport === "ws"
-        ? new WebSocketClientTransport(entry.endpoint!)
-        : new PostMessageClientTransport(this.port);
+      const transport =
+        entry.transport === "ws"
+          ? new WebSocketClientTransport(entry.endpoint!)
+          : new PostMessageClientTransport(this.port);
 
       const consumer = new SlopConsumer(transport);
       const hello = await consumer.connect();

--- a/apps/extension/src/background/tab-registry.ts
+++ b/apps/extension/src/background/tab-registry.ts
@@ -1,11 +1,6 @@
 import type { ChatMessage } from "@slop-ai/consumer/browser";
 import { formatTree, affordancesToTools } from "@slop-ai/consumer/browser";
-import type {
-  BackgroundMessage,
-  BridgeMessageFromDesktop,
-  ProviderMessage,
-  ProviderSpec,
-} from "../types";
+import type { BackgroundMessage, BridgeMessageFromDesktop, ProviderMessage, ProviderSpec } from "../types";
 import { Session } from "./session";
 import { initConversation, runTurn } from "./chat-engine";
 import * as bridge from "./bridge-client";
@@ -71,10 +66,7 @@ export function teardown(tabId: number): void {
   lastStatus.delete(tabId);
 }
 
-export function setDiscoveries(
-  tabId: number,
-  providers: ProviderSpec[],
-): void {
+export function setDiscoveries(tabId: number, providers: ProviderSpec[]): void {
   const entry = tabs.get(tabId);
   if (!entry) return;
 

--- a/apps/extension/src/background/tool-router.ts
+++ b/apps/extension/src/background/tool-router.ts
@@ -20,7 +20,7 @@ export function buildMergedContext(providers: ProviderTreeInfo[]): MergedContext
   const singleProvider = providers.length === 1;
   const allTools: LlmTool[] = [];
   let stateStr = "";
-  const providerNames = providers.map(p => ({ name: p.name, index: p.index }));
+  const providerNames = providers.map((p) => ({ name: p.name, index: p.index }));
 
   // Per-provider ToolSets for resolve
   const providerToolSets: { name: string; index: number; toolSet: ToolSet }[] = [];

--- a/apps/extension/src/content/ax-adapter.ts
+++ b/apps/extension/src/content/ax-adapter.ts
@@ -71,21 +71,13 @@ interface CursorElementInfo {
  */
 function findCursorInteractiveElements(root: HTMLElement): Map<Element, CursorElementInfo> {
   const out = new Map<Element, CursorElementInfo>();
-  const interactiveTags = new Set([
-    "a",
-    "button",
-    "input",
-    "select",
-    "textarea",
-    "details",
-    "summary",
-  ]);
+  const interactiveTags = new Set(["a", "button", "input", "select", "textarea", "details", "summary"]);
 
   const all = root.querySelectorAll("*");
   for (let i = 0; i < all.length; i++) {
     const el = all[i];
     if (!(el instanceof HTMLElement)) continue;
-    if (el.closest("[hidden], [aria-hidden=\"true\"]")) continue;
+    if (el.closest('[hidden], [aria-hidden="true"]')) continue;
 
     const tagName = el.tagName.toLowerCase();
     if (interactiveTags.has(tagName)) continue;
@@ -246,7 +238,10 @@ function getAccessibleName(el: Element, cursorFallback?: CursorElementInfo): str
 
   const labelledBy = el.getAttribute("aria-labelledby");
   if (labelledBy) {
-    const parts = labelledBy.split(/\s+/).map(id => document.getElementById(id)?.textContent?.trim()).filter(Boolean);
+    const parts = labelledBy
+      .split(/\s+/)
+      .map((id) => document.getElementById(id)?.textContent?.trim())
+      .filter(Boolean);
     if (parts.length) return sanitizeAccessibleString(parts.join(" "));
   }
 
@@ -281,7 +276,10 @@ function getAccessibleName(el: Element, cursorFallback?: CursorElementInfo): str
 function getDescription(el: Element): string {
   const describedBy = el.getAttribute("aria-describedby");
   if (describedBy) {
-    const parts = describedBy.split(/\s+/).map(id => document.getElementById(id)?.textContent?.trim()).filter(Boolean);
+    const parts = describedBy
+      .split(/\s+/)
+      .map((id) => document.getElementById(id)?.textContent?.trim())
+      .filter(Boolean);
     if (parts.length) return parts.join(" ");
   }
 
@@ -306,18 +304,13 @@ function getDescription(el: Element): string {
 
 // --- Affordance extraction ---
 
-function getAffordances(
-  el: Element,
-  role: string,
-  cursor: CursorElementInfo | undefined,
-): SlopNode["affordances"] {
+function getAffordances(el: Element, role: string, cursor: CursorElementInfo | undefined): SlopNode["affordances"] {
   const affordances: NonNullable<SlopNode["affordances"]> = [];
   const name = getAccessibleName(el, cursor);
 
   if (["button", "link", "menuitem", "tab"].includes(role)) {
-    const label = role === "link"
-      ? `Navigate to ${(el as HTMLAnchorElement).href?.slice(0, 60) ?? "link"}`
-      : name || "Click";
+    const label =
+      role === "link" ? `Navigate to ${(el as HTMLAnchorElement).href?.slice(0, 60) ?? "link"}` : name || "Click";
     affordances.push({ action: "click", label });
   }
 
@@ -347,9 +340,7 @@ function getAffordances(
   }
 
   if (role === "combobox") {
-    const options = el instanceof HTMLSelectElement
-      ? Array.from(el.options).map(o => o.value)
-      : [];
+    const options = el instanceof HTMLSelectElement ? Array.from(el.options).map((o) => o.value) : [];
     affordances.push({
       action: "select",
       label: `Select option in ${name || "dropdown"}`,
@@ -426,8 +417,31 @@ function isMeaningful(el: Element, role: string, cursorMap: ReadonlyMap<Element,
   if (el.getAttribute("role")) return true;
 
   // Semantic HTML tags
-  if (["MAIN", "NAV", "ASIDE", "HEADER", "FOOTER", "SECTION", "ARTICLE", "FORM",
-       "H1", "H2", "H3", "H4", "H5", "H6", "UL", "OL", "LI", "TABLE", "IMG", "FIGURE"].includes(tag)) return true;
+  if (
+    [
+      "MAIN",
+      "NAV",
+      "ASIDE",
+      "HEADER",
+      "FOOTER",
+      "SECTION",
+      "ARTICLE",
+      "FORM",
+      "H1",
+      "H2",
+      "H3",
+      "H4",
+      "H5",
+      "H6",
+      "UL",
+      "OL",
+      "LI",
+      "TABLE",
+      "IMG",
+      "FIGURE",
+    ].includes(tag)
+  )
+    return true;
 
   return false;
 }
@@ -528,10 +542,7 @@ export interface AxBuildOptions {
   mode?: "full" | "interactive";
 }
 
-function buildSlopNodeForElement(
-  el: Element,
-  cursor: CursorElementInfo | undefined,
-): SlopNode | null {
+function buildSlopNodeForElement(el: Element, cursor: CursorElementInfo | undefined): SlopNode | null {
   const rawRole = getRole(el);
   const role = rawRole || roleFromCursorHint(cursor);
   const affordances = getAffordances(el, role, cursor);
@@ -586,7 +597,7 @@ function buildInteractiveFlat(cursorMap: ReadonlyMap<Element, CursorElementInfo>
 
   const candidates = new Set<Element>();
   for (const el of document.querySelectorAll(
-    "a[href], button, input, textarea, select, summary, [role], [tabindex]:not([tabindex=\"-1\"])",
+    'a[href], button, input, textarea, select, summary, [role], [tabindex]:not([tabindex="-1"])',
   )) {
     if (!(el instanceof HTMLElement)) continue;
     if (shouldSkip(el)) continue;
@@ -680,7 +691,16 @@ export function observeChanges(callback: (tree: SlopNode) => void): () => void {
     childList: true,
     subtree: true,
     attributes: true,
-    attributeFilter: ["role", "aria-label", "aria-expanded", "aria-checked", "aria-hidden", "value", "checked", "disabled"],
+    attributeFilter: [
+      "role",
+      "aria-label",
+      "aria-expanded",
+      "aria-checked",
+      "aria-hidden",
+      "value",
+      "checked",
+      "disabled",
+    ],
   });
 
   return () => {
@@ -692,7 +712,11 @@ export function observeChanges(callback: (tree: SlopNode) => void): () => void {
 
 // --- Action execution ---
 
-export function executeAction(nodeId: string, action: string, params?: Record<string, unknown>): { status: string; message?: string } {
+export function executeAction(
+  nodeId: string,
+  action: string,
+  params?: Record<string, unknown>,
+): { status: string; message?: string } {
   const el = resolveElement(nodeId);
   if (!el) return { status: "error", message: `Element ${nodeId} not found` };
 

--- a/apps/extension/src/content/bridge-relay.ts
+++ b/apps/extension/src/content/bridge-relay.ts
@@ -5,11 +5,7 @@
  * PostMessageClientTransport in the SDK. The background also handles these
  * for desktop bridge relay.
  */
-import type {
-  BackgroundMessage,
-  ProviderMessage,
-  RelayConsumerMessage,
-} from "../types";
+import type { BackgroundMessage, ProviderMessage, RelayConsumerMessage } from "../types";
 
 export function createBridgeRelay(port: chrome.runtime.Port) {
   let active = false;
@@ -58,14 +54,14 @@ export function createBridgeRelay(port: chrome.runtime.Port) {
 function isBridgeWindowMessage(
   value: unknown,
 ): value is { slop: true; __slop_relay?: boolean; message: ProviderMessage | RelayConsumerMessage } {
-  return !!value
-    && typeof value === "object"
-    && (value as Record<string, unknown>).slop === true
-    && "message" in (value as Record<string, unknown>);
+  return (
+    !!value &&
+    typeof value === "object" &&
+    (value as Record<string, unknown>).slop === true &&
+    "message" in (value as Record<string, unknown>)
+  );
 }
 
 function isBackgroundMessage(value: unknown): value is BackgroundMessage {
-  return !!value
-    && typeof value === "object"
-    && typeof (value as { type?: unknown }).type === "string";
+  return !!value && typeof value === "object" && typeof (value as { type?: unknown }).type === "string";
 }

--- a/apps/extension/src/content/index.ts
+++ b/apps/extension/src/content/index.ts
@@ -25,7 +25,7 @@ let reconnecting = false;
 // ========================================================================
 
 async function init() {
-  const result = await chrome.storage.local.get("prefs") as PrefsStorageRecord;
+  const result = (await chrome.storage.local.get("prefs")) as PrefsStorageRecord;
   isActive = result.prefs?.active ?? true;
 
   currentDiscoveries = discoverSlop();
@@ -48,9 +48,7 @@ async function init() {
 
   chrome.storage.onChanged.addListener((changes, area) => {
     if (area !== "local" || !changes.prefs) return;
-    const nextPrefs = isExtensionPrefsPatch(changes.prefs.newValue)
-      ? changes.prefs.newValue
-      : undefined;
+    const nextPrefs = isExtensionPrefsPatch(changes.prefs.newValue) ? changes.prefs.newValue : undefined;
     const newActive = nextPrefs?.active ?? true;
     if (newActive && !isActive && currentDiscoveries.length > 0) {
       isActive = true;
@@ -210,12 +208,16 @@ function startAxAdapter() {
   let version = 1;
 
   // AX adapter acts as a postMessage provider — use SDK-compatible message types
-  const slopUp = (message: ProviderMessage) =>
-    port?.postMessage({ type: "slop-from-provider", message });
+  const slopUp = (message: ProviderMessage) => port?.postMessage({ type: "slop-from-provider", message });
 
   slopUp({
     type: "hello",
-    provider: { id: "ax-adapter", name: document.title || "Page", slop_version: "0.1", capabilities: ["state", "affordances"] },
+    provider: {
+      id: "ax-adapter",
+      name: document.title || "Page",
+      slop_version: "0.1",
+      capabilities: ["state", "affordances"],
+    },
   });
 
   slopUp({ type: "snapshot", id: "sub-1", version, tree });
@@ -233,7 +235,8 @@ function startAxAdapter() {
       const nodeId = path.split("/").pop() ?? path.replace(/^\//, "");
       const result = executeAction(nodeId, action, params);
       slopUp({
-        type: "result", id,
+        type: "result",
+        id,
         status: result.status === "ok" ? "ok" : "error",
         ...(result.status === "ok" ? {} : { error: { code: "internal", message: result.message ?? "Unknown error" } }),
       });
@@ -243,7 +246,15 @@ function startAxAdapter() {
       }, 100);
     }
     if (message.type === "slop-to-provider" && message.message.type === "connect") {
-      slopUp({ type: "hello", provider: { id: "ax-adapter", name: document.title || "Page", slop_version: "0.1", capabilities: ["state", "affordances"] } });
+      slopUp({
+        type: "hello",
+        provider: {
+          id: "ax-adapter",
+          name: document.title || "Page",
+          slop_version: "0.1",
+          capabilities: ["state", "affordances"],
+        },
+      });
     }
     if (message.type === "slop-to-provider" && message.message.type === "subscribe") {
       slopUp({ type: "snapshot", id: message.message.id, version, tree: buildAxTree() });
@@ -267,11 +278,17 @@ function startAxAdapter() {
 }
 
 function stopAxAdapter() {
-  if (axCleanup) { axCleanup(); axCleanup = null; }
+  if (axCleanup) {
+    axCleanup();
+    axCleanup = null;
+  }
   hideChatUI();
   bridgeRelay?.dispose();
   bridgeRelay = null;
-  if (port) { port.disconnect(); port = null; }
+  if (port) {
+    port.disconnect();
+    port = null;
+  }
 }
 
 // ========================================================================
@@ -312,16 +329,11 @@ function isExtensionPrefsPatch(value: unknown): value is Partial<ExtensionPrefs>
 }
 
 function isPortMessageToContent(value: unknown): value is PortMessageToContent {
-  return !!value
-    && typeof value === "object"
-    && typeof (value as { type?: unknown }).type === "string";
+  return !!value && typeof value === "object" && typeof (value as { type?: unknown }).type === "string";
 }
 
 function isPopupCommandMessage(value: unknown): value is PopupCommandMessage {
   if (!value || typeof value !== "object") return false;
   const type = (value as { type?: unknown }).type;
-  return type === "scan-page"
-    || type === "stop-scan"
-    || type === "get-scan-status"
-    || type === "get-slop-status";
+  return type === "scan-page" || type === "stop-scan" || type === "get-scan-status" || type === "get-slop-status";
 }

--- a/apps/extension/src/env.d.ts
+++ b/apps/extension/src/env.d.ts
@@ -30,11 +30,7 @@ declare namespace chrome {
     }
 
     function query(queryInfo: { active?: boolean; currentWindow?: boolean }): Promise<Tab[]>;
-    function sendMessage(
-      tabId: number,
-      message: unknown,
-      responseCallback?: (response?: unknown) => void,
-    ): void;
+    function sendMessage(tabId: number, message: unknown, responseCallback?: (response?: unknown) => void): void;
     const onRemoved: Event<(tabId: number) => void>;
   }
 
@@ -64,11 +60,9 @@ declare namespace chrome {
     function openOptionsPage(): void;
 
     const onConnect: Event<(port: Port) => void>;
-    const onMessage: Event<(
-      message: unknown,
-      sender: MessageSender,
-      sendResponse: (response?: unknown) => void,
-    ) => void>;
+    const onMessage: Event<
+      (message: unknown, sender: MessageSender, sendResponse: (response?: unknown) => void) => void
+    >;
     const lastError: LastError | undefined;
   }
 
@@ -92,9 +86,6 @@ declare namespace chrome {
 
     const local: StorageArea;
     const sync: StorageArea;
-    const onChanged: Event<(
-      changes: Record<string, StorageChange>,
-      areaName: StorageAreaName,
-    ) => void>;
+    const onChanged: Event<(changes: Record<string, StorageChange>, areaName: StorageAreaName) => void>;
   }
 }

--- a/apps/extension/src/options/options.ts
+++ b/apps/extension/src/options/options.ts
@@ -18,7 +18,7 @@ const statusEl = document.getElementById("status")!;
 let storage: SlopStorage = DEFAULT_STORAGE;
 
 async function loadStorage(): Promise<void> {
-  const result = await chrome.storage.sync.get("slopStorage") as SlopStorageRecord;
+  const result = (await chrome.storage.sync.get("slopStorage")) as SlopStorageRecord;
   storage = result.slopStorage ?? DEFAULT_STORAGE;
   renderProfiles();
 }
@@ -62,7 +62,7 @@ function activateProfile(id: string) {
 }
 
 function deleteProfile(id: string) {
-  storage.profiles = storage.profiles.filter(p => p.id !== id);
+  storage.profiles = storage.profiles.filter((p) => p.id !== id);
   if (storage.activeProfileId === id && storage.profiles.length > 0) {
     storage.activeProfileId = storage.profiles[0].id;
   }
@@ -70,7 +70,7 @@ function deleteProfile(id: string) {
 }
 
 function openEditForm(id?: string) {
-  const profile = id ? storage.profiles.find(p => p.id === id) : null;
+  const profile = id ? storage.profiles.find((p) => p.id === id) : null;
   formTitle.textContent = profile ? "Edit Profile" : "New Profile";
   editIdEl.value = profile?.id ?? "";
   profileNameEl.value = profile?.name ?? "";
@@ -89,10 +89,18 @@ function closeEditForm() {
 function toggleApiKey() {
   apiKeyRow.classList.toggle("visible", providerEl.value !== "ollama");
   switch (providerEl.value) {
-    case "ollama": endpointEl.placeholder = "http://localhost:11434"; break;
-    case "openai": endpointEl.placeholder = "https://api.openai.com"; break;
-    case "openrouter": endpointEl.placeholder = "https://openrouter.ai/api"; break;
-    case "gemini": endpointEl.placeholder = "https://generativelanguage.googleapis.com"; break;
+    case "ollama":
+      endpointEl.placeholder = "http://localhost:11434";
+      break;
+    case "openai":
+      endpointEl.placeholder = "https://api.openai.com";
+      break;
+    case "openrouter":
+      endpointEl.placeholder = "https://openrouter.ai/api";
+      break;
+    case "gemini":
+      endpointEl.placeholder = "https://generativelanguage.googleapis.com";
+      break;
   }
 }
 
@@ -102,12 +110,20 @@ function saveProfile() {
     id,
     name: profileNameEl.value || providerEl.value.charAt(0).toUpperCase() + providerEl.value.slice(1),
     llmProvider: providerEl.value as LlmProfile["llmProvider"],
-    endpoint: endpointEl.value || { ollama: "http://localhost:11434", openai: "https://api.openai.com", openrouter: "https://openrouter.ai/api", gemini: "https://generativelanguage.googleapis.com" }[providerEl.value] || "http://localhost:11434",
+    endpoint:
+      endpointEl.value ||
+      {
+        ollama: "http://localhost:11434",
+        openai: "https://api.openai.com",
+        openrouter: "https://openrouter.ai/api",
+        gemini: "https://generativelanguage.googleapis.com",
+      }[providerEl.value] ||
+      "http://localhost:11434",
     apiKey: apiKeyEl.value,
-    model: "",  // selected dynamically in the chat UI
+    model: "", // selected dynamically in the chat UI
   };
 
-  const idx = storage.profiles.findIndex(p => p.id === id);
+  const idx = storage.profiles.findIndex((p) => p.id === id);
   if (idx >= 0) {
     storage.profiles[idx] = profile;
   } else {
@@ -129,7 +145,9 @@ function save() {
 
 function showStatus(text: string) {
   statusEl.textContent = text;
-  setTimeout(() => { statusEl.textContent = ""; }, 2000);
+  setTimeout(() => {
+    statusEl.textContent = "";
+  }, 2000);
 }
 
 function esc(s: string): string {

--- a/apps/extension/src/popup/popup.ts
+++ b/apps/extension/src/popup/popup.ts
@@ -13,7 +13,7 @@ const scanBtn = document.getElementById("scanBtn") as HTMLButtonElement;
 let isScanning = false;
 
 // Load prefs + check scan status
-getPrefs().then(prefs => {
+getPrefs().then((prefs) => {
   activeToggle.checked = prefs.active;
   chatToggle.checked = prefs.chatUIEnabled;
   bridgeToggle.checked = prefs.bridgeEnabled;

--- a/apps/extension/src/types.ts
+++ b/apps/extension/src/types.ts
@@ -1,8 +1,4 @@
-import type {
-  ConsumerMessage,
-  ProviderMessage,
-  SlopNode,
-} from "@slop-ai/consumer/browser";
+import type { ConsumerMessage, ProviderMessage, SlopNode } from "@slop-ai/consumer/browser";
 export type {
   ConsumerMessage,
   ProviderMessage,
@@ -118,7 +114,7 @@ export const DEFAULT_STORAGE: SlopStorage = {
 };
 
 export function getActiveProfile(storage: SlopStorage): LlmProfile {
-  return storage.profiles.find(p => p.id === storage.activeProfileId) ?? storage.profiles[0] ?? DEFAULT_PROFILE;
+  return storage.profiles.find((p) => p.id === storage.activeProfileId) ?? storage.profiles[0] ?? DEFAULT_PROFILE;
 }
 
 // ========================================================================
@@ -146,7 +142,7 @@ export const DEFAULT_PREFS: ExtensionPrefs = {
 };
 
 export async function getPrefs(): Promise<ExtensionPrefs> {
-  const result = await chrome.storage.local.get("prefs") as PrefsStorageRecord;
+  const result = (await chrome.storage.local.get("prefs")) as PrefsStorageRecord;
   return { ...DEFAULT_PREFS, ...result.prefs };
 }
 

--- a/apps/extension/src/ui/chat.ts
+++ b/apps/extension/src/ui/chat.ts
@@ -95,7 +95,10 @@ export function createChatUI(callbacks: ChatCallbacks): ChatUI {
 
   // Event wiring
   const closeBtn = shadow.getElementById("slop-close")!;
-  closeBtn.onclick = () => { panelOpen = false; panel.classList.add("hidden"); };
+  closeBtn.onclick = () => {
+    panelOpen = false;
+    panel.classList.add("hidden");
+  };
 
   const profileSelect = shadow.getElementById("slop-profile-select") as HTMLSelectElement;
   profileSelect.onchange = () => callbacks.onSwitchProfile(profileSelect.value);
@@ -120,7 +123,9 @@ export function createChatUI(callbacks: ChatCallbacks): ChatUI {
   }
 
   sendBtn.onclick = doSend;
-  input.onkeydown = (e) => { if (e.key === "Enter") doSend(); };
+  input.onkeydown = (e) => {
+    if (e.key === "Enter") doSend();
+  };
 
   document.body.appendChild(host);
 

--- a/benchmarks/mcp-vs-slop/app/mcp-server.ts
+++ b/benchmarks/mcp-vs-slop/app/mcp-server.ts
@@ -1,19 +1,13 @@
 import { Server } from "@modelcontextprotocol/sdk/server";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { IssueTrackerStore } from "./store";
 import { createSeedData, createLargeSeedData } from "./seed";
 
 const store = new IssueTrackerStore();
 store.reset(process.env.BENCH_LARGE_DATASET ? createLargeSeedData() : createSeedData());
 
-const server = new Server(
-  { name: "issue-tracker-mcp", version: "1.0.0" },
-  { capabilities: { tools: {} } },
-);
+const server = new Server({ name: "issue-tracker-mcp", version: "1.0.0" }, { capabilities: { tools: {} } });
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [
@@ -169,10 +163,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const issues = store.listIssues(a.repo_id);
       const openCount = issues.filter((i) => i.status === "open").length;
       return {
-        content: [{
-          type: "text",
-          text: JSON.stringify({ ...repo, open_issues: openCount, total_issues: issues.length }),
-        }],
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ ...repo, open_issues: openCount, total_issues: issues.length }),
+          },
+        ],
       };
     }
 

--- a/benchmarks/mcp-vs-slop/app/seed.ts
+++ b/benchmarks/mcp-vs-slop/app/seed.ts
@@ -22,56 +22,269 @@ export const seedLabels: Label[] = [
 
 export const seedIssues: Issue[] = [
   // Frontend issues
-  { id: "issue-1", repoId: "frontend", title: "Login form not validating email format", body: "The login form accepts invalid email addresses. Need to add proper validation.", status: "open", labels: ["bug"], assignee: null, createdAt: "2026-03-15T10:00:00Z" },
-  { id: "issue-2", repoId: "frontend", title: "Add dark mode support", body: "Users have requested a dark mode toggle in the settings page.", status: "open", labels: ["feature"], assignee: "bob", createdAt: "2026-03-16T14:00:00Z" },
-  { id: "issue-3", repoId: "frontend", title: "Fix authentication token refresh", body: "The auth token refresh flow is broken, users get logged out after 30 minutes.", status: "open", labels: ["bug", "security"], assignee: null, createdAt: "2026-03-18T09:00:00Z" },
-  { id: "issue-4", repoId: "frontend", title: "Update React to v19", body: "Upgrade from React 18 to React 19 for improved performance.", status: "closed", labels: ["feature"], assignee: "alice", createdAt: "2026-03-10T11:00:00Z" },
-  { id: "issue-5", repoId: "frontend", title: "Remove deprecated API calls", body: "Clean up deprecated v1 API calls that were replaced in the backend migration.", status: "open", labels: ["wontfix"], assignee: null, createdAt: "2026-03-20T08:00:00Z" },
+  {
+    id: "issue-1",
+    repoId: "frontend",
+    title: "Login form not validating email format",
+    body: "The login form accepts invalid email addresses. Need to add proper validation.",
+    status: "open",
+    labels: ["bug"],
+    assignee: null,
+    createdAt: "2026-03-15T10:00:00Z",
+  },
+  {
+    id: "issue-2",
+    repoId: "frontend",
+    title: "Add dark mode support",
+    body: "Users have requested a dark mode toggle in the settings page.",
+    status: "open",
+    labels: ["feature"],
+    assignee: "bob",
+    createdAt: "2026-03-16T14:00:00Z",
+  },
+  {
+    id: "issue-3",
+    repoId: "frontend",
+    title: "Fix authentication token refresh",
+    body: "The auth token refresh flow is broken, users get logged out after 30 minutes.",
+    status: "open",
+    labels: ["bug", "security"],
+    assignee: null,
+    createdAt: "2026-03-18T09:00:00Z",
+  },
+  {
+    id: "issue-4",
+    repoId: "frontend",
+    title: "Update React to v19",
+    body: "Upgrade from React 18 to React 19 for improved performance.",
+    status: "closed",
+    labels: ["feature"],
+    assignee: "alice",
+    createdAt: "2026-03-10T11:00:00Z",
+  },
+  {
+    id: "issue-5",
+    repoId: "frontend",
+    title: "Remove deprecated API calls",
+    body: "Clean up deprecated v1 API calls that were replaced in the backend migration.",
+    status: "open",
+    labels: ["wontfix"],
+    assignee: null,
+    createdAt: "2026-03-20T08:00:00Z",
+  },
 
   // Backend issues
-  { id: "issue-6", repoId: "backend", title: "Rate limiting not working on /api/search", body: "The rate limiter middleware is not being applied to the search endpoint.", status: "open", labels: ["bug", "security"], assignee: null, createdAt: "2026-03-14T16:00:00Z" },
-  { id: "issue-7", repoId: "backend", title: "Add pagination to list endpoints", body: "All list endpoints return unbounded results. Add cursor-based pagination.", status: "open", labels: ["feature"], assignee: "charlie", createdAt: "2026-03-17T13:00:00Z" },
-  { id: "issue-8", repoId: "backend", title: "Database connection pool exhaustion", body: "Under high load, the connection pool runs out. Need to tune pool settings.", status: "open", labels: ["bug"], assignee: null, createdAt: "2026-03-19T07:00:00Z" },
-  { id: "issue-9", repoId: "backend", title: "Migrate to PostgreSQL 16", body: "Upgrade from PG 15 to PG 16 for improved query planning.", status: "closed", labels: ["feature"], assignee: "alice", createdAt: "2026-03-08T10:00:00Z" },
-  { id: "issue-10", repoId: "backend", title: "Legacy webhook format support", body: "Some consumers still use the v1 webhook format. Keep it or drop it?", status: "open", labels: ["wontfix"], assignee: null, createdAt: "2026-03-21T15:00:00Z" },
+  {
+    id: "issue-6",
+    repoId: "backend",
+    title: "Rate limiting not working on /api/search",
+    body: "The rate limiter middleware is not being applied to the search endpoint.",
+    status: "open",
+    labels: ["bug", "security"],
+    assignee: null,
+    createdAt: "2026-03-14T16:00:00Z",
+  },
+  {
+    id: "issue-7",
+    repoId: "backend",
+    title: "Add pagination to list endpoints",
+    body: "All list endpoints return unbounded results. Add cursor-based pagination.",
+    status: "open",
+    labels: ["feature"],
+    assignee: "charlie",
+    createdAt: "2026-03-17T13:00:00Z",
+  },
+  {
+    id: "issue-8",
+    repoId: "backend",
+    title: "Database connection pool exhaustion",
+    body: "Under high load, the connection pool runs out. Need to tune pool settings.",
+    status: "open",
+    labels: ["bug"],
+    assignee: null,
+    createdAt: "2026-03-19T07:00:00Z",
+  },
+  {
+    id: "issue-9",
+    repoId: "backend",
+    title: "Migrate to PostgreSQL 16",
+    body: "Upgrade from PG 15 to PG 16 for improved query planning.",
+    status: "closed",
+    labels: ["feature"],
+    assignee: "alice",
+    createdAt: "2026-03-08T10:00:00Z",
+  },
+  {
+    id: "issue-10",
+    repoId: "backend",
+    title: "Legacy webhook format support",
+    body: "Some consumers still use the v1 webhook format. Keep it or drop it?",
+    status: "open",
+    labels: ["wontfix"],
+    assignee: null,
+    createdAt: "2026-03-21T15:00:00Z",
+  },
 
   // Infra issues
-  { id: "issue-11", repoId: "infra", title: "CI pipeline times out on large PRs", body: "PRs with more than 50 changed files cause the CI to timeout at 30 minutes.", status: "open", labels: ["bug"], assignee: null, createdAt: "2026-03-13T12:00:00Z" },
-  { id: "issue-12", repoId: "infra", title: "Add staging environment auto-deploy", body: "Set up automatic deployment to staging on merge to main.", status: "open", labels: ["enhancement"], assignee: "bob", createdAt: "2026-03-16T09:00:00Z" },
-  { id: "issue-13", repoId: "infra", title: "Terraform state lock contention", body: "Multiple devs running terraform plan causes state lock conflicts.", status: "open", labels: ["bug"], assignee: null, createdAt: "2026-03-22T11:00:00Z" },
-  { id: "issue-14", repoId: "infra", title: "Upgrade Kubernetes to 1.29", body: "Current cluster is on 1.27, need to upgrade for security patches.", status: "closed", labels: ["enhancement"], assignee: "charlie", createdAt: "2026-03-05T08:00:00Z" },
-  { id: "issue-15", repoId: "infra", title: "Old monitoring dashboard removal", body: "The Grafana v8 dashboards are unused since we migrated. Remove them.", status: "open", labels: ["wontfix"], assignee: null, createdAt: "2026-03-23T14:00:00Z" },
+  {
+    id: "issue-11",
+    repoId: "infra",
+    title: "CI pipeline times out on large PRs",
+    body: "PRs with more than 50 changed files cause the CI to timeout at 30 minutes.",
+    status: "open",
+    labels: ["bug"],
+    assignee: null,
+    createdAt: "2026-03-13T12:00:00Z",
+  },
+  {
+    id: "issue-12",
+    repoId: "infra",
+    title: "Add staging environment auto-deploy",
+    body: "Set up automatic deployment to staging on merge to main.",
+    status: "open",
+    labels: ["enhancement"],
+    assignee: "bob",
+    createdAt: "2026-03-16T09:00:00Z",
+  },
+  {
+    id: "issue-13",
+    repoId: "infra",
+    title: "Terraform state lock contention",
+    body: "Multiple devs running terraform plan causes state lock conflicts.",
+    status: "open",
+    labels: ["bug"],
+    assignee: null,
+    createdAt: "2026-03-22T11:00:00Z",
+  },
+  {
+    id: "issue-14",
+    repoId: "infra",
+    title: "Upgrade Kubernetes to 1.29",
+    body: "Current cluster is on 1.27, need to upgrade for security patches.",
+    status: "closed",
+    labels: ["enhancement"],
+    assignee: "charlie",
+    createdAt: "2026-03-05T08:00:00Z",
+  },
+  {
+    id: "issue-15",
+    repoId: "infra",
+    title: "Old monitoring dashboard removal",
+    body: "The Grafana v8 dashboards are unused since we migrated. Remove them.",
+    status: "open",
+    labels: ["wontfix"],
+    assignee: null,
+    createdAt: "2026-03-23T14:00:00Z",
+  },
 ];
 
 export const seedComments: Comment[] = [
   // Comments on issue-1
-  { id: "comment-1", issueId: "issue-1", author: "alice", body: "I can reproduce this. The regex is missing the TLD check.", createdAt: "2026-03-15T11:00:00Z" },
-  { id: "comment-2", issueId: "issue-1", author: "bob", body: "Should we use a library like zod for this?", createdAt: "2026-03-15T12:00:00Z" },
+  {
+    id: "comment-1",
+    issueId: "issue-1",
+    author: "alice",
+    body: "I can reproduce this. The regex is missing the TLD check.",
+    createdAt: "2026-03-15T11:00:00Z",
+  },
+  {
+    id: "comment-2",
+    issueId: "issue-1",
+    author: "bob",
+    body: "Should we use a library like zod for this?",
+    createdAt: "2026-03-15T12:00:00Z",
+  },
 
   // Comments on issue-3
-  { id: "comment-3", issueId: "issue-3", author: "charlie", body: "This is critical — affects all users. The refresh endpoint returns 401 instead of issuing a new token.", createdAt: "2026-03-18T10:00:00Z" },
-  { id: "comment-4", issueId: "issue-3", author: "alice", body: "I think the issue is in the middleware. The token expiry check is using UTC but the token was issued with local time.", createdAt: "2026-03-18T14:00:00Z" },
+  {
+    id: "comment-3",
+    issueId: "issue-3",
+    author: "charlie",
+    body: "This is critical — affects all users. The refresh endpoint returns 401 instead of issuing a new token.",
+    createdAt: "2026-03-18T10:00:00Z",
+  },
+  {
+    id: "comment-4",
+    issueId: "issue-3",
+    author: "alice",
+    body: "I think the issue is in the middleware. The token expiry check is using UTC but the token was issued with local time.",
+    createdAt: "2026-03-18T14:00:00Z",
+  },
 
   // Comments on issue-6
-  { id: "comment-5", issueId: "issue-6", author: "bob", body: "The middleware is applied but the search endpoint is mounted before the rate limiter.", createdAt: "2026-03-14T17:00:00Z" },
+  {
+    id: "comment-5",
+    issueId: "issue-6",
+    author: "bob",
+    body: "The middleware is applied but the search endpoint is mounted before the rate limiter.",
+    createdAt: "2026-03-14T17:00:00Z",
+  },
 
   // Comments on issue-7
-  { id: "comment-6", issueId: "issue-7", author: "alice", body: "Let's use cursor-based pagination, not offset-based. Better for large datasets.", createdAt: "2026-03-17T14:00:00Z" },
-  { id: "comment-7", issueId: "issue-7", author: "charlie", body: "Agreed. I'll base it on the created_at timestamp + id for stable cursors.", createdAt: "2026-03-17T15:00:00Z" },
+  {
+    id: "comment-6",
+    issueId: "issue-7",
+    author: "alice",
+    body: "Let's use cursor-based pagination, not offset-based. Better for large datasets.",
+    createdAt: "2026-03-17T14:00:00Z",
+  },
+  {
+    id: "comment-7",
+    issueId: "issue-7",
+    author: "charlie",
+    body: "Agreed. I'll base it on the created_at timestamp + id for stable cursors.",
+    createdAt: "2026-03-17T15:00:00Z",
+  },
 
   // Comments on issue-8
-  { id: "comment-8", issueId: "issue-8", author: "alice", body: "Default pool size is 10. We should increase to 25 and add connection timeout.", createdAt: "2026-03-19T08:00:00Z" },
+  {
+    id: "comment-8",
+    issueId: "issue-8",
+    author: "alice",
+    body: "Default pool size is 10. We should increase to 25 and add connection timeout.",
+    createdAt: "2026-03-19T08:00:00Z",
+  },
 
   // Comments on issue-11
-  { id: "comment-9", issueId: "issue-11", author: "charlie", body: "We could split the test suite into parallel jobs.", createdAt: "2026-03-13T13:00:00Z" },
-  { id: "comment-10", issueId: "issue-11", author: "bob", body: "Or increase the timeout to 60 minutes? The large PRs are rare.", createdAt: "2026-03-13T14:00:00Z" },
+  {
+    id: "comment-9",
+    issueId: "issue-11",
+    author: "charlie",
+    body: "We could split the test suite into parallel jobs.",
+    createdAt: "2026-03-13T13:00:00Z",
+  },
+  {
+    id: "comment-10",
+    issueId: "issue-11",
+    author: "bob",
+    body: "Or increase the timeout to 60 minutes? The large PRs are rare.",
+    createdAt: "2026-03-13T14:00:00Z",
+  },
 
   // Comments on issue-12
-  { id: "comment-11", issueId: "issue-12", author: "alice", body: "We should add a manual approval step before staging deploys.", createdAt: "2026-03-16T10:00:00Z" },
+  {
+    id: "comment-11",
+    issueId: "issue-12",
+    author: "alice",
+    body: "We should add a manual approval step before staging deploys.",
+    createdAt: "2026-03-16T10:00:00Z",
+  },
 
   // Comments on issue-13
-  { id: "comment-12", issueId: "issue-13", author: "bob", body: "Terraform Cloud would solve this with remote state management.", createdAt: "2026-03-22T12:00:00Z" },
-  { id: "comment-13", issueId: "issue-13", author: "charlie", body: "Or we could use a simple locking mechanism with DynamoDB.", createdAt: "2026-03-22T13:00:00Z" },
+  {
+    id: "comment-12",
+    issueId: "issue-13",
+    author: "bob",
+    body: "Terraform Cloud would solve this with remote state management.",
+    createdAt: "2026-03-22T12:00:00Z",
+  },
+  {
+    id: "comment-13",
+    issueId: "issue-13",
+    author: "charlie",
+    body: "Or we could use a simple locking mechanism with DynamoDB.",
+    createdAt: "2026-03-22T13:00:00Z",
+  },
 ];
 
 export function createSeedData() {
@@ -89,21 +302,42 @@ export function createSeedData() {
  */
 export function createLargeSeedData() {
   const repoNames = [
-    "frontend", "backend", "infra", "mobile-ios", "mobile-android",
-    "docs", "analytics", "auth-service", "payments", "notifications",
+    "frontend",
+    "backend",
+    "infra",
+    "mobile-ios",
+    "mobile-android",
+    "docs",
+    "analytics",
+    "auth-service",
+    "payments",
+    "notifications",
   ];
   const labelNames = ["bug", "feature", "enhancement", "security", "wontfix", "needs-review", "good-first-issue"];
   const authors = ["alice", "bob", "charlie", "diana", "evan", "fiona"];
   const statuses: ("open" | "closed")[] = ["open", "open", "open", "closed"]; // 75% open
 
   const issueTitles = [
-    "Fix broken redirect after login", "Add support for dark mode", "Memory leak in worker pool",
-    "Update dependency to latest major", "Flaky test in CI pipeline", "Add rate limiting to API",
-    "Improve error messages for users", "Migrate to new auth provider", "Fix timezone handling in scheduler",
-    "Add bulk export functionality", "Refactor database query layer", "Broken pagination on mobile",
-    "Add webhook retry logic", "Remove deprecated endpoints", "Fix race condition in cache",
-    "Add multi-language support", "Improve startup performance", "Fix CSS layout on Safari",
-    "Add health check endpoint", "Upgrade Kubernetes manifests",
+    "Fix broken redirect after login",
+    "Add support for dark mode",
+    "Memory leak in worker pool",
+    "Update dependency to latest major",
+    "Flaky test in CI pipeline",
+    "Add rate limiting to API",
+    "Improve error messages for users",
+    "Migrate to new auth provider",
+    "Fix timezone handling in scheduler",
+    "Add bulk export functionality",
+    "Refactor database query layer",
+    "Broken pagination on mobile",
+    "Add webhook retry logic",
+    "Remove deprecated endpoints",
+    "Fix race condition in cache",
+    "Add multi-language support",
+    "Improve startup performance",
+    "Fix CSS layout on Safari",
+    "Add health check endpoint",
+    "Upgrade Kubernetes manifests",
   ];
 
   const commentBodies = [
@@ -123,7 +357,7 @@ export function createLargeSeedData() {
     id: name,
     name,
     description: `The ${name} service`,
-    visibility: name === "infra" || name === "payments" ? "private" as const : "public" as const,
+    visibility: name === "infra" || name === "payments" ? ("private" as const) : ("public" as const),
   }));
 
   const labels: Label[] = [];
@@ -138,7 +372,10 @@ export function createLargeSeedData() {
   let issueId = 1;
   // Deterministic pseudo-random using simple seed
   let rng = 42;
-  const rand = () => { rng = (rng * 1103515245 + 12345) & 0x7fffffff; return rng / 0x7fffffff; };
+  const rand = () => {
+    rng = (rng * 1103515245 + 12345) & 0x7fffffff;
+    return rng / 0x7fffffff;
+  };
 
   for (const repo of repos) {
     const count = 8 + Math.floor(rand() * 5); // 8-12 issues per repo

--- a/benchmarks/mcp-vs-slop/app/slop-server.ts
+++ b/benchmarks/mcp-vs-slop/app/slop-server.ts
@@ -117,12 +117,7 @@ export function createSlopServer(store: IssueTrackerStore, opts?: SlopServerOpts
       return {
         type: "collection",
         props: { count: repoIssues.length },
-        children: Object.fromEntries(
-          repoIssues.map((issue) => [
-            issue.id,
-            buildIssueNode(store, slop, issue, false),
-          ]),
-        ),
+        children: Object.fromEntries(repoIssues.map((issue) => [issue.id, buildIssueNode(store, slop, issue, false)])),
       };
     });
   }
@@ -170,10 +165,7 @@ function buildOptimizedCollection(
     props: { count: allIssues.length },
     summary: `${allIssues.length} issues: ${openIssues.length} open (${unassigned} unassigned, ${bugs} bugs), ${closedCount} closed. Labels: ${labelSummary}`,
     children: Object.fromEntries(
-      scored.map(({ issue, salience }) => [
-        issue.id,
-        buildIssueNode(store, slop, issue, true, salience),
-      ]),
+      scored.map(({ issue, salience }) => [issue.id, buildIssueNode(store, slop, issue, true, salience)]),
     ),
   };
 }

--- a/benchmarks/mcp-vs-slop/app/store.ts
+++ b/benchmarks/mcp-vs-slop/app/store.ts
@@ -52,10 +52,7 @@ export class IssueTrackerStore {
 
   // --- Issues ---
 
-  listIssues(
-    repoId: string,
-    filters?: { status?: "open" | "closed"; label?: string },
-  ): Issue[] {
+  listIssues(repoId: string, filters?: { status?: "open" | "closed"; label?: string }): Issue[] {
     let issues = this.issues.filter((i) => i.repoId === repoId);
     if (filters?.status) issues = issues.filter((i) => i.status === filters.status);
     if (filters?.label) issues = issues.filter((i) => i.labels.includes(filters.label!));

--- a/benchmarks/mcp-vs-slop/harness/agent-runner.ts
+++ b/benchmarks/mcp-vs-slop/harness/agent-runner.ts
@@ -53,13 +53,25 @@ export async function runAgentBenchmark(
       configs.push({ label: "MCP agent", proto: "mcp", run: () => runMcpAgent(genAI, scenario) });
     }
     if (shouldRun("slop")) {
-      configs.push({ label: "SLOP agent (full tree)", proto: "slop", run: () => runSlopAgent(genAI, scenario, "slop", -1, undefined, seed) });
+      configs.push({
+        label: "SLOP agent (full tree)",
+        proto: "slop",
+        run: () => runSlopAgent(genAI, scenario, "slop", -1, undefined, seed),
+      });
     }
     if (shouldRun("slop-optimized")) {
-      configs.push({ label: "SLOP agent (optimized)", proto: "slop-optimized", run: () => runSlopAgent(genAI, scenario, "slop-optimized", -1, { optimized: true }, seed) });
+      configs.push({
+        label: "SLOP agent (optimized)",
+        proto: "slop-optimized",
+        run: () => runSlopAgent(genAI, scenario, "slop-optimized", -1, { optimized: true }, seed),
+      });
     }
     if (shouldRun("slop-basic")) {
-      configs.push({ label: "SLOP agent (basic prompt)", proto: "slop-basic", run: () => runSlopAgent(genAI, scenario, "slop-basic", -1, undefined, seed, true) });
+      configs.push({
+        label: "SLOP agent (basic prompt)",
+        proto: "slop-basic",
+        run: () => runSlopAgent(genAI, scenario, "slop-basic", -1, undefined, seed, true),
+      });
     }
 
     const protocolResults: AgentMetrics[] = [];
@@ -101,9 +113,7 @@ function averageAgentMetrics(runs: AgentMetrics[]): AgentMetrics {
       passed: passCount === totalRuns,
       totalChecks: last.totalChecks,
       passedChecks: Math.round(avg(verifications.map((v) => v!.passedChecks))),
-      failures: passCount === totalRuns
-        ? []
-        : [`Passed ${passCount}/${totalRuns} runs. ` + last.failures.join("; ")],
+      failures: passCount === totalRuns ? [] : [`Passed ${passCount}/${totalRuns} runs. ` + last.failures.join("; ")],
     };
   }
 
@@ -167,7 +177,10 @@ async function runSlopAgent(
         parameters: convertToGeminiSchema({
           type: "object",
           properties: {
-            path: { type: "string", description: "The tree path to load, e.g. a collection path or a specific node path" },
+            path: {
+              type: "string",
+              description: "The tree path to load, e.g. a collection path or a specific node path",
+            },
             depth: { type: "integer", description: "How many levels deep to resolve. -1 for full depth. Default: -1" },
           },
           required: ["path"],
@@ -182,11 +195,13 @@ async function runSlopAgent(
     ];
 
     function buildGeminiTools() {
-      const tools = toolSet.tools.map((t): FunctionDeclaration => ({
-        name: t.function.name,
-        description: t.function.description,
-        parameters: convertToGeminiSchema(t.function.parameters),
-      }));
+      const tools = toolSet.tools.map(
+        (t): FunctionDeclaration => ({
+          name: t.function.name,
+          description: t.function.description,
+          parameters: convertToGeminiSchema(t.function.parameters),
+        }),
+      );
       tools.push(...navigationTools);
       return tools;
     }
@@ -224,7 +239,10 @@ async function runSlopAgent(
     while (maxIterations-- > 0) {
       const parts = response.response.candidates?.[0]?.content?.parts ?? [];
       const fnCalls = parts.filter((p) => "functionCall" in p);
-      const textParts = parts.filter((p) => "text" in p).map((p) => (p as any).text).join("");
+      const textParts = parts
+        .filter((p) => "text" in p)
+        .map((p) => (p as any).text)
+        .join("");
 
       if (textParts) verboseLlmTurn(proto, llmCalls, textParts);
 
@@ -291,7 +309,11 @@ async function runSlopAgent(
           metrics.recordSend(JSON.stringify({ path: resolved.path, action: resolved.action, params: fc.args }).length);
           metrics.recordReceive(JSON.stringify(result).length);
           const rawData = result.data ?? { status: result.status };
-          const responseObj = Array.isArray(rawData) ? { results: rawData } : (typeof rawData === "object" && rawData !== null ? rawData : { value: rawData });
+          const responseObj = Array.isArray(rawData)
+            ? { results: rawData }
+            : typeof rawData === "object" && rawData !== null
+              ? rawData
+              : { value: rawData };
           verboseToolResult(proto, fc.name, responseObj);
           fnResults.push({
             functionResponse: { name: fc.name, response: responseObj },
@@ -349,10 +371,7 @@ async function runSlopAgent(
   };
 }
 
-async function runMcpAgent(
-  genAI: GoogleGenerativeAI,
-  scenario: Scenario,
-): Promise<AgentMetrics> {
+async function runMcpAgent(genAI: GoogleGenerativeAI, scenario: Scenario): Promise<AgentMetrics> {
   const metrics = new MetricsCollector("mcp");
   let inputTokens = 0;
   let outputTokens = 0;
@@ -373,11 +392,13 @@ async function runMcpAgent(
   const { tools: mcpTools } = await client.listTools();
   metrics.endSetup();
 
-  const geminiTools = mcpTools.map((t): FunctionDeclaration => ({
-    name: t.name,
-    description: t.description ?? "",
-    parameters: convertToGeminiSchema(t.inputSchema),
-  }));
+  const geminiTools = mcpTools.map(
+    (t): FunctionDeclaration => ({
+      name: t.name,
+      description: t.description ?? "",
+      parameters: convertToGeminiSchema(t.inputSchema),
+    }),
+  );
 
   const model = genAI.getGenerativeModel({
     model: geminiModel,
@@ -411,7 +432,10 @@ async function runMcpAgent(
   while (maxIterations-- > 0) {
     const parts = response.response.candidates?.[0]?.content?.parts ?? [];
     const fnCalls = parts.filter((p) => "functionCall" in p);
-    const textParts = parts.filter((p) => "text" in p).map((p) => (p as any).text).join("");
+    const textParts = parts
+      .filter((p) => "text" in p)
+      .map((p) => (p as any).text)
+      .join("");
 
     if (textParts) verboseLlmTurn("mcp", llmCalls, textParts);
 
@@ -427,10 +451,11 @@ async function runMcpAgent(
       toolCalls++;
       verboseToolCall("mcp", fc.name, fc.args);
       const result = await client.callTool({ name: fc.name, arguments: fc.args ?? {} });
-      const resultText = (result.content as any[])
-        ?.filter((c: any) => c.type === "text")
-        .map((c: any) => c.text)
-        .join("") ?? "";
+      const resultText =
+        (result.content as any[])
+          ?.filter((c: any) => c.type === "text")
+          .map((c: any) => c.text)
+          .join("") ?? "";
       metrics.recordSend(JSON.stringify({ name: fc.name, arguments: fc.args }).length);
       metrics.recordReceive(resultText.length);
 
@@ -440,7 +465,11 @@ async function runMcpAgent(
       } catch {
         parsed = { text: resultText };
       }
-      const responseObj = Array.isArray(parsed) ? { results: parsed } : (typeof parsed === "object" && parsed !== null ? parsed : { value: parsed });
+      const responseObj = Array.isArray(parsed)
+        ? { results: parsed }
+        : typeof parsed === "object" && parsed !== null
+          ? parsed
+          : { value: parsed };
       verboseToolResult("mcp", fc.name, responseObj);
       fnResults.push({
         functionResponse: { name: fc.name, response: responseObj },
@@ -523,9 +552,7 @@ function toSummary(result: VerificationResult, protocol?: string): VerificationS
     passed: result.passed,
     totalChecks: result.checks.length,
     passedChecks: result.checks.filter((c) => c.passed).length,
-    failures: result.checks
-      .filter((c) => !c.passed)
-      .map((c) => `${c.name}${c.detail ? ` (${c.detail})` : ""}`),
+    failures: result.checks.filter((c) => !c.passed).map((c) => `${c.name}${c.detail ? ` (${c.detail})` : ""}`),
   };
 }
 

--- a/benchmarks/mcp-vs-slop/harness/reporter.ts
+++ b/benchmarks/mcp-vs-slop/harness/reporter.ts
@@ -25,9 +25,7 @@ function pad(s: string, len: number): string {
 }
 
 function renderTable(headers: string[], rows: string[][]): string {
-  const widths = headers.map((h, i) =>
-    Math.max(h.length, ...rows.map((r) => (r[i] ?? "").length), 8),
-  );
+  const widths = headers.map((h, i) => Math.max(h.length, ...rows.map((r) => (r[i] ?? "").length), 8));
   const lines: string[] = [];
 
   lines.push(`| ${headers.map((h, i) => pad(h, widths[i])).join(" | ")} |`);
@@ -86,10 +84,7 @@ function renderScenario(result: ScenarioResult): string {
     const row = [label, ...values];
     if (protocols.length > 1) {
       const nonMcp = protocols.filter((p) => p.protocol !== "mcp");
-      const best = nonMcp.reduce(
-        (min, p) => (getter(p) < getter(min) ? p : min),
-        nonMcp[0],
-      );
+      const best = nonMcp.reduce((min, p) => (getter(p) < getter(min) ? p : min), nonMcp[0]);
       if (best && baseline.protocol === "mcp") {
         row.push(delta(getter(best), getter(baseline)));
       } else {

--- a/benchmarks/mcp-vs-slop/harness/slop-system-prompt.ts
+++ b/benchmarks/mcp-vs-slop/harness/slop-system-prompt.ts
@@ -82,5 +82,9 @@ Use **slop_query** on this node's path to resolve the full node and discover its
  * Combines the domain-agnostic SLOP concepts with the app's current state.
  */
 export function buildSlopSystemPrompt(stateContext: string): string {
-  return SLOP_SYSTEM_PROMPT + stateContext + "\n\nComplete the task using the available tools. When done, respond with \"DONE\".";
+  return (
+    SLOP_SYSTEM_PROMPT +
+    stateContext +
+    '\n\nComplete the task using the available tools. When done, respond with "DONE".'
+  );
 }

--- a/benchmarks/mcp-vs-slop/harness/types.ts
+++ b/benchmarks/mcp-vs-slop/harness/types.ts
@@ -50,61 +50,54 @@ export interface ModelPricing {
 export const MODEL_PRICING: Record<string, ModelPricing> = {
   "gemini-2.5-flash": {
     model: "Gemini 2.5 Flash",
-    inputPerMillion: 0.30,
-    outputPerMillion: 2.50,
+    inputPerMillion: 0.3,
+    outputPerMillion: 2.5,
   },
   "gemini-2.5-pro": {
     model: "Gemini 2.5 Pro",
     inputPerMillion: 1.25,
-    outputPerMillion: 10.00,
+    outputPerMillion: 10.0,
   },
   "gemini-3-flash-preview": {
     model: "Gemini 3 Flash",
-    inputPerMillion: 0.50,
-    outputPerMillion: 3.00,
+    inputPerMillion: 0.5,
+    outputPerMillion: 3.0,
   },
   "gemini-3.1-pro-preview": {
     model: "Gemini 3.1 Pro",
-    inputPerMillion: 2.00,
-    outputPerMillion: 12.00,
+    inputPerMillion: 2.0,
+    outputPerMillion: 12.0,
   },
   "gpt-4.1-nano": {
     model: "GPT-4.1 nano",
-    inputPerMillion: 0.10,
-    outputPerMillion: 0.40,
+    inputPerMillion: 0.1,
+    outputPerMillion: 0.4,
   },
   "gpt-4.1-mini": {
     model: "GPT-4.1 mini",
-    inputPerMillion: 0.40,
-    outputPerMillion: 1.60,
+    inputPerMillion: 0.4,
+    outputPerMillion: 1.6,
   },
   "gpt-4.1": {
     model: "GPT-4.1",
-    inputPerMillion: 2.00,
-    outputPerMillion: 8.00,
+    inputPerMillion: 2.0,
+    outputPerMillion: 8.0,
   },
   "claude-sonnet-4": {
     model: "Claude Sonnet 4",
-    inputPerMillion: 3.00,
-    outputPerMillion: 15.00,
+    inputPerMillion: 3.0,
+    outputPerMillion: 15.0,
   },
   "claude-opus-4": {
     model: "Claude Opus 4",
-    inputPerMillion: 15.00,
-    outputPerMillion: 75.00,
+    inputPerMillion: 15.0,
+    outputPerMillion: 75.0,
   },
 };
 
-export function estimateCost(
-  inputTokens: number,
-  outputTokens: number,
-  model = "gemini-2.5-flash",
-): number {
+export function estimateCost(inputTokens: number, outputTokens: number, model = "gemini-2.5-flash"): number {
   const pricing = MODEL_PRICING[model] ?? MODEL_PRICING["gemini-2.5-flash"];
-  return (
-    (inputTokens / 1_000_000) * pricing.inputPerMillion +
-    (outputTokens / 1_000_000) * pricing.outputPerMillion
-  );
+  return (inputTokens / 1_000_000) * pricing.inputPerMillion + (outputTokens / 1_000_000) * pricing.outputPerMillion;
 }
 
 export interface ScenarioResult {

--- a/benchmarks/mcp-vs-slop/run.ts
+++ b/benchmarks/mcp-vs-slop/run.ts
@@ -40,14 +40,20 @@ setVerbose(values.verbose!);
 // Parse protocol filter: "all", or comma-separated: "mcp,slop-optimized"
 const protocolFilter = values.protocol!;
 const selectedProtocols: Set<string> | null =
-  protocolFilter === "all"
-    ? null
-    : new Set(protocolFilter.split(",").map((s) => s.trim()));
+  protocolFilter === "all" ? null : new Set(protocolFilter.split(",").map((s) => s.trim()));
 
 const allScenarios = [
-  exploreAndAct, triage, bulkUpdate, scaleTriage,
-  negative, contextual, recovery,
-  stateTransitions, crossEntity, conditional, ambiguity,
+  exploreAndAct,
+  triage,
+  bulkUpdate,
+  scaleTriage,
+  negative,
+  contextual,
+  recovery,
+  stateTransitions,
+  crossEntity,
+  conditional,
+  ambiguity,
   complexWorkflow,
 ];
 

--- a/benchmarks/mcp-vs-slop/scenarios/ambiguity.ts
+++ b/benchmarks/mcp-vs-slop/scenarios/ambiguity.ts
@@ -16,12 +16,12 @@ export const ambiguity: Scenario = {
   name: "ambiguity",
   description: "Resolve ambiguous references by reasoning about state",
   agentPrompt:
-    'I need help with a few things, but I don\'t remember the exact issue numbers:\n\n' +
-    '1. There\'s a bug about "connections" somewhere — I think it\'s about the database. Close it, it\'s been resolved.\n' +
+    "I need help with a few things, but I don't remember the exact issue numbers:\n\n" +
+    "1. There's a bug about \"connections\" somewhere — I think it's about the database. Close it, it's been resolved.\n" +
     '2. The "upgrade" issue that\'s already done (closed) — add a comment from "agent" saying "Confirmed: upgrade completed successfully in prod."\n' +
     '3. Someone filed an issue about "Kubernetes" — assign it to "charlie" since he handles infra.\n' +
     '4. There are two issues about "rate limiting" across different repos. Add the label "p0-critical" to both of them.\n\n' +
-    'Figure out which issues I\'m talking about and do the right thing.',
+    "Figure out which issues I'm talking about and do the right thing.",
 
   steps: [
     {
@@ -54,9 +54,7 @@ export const ambiguity: Scenario = {
     const upgradeCommented = closedUpgradeIssues.some((id) =>
       store.listComments(id).some((c) => c.author === "agent" && c.body.toLowerCase().includes("upgrade")),
     );
-    const whichUpgrade = closedUpgradeIssues.find((id) =>
-      store.listComments(id).some((c) => c.author === "agent"),
-    );
+    const whichUpgrade = closedUpgradeIssues.find((id) => store.listComments(id).some((c) => c.author === "agent"));
 
     const checks = [
       {
@@ -67,9 +65,7 @@ export const ambiguity: Scenario = {
       {
         name: "Commented on a closed upgrade issue",
         passed: upgradeCommented,
-        detail: whichUpgrade
-          ? `commented on ${whichUpgrade}`
-          : "no agent comment on any closed upgrade issue",
+        detail: whichUpgrade ? `commented on ${whichUpgrade}` : "no agent comment on any closed upgrade issue",
       },
       {
         name: "Kubernetes issue (issue-14) assigned to charlie",

--- a/benchmarks/mcp-vs-slop/scenarios/bulk-update.ts
+++ b/benchmarks/mcp-vs-slop/scenarios/bulk-update.ts
@@ -13,8 +13,7 @@ import type { IssueTrackerStore } from "../app/store";
 export const bulkUpdate: Scenario = {
   name: "bulk-update",
   description: 'Close all issues labeled "wontfix" across all repos',
-  agentPrompt:
-    'Find all open issues that have the "wontfix" label across all repositories and close them.',
+  agentPrompt: 'Find all open issues that have the "wontfix" label across all repositories and close them.',
 
   steps: [
     {
@@ -27,10 +26,7 @@ export const bulkUpdate: Scenario = {
           if (!issuesNode) continue;
           for (const issue of issuesNode.children ?? []) {
             const props = issue.properties ?? {};
-            if (
-              props.status === "open" &&
-              (props.labels as string[])?.includes("wontfix")
-            ) {
+            if (props.status === "open" && (props.labels as string[])?.includes("wontfix")) {
               _targets.push(issue.id);
             }
           }

--- a/benchmarks/mcp-vs-slop/scenarios/complex-workflow.ts
+++ b/benchmarks/mcp-vs-slop/scenarios/complex-workflow.ts
@@ -33,7 +33,8 @@ import type { IssueTrackerStore } from "../app/store";
  */
 export const complexWorkflow: Scenario = {
   name: "complex-workflow",
-  description: "Sprint planning: find busiest repo, pick top bugs, assign to least-loaded person, summarize, label, clean up",
+  description:
+    "Sprint planning: find busiest repo, pick top bugs, assign to least-loaded person, summarize, label, clean up",
   agentPrompt:
     "I'm preparing for sprint planning. Help me with the following:\n\n" +
     "1. Find which repository has the most open, unassigned bugs (issues with the 'bug' label that have no assignee).\n" +
@@ -67,9 +68,7 @@ export const complexWorkflow: Scenario = {
     // So alice has the fewest → should be assigned.
 
     // Find which issues got the sprint-candidate label
-    const sprintCandidates = store.issues.filter((i) =>
-      i.labels.includes("sprint-candidate"),
-    );
+    const sprintCandidates = store.issues.filter((i) => i.labels.includes("sprint-candidate"));
 
     // Find which repo the agent chose (the one with sprint-candidate issues)
     const chosenRepoId = sprintCandidates.length > 0 ? sprintCandidates[0].repoId : null;
@@ -83,9 +82,7 @@ export const complexWorkflow: Scenario = {
       },
       {
         name: "Both sprint candidates are from the same repo",
-        passed:
-          sprintCandidates.length === 2 &&
-          sprintCandidates[0].repoId === sprintCandidates[1].repoId,
+        passed: sprintCandidates.length === 2 && sprintCandidates[0].repoId === sprintCandidates[1].repoId,
         detail: sprintCandidates.map((i) => `${i.id}@${i.repoId}`).join(", "),
       },
       {
@@ -98,10 +95,7 @@ export const complexWorkflow: Scenario = {
     // If there's a security+bug issue in the chosen repo, it should be one of the candidates
     if (chosenRepoId) {
       const securityBugs = store.issues.filter(
-        (i) =>
-          i.repoId === chosenRepoId &&
-          i.labels.includes("bug") &&
-          i.labels.includes("security"),
+        (i) => i.repoId === chosenRepoId && i.labels.includes("bug") && i.labels.includes("security"),
       );
       if (securityBugs.length > 0) {
         checks.push({
@@ -136,17 +130,13 @@ export const complexWorkflow: Scenario = {
       checks.push({
         name: `${candidate.id} has agent comment`,
         passed: agentComment !== undefined,
-        detail: agentComment
-          ? `"${agentComment.body.slice(0, 50)}..."`
-          : "no agent comment",
+        detail: agentComment ? `"${agentComment.body.slice(0, 50)}..."` : "no agent comment",
       });
     }
 
     // Wontfix issues in the chosen repo should be closed
     if (chosenRepoId) {
-      const wontfixInRepo = store.issues.filter(
-        (i) => i.repoId === chosenRepoId && i.labels.includes("wontfix"),
-      );
+      const wontfixInRepo = store.issues.filter((i) => i.repoId === chosenRepoId && i.labels.includes("wontfix"));
       for (const wf of wontfixInRepo) {
         checks.push({
           name: `${wf.id} (wontfix in ${chosenRepoId}) closed`,

--- a/benchmarks/mcp-vs-slop/scenarios/conditional.ts
+++ b/benchmarks/mcp-vs-slop/scenarios/conditional.ts
@@ -16,11 +16,11 @@ export const conditional: Scenario = {
   name: "conditional",
   description: "Perform different actions based on issue state (comments, labels, assignees)",
   agentPrompt:
-    'Apply these rules to ALL open issues in the frontend repo:\n\n' +
+    "Apply these rules to ALL open issues in the frontend repo:\n\n" +
     '1. If the issue has 2 or more comments, it\'s been discussed enough — add the "needs-review" label.\n' +
     '2. If the issue has 0 comments and no assignee, it\'s been neglected — assign it to "bob" and add a comment from "agent" saying "Assigning to bob for initial triage."\n' +
     '3. If the issue already has the "wontfix" label, skip it entirely — don\'t modify it.\n\n' +
-    'Apply these rules to each open issue independently. Report what you did for each.',
+    "Apply these rules to each open issue independently. Report what you did for each.",
 
   steps: [
     {

--- a/benchmarks/mcp-vs-slop/scenarios/contextual.ts
+++ b/benchmarks/mcp-vs-slop/scenarios/contextual.ts
@@ -20,13 +20,13 @@ export const contextual: Scenario = {
   name: "contextual",
   description: "Multi-turn contextual actions: create, refer by context, handle confirmation",
   agentPrompt:
-    'Perform these steps in order:\n' +
+    "Perform these steps in order:\n" +
     '1. Create a new issue in the "backend" repo titled "API rate limiting needs overhaul" with body "Current rate limiter is per-IP but we need per-user rate limiting with configurable thresholds." and label it "feature".\n' +
     '2. For the issue you just created, add a comment from "agent" saying "I\'ll start by auditing the current rate limiting middleware."\n' +
     '3. For that same issue, also add the "security" label.\n' +
     '4. Now assign that issue to "charlie".\n' +
     '5. Finally, close issue "issue-6" in the backend repo (the one about rate limiting not working on /api/search).\n\n' +
-    'Make sure you complete ALL steps. Refer to the issue you created by its actual ID, not by description.',
+    "Make sure you complete ALL steps. Refer to the issue you created by its actual ID, not by description.",
 
   steps: [
     {
@@ -42,9 +42,7 @@ export const contextual: Scenario = {
 
   verify(store: IssueTrackerStore): VerificationResult {
     // Find the newly created issue
-    const newIssue = store.issues.find(
-      (i) => i.repoId === "backend" && i.title === "API rate limiting needs overhaul",
-    );
+    const newIssue = store.issues.find((i) => i.repoId === "backend" && i.title === "API rate limiting needs overhaul");
 
     const checks = [
       {
@@ -64,22 +62,19 @@ export const contextual: Scenario = {
       },
       {
         name: "Comment added from 'agent' on new issue",
-        passed: newIssue
-          ? store.listComments(newIssue.id).some((c) => c.author === "agent")
-          : false,
-        detail: newIssue
-          ? `comments: ${store.listComments(newIssue.id).length}`
-          : "no issue",
+        passed: newIssue ? store.listComments(newIssue.id).some((c) => c.author === "agent") : false,
+        detail: newIssue ? `comments: ${store.listComments(newIssue.id).length}` : "no issue",
       },
       {
         name: "Comment mentions rate limiting middleware",
         passed: newIssue
-          ? store.listComments(newIssue.id).some((c) =>
-              c.body.toLowerCase().includes("rate limit"),
-            )
+          ? store.listComments(newIssue.id).some((c) => c.body.toLowerCase().includes("rate limit"))
           : false,
         detail: newIssue
-          ? store.listComments(newIssue.id).map((c) => `"${c.body.slice(0, 40)}..."`).join(", ")
+          ? store
+              .listComments(newIssue.id)
+              .map((c) => `"${c.body.slice(0, 40)}..."`)
+              .join(", ")
           : "no issue",
       },
       {

--- a/benchmarks/mcp-vs-slop/scenarios/cross-entity.ts
+++ b/benchmarks/mcp-vs-slop/scenarios/cross-entity.ts
@@ -17,12 +17,12 @@ export const crossEntity: Scenario = {
   name: "cross-entity",
   description: "Use information from comments to act on related issues across repos",
   agentPrompt:
-    'I need you to investigate and connect some related issues:\n\n' +
-    '1. Look at issue-6 in the backend repo (rate limiting on /api/search). Read its comments to understand the root cause.\n' +
+    "I need you to investigate and connect some related issues:\n\n" +
+    "1. Look at issue-6 in the backend repo (rate limiting on /api/search). Read its comments to understand the root cause.\n" +
     '2. The comment on issue-6 mentions the middleware ordering problem. Issue-3 in the frontend repo is about auth token refresh, which also involves middleware. Add a comment from "agent" on issue-3 saying "This may be related to the middleware ordering issue found in issue-6 (backend). The auth middleware and rate limiter may have the same root cause."\n' +
     '3. Since both issues are middleware-related, add the label "middleware" to both issue-6 and issue-3.\n' +
     '4. Both issues are security-sensitive. Make sure both have the "security" label (check first — one of them might already have it).\n' +
-    '5. Assign both issues to the same person — whoever is NOT currently assigned to either. Pick someone from the team: alice, bob, or charlie.',
+    "5. Assign both issues to the same person — whoever is NOT currently assigned to either. Pick someone from the team: alice, bob, or charlie.",
 
   steps: [
     {
@@ -44,7 +44,8 @@ export const crossEntity: Scenario = {
     const checks = [
       {
         name: "Agent commented on issue-3 referencing issue-6",
-        passed: agentComment !== undefined &&
+        passed:
+          agentComment !== undefined &&
           (agentComment.body.includes("issue-6") || agentComment.body.includes("issue 6")),
         detail: agentComment ? `"${agentComment.body.slice(0, 60)}..."` : "no agent comment",
       },
@@ -70,9 +71,7 @@ export const crossEntity: Scenario = {
       },
       {
         name: "Both issues assigned to same person",
-        passed: issue3?.assignee !== null &&
-          issue6?.assignee !== null &&
-          issue3?.assignee === issue6?.assignee,
+        passed: issue3?.assignee !== null && issue6?.assignee !== null && issue3?.assignee === issue6?.assignee,
         detail: `issue-3: ${issue3?.assignee}, issue-6: ${issue6?.assignee}`,
       },
       {

--- a/benchmarks/mcp-vs-slop/scenarios/negative.ts
+++ b/benchmarks/mcp-vs-slop/scenarios/negative.ts
@@ -18,11 +18,11 @@ export const negative: Scenario = {
   name: "negative",
   description: "Ask the agent to perform impossible actions and verify state is unchanged",
   agentPrompt:
-    'Do the following tasks:\n' +
+    "Do the following tasks:\n" +
     '1. Close issue "issue-4" in the frontend repo (it\'s about React 19 upgrade).\n' +
     '2. Assign issue "issue-9" in the backend repo to "dave" (it\'s about PostgreSQL 16 migration).\n' +
     '3. Delete the "infra" repository entirely.\n\n' +
-    'For each task, if you cannot perform it, explain why. Do NOT force or work around limitations.',
+    "For each task, if you cannot perform it, explain why. Do NOT force or work around limitations.",
 
   steps: [
     {
@@ -49,9 +49,7 @@ export const negative: Scenario = {
         // (well, assigning a closed issue is technically possible, but the prompt
         // asks to assign it which implies it should be actionable)
         name: "issue-9 remains as-is (closed, assigned to alice)",
-        passed:
-          store.getIssue("issue-9")?.status === "closed" &&
-          store.getIssue("issue-9")?.assignee === "alice",
+        passed: store.getIssue("issue-9")?.status === "closed" && store.getIssue("issue-9")?.assignee === "alice",
         detail: `status: ${store.getIssue("issue-9")?.status}, assignee: ${store.getIssue("issue-9")?.assignee}`,
       },
       {

--- a/benchmarks/mcp-vs-slop/scenarios/recovery.ts
+++ b/benchmarks/mcp-vs-slop/scenarios/recovery.ts
@@ -23,12 +23,12 @@ export const recovery: Scenario = {
   name: "recovery",
   description: "Recover from impossible action then perform a valid one",
   agentPrompt:
-    'I need you to do two things:\n\n' +
-    '1. First, try to merge pull request #42 in the frontend repo. I think there should be a merge action available.\n\n' +
+    "I need you to do two things:\n\n" +
+    "1. First, try to merge pull request #42 in the frontend repo. I think there should be a merge action available.\n\n" +
     '2. After that, regardless of whether the merge worked, find the open issue about "login form" validation in the frontend repo (issue-1), ' +
     'add a comment from "agent" saying "Investigated: the email regex is missing TLD validation. Fix incoming.", ' +
     'assign it to "bob", and add the "in-progress" label.\n\n' +
-    'If the first task is not possible, explain why and move on to the second task immediately.',
+    "If the first task is not possible, explain why and move on to the second task immediately.",
 
   steps: [
     {
@@ -58,17 +58,15 @@ export const recovery: Scenario = {
         // The valid action: comment added
         name: "Comment added to issue-1 from 'agent'",
         passed: agentComment !== undefined,
-        detail: agentComment
-          ? `"${agentComment.body.slice(0, 50)}..."`
-          : "no agent comment found",
+        detail: agentComment ? `"${agentComment.body.slice(0, 50)}..."` : "no agent comment found",
       },
       {
         // Comment content mentions the fix
         name: "Comment mentions TLD validation or regex",
         passed: agentComment
-          ? (agentComment.body.toLowerCase().includes("tld") ||
-             agentComment.body.toLowerCase().includes("regex") ||
-             agentComment.body.toLowerCase().includes("validation"))
+          ? agentComment.body.toLowerCase().includes("tld") ||
+            agentComment.body.toLowerCase().includes("regex") ||
+            agentComment.body.toLowerCase().includes("validation")
           : false,
         detail: agentComment ? `"${agentComment.body.slice(0, 60)}"` : "no comment",
       },

--- a/benchmarks/mcp-vs-slop/scenarios/scale-triage.ts
+++ b/benchmarks/mcp-vs-slop/scenarios/scale-triage.ts
@@ -23,8 +23,7 @@ interface IssueSummary {
  */
 export const scaleTriage: Scenario = {
   name: "scale-triage",
-  description:
-    'Triage unassigned bugs across 10 repos (~100 issues) — assign to "alice" with "needs-review"',
+  description: 'Triage unassigned bugs across 10 repos (~100 issues) — assign to "alice" with "needs-review"',
   largeDataset: true,
   agentPrompt:
     'Review all open issues across ALL repositories. For every unassigned issue that has the "bug" label, assign it to "alice" and add the "needs-review" label. Work through all repos systematically.',
@@ -41,11 +40,7 @@ export const scaleTriage: Scenario = {
           if (!issuesNode) continue;
           for (const issue of issuesNode.children ?? []) {
             const props = issue.properties ?? {};
-            if (
-              props.status === "open" &&
-              !props.assignee &&
-              (props.labels as string[])?.includes("bug")
-            ) {
+            if (props.status === "open" && !props.assignee && (props.labels as string[])?.includes("bug")) {
               _targets.push(issue.id);
             }
           }
@@ -74,11 +69,7 @@ export const scaleTriage: Scenario = {
           if (!issuesNode) continue;
           for (const issue of issuesNode.children ?? []) {
             const props = issue.properties ?? {};
-            if (
-              props.status === "open" &&
-              !props.assignee &&
-              (props.labels as string[])?.includes("bug")
-            ) {
+            if (props.status === "open" && !props.assignee && (props.labels as string[])?.includes("bug")) {
               // Find the repo id from the tree path
               targets.push({ repoId: repo.id, issueId: issue.id });
             }
@@ -190,31 +181,31 @@ function safeParseJson(text: string): unknown {
 }
 
 function isTextContentBlock(value: unknown): value is { type: "text"; text: string } {
-  return !!value
-    && typeof value === "object"
-    && (value as { type?: unknown }).type === "text"
-    && typeof (value as { text?: unknown }).text === "string";
+  return (
+    !!value &&
+    typeof value === "object" &&
+    (value as { type?: unknown }).type === "text" &&
+    typeof (value as { text?: unknown }).text === "string"
+  );
 }
 
 function isContentResult(value: unknown): value is { content: unknown[] } {
-  return !!value
-    && typeof value === "object"
-    && Array.isArray((value as { content?: unknown }).content);
+  return !!value && typeof value === "object" && Array.isArray((value as { content?: unknown }).content);
 }
 
 function isRepoSummary(value: unknown): value is RepoSummary {
-  return !!value
-    && typeof value === "object"
-    && typeof (value as { id?: unknown }).id === "string";
+  return !!value && typeof value === "object" && typeof (value as { id?: unknown }).id === "string";
 }
 
 function isIssueSummary(value: unknown): value is IssueSummary {
-  return !!value
-    && typeof value === "object"
-    && typeof (value as { id?: unknown }).id === "string"
-    && Array.isArray((value as { labels?: unknown }).labels)
-    && (value as { labels: unknown[] }).labels.every((label) => typeof label === "string")
-    && (typeof (value as { assignee?: unknown }).assignee === "string"
-      || typeof (value as { assignee?: unknown }).assignee === "undefined"
-      || (value as { assignee?: unknown }).assignee === null);
+  return (
+    !!value &&
+    typeof value === "object" &&
+    typeof (value as { id?: unknown }).id === "string" &&
+    Array.isArray((value as { labels?: unknown }).labels) &&
+    (value as { labels: unknown[] }).labels.every((label) => typeof label === "string") &&
+    (typeof (value as { assignee?: unknown }).assignee === "string" ||
+      typeof (value as { assignee?: unknown }).assignee === "undefined" ||
+      (value as { assignee?: unknown }).assignee === null)
+  );
 }

--- a/benchmarks/mcp-vs-slop/scenarios/state-transitions.ts
+++ b/benchmarks/mcp-vs-slop/scenarios/state-transitions.ts
@@ -18,14 +18,14 @@ export const stateTransitions: Scenario = {
   name: "state-transitions",
   description: "Close an issue, verify state changed, reopen it, then close a different one",
   agentPrompt:
-    'Perform these steps in order:\n' +
-    '1. Close issue-1 in the frontend repo (the login form validation bug).\n' +
-    '2. Verify that issue-1 is now closed by checking its status.\n' +
-    '3. Actually, we still need that fix — reopen issue-1.\n' +
+    "Perform these steps in order:\n" +
+    "1. Close issue-1 in the frontend repo (the login form validation bug).\n" +
+    "2. Verify that issue-1 is now closed by checking its status.\n" +
+    "3. Actually, we still need that fix — reopen issue-1.\n" +
     '4. Add a comment from "agent" on issue-1 saying "Reopened — this is still a priority."\n' +
-    '5. Now close issue-5 instead (the deprecated API calls issue in frontend, labeled wontfix).\n' +
+    "5. Now close issue-5 instead (the deprecated API calls issue in frontend, labeled wontfix).\n" +
     '6. Add the "wontfix" label to issue-1 as well, since we\'re deprioritizing validation fixes.\n\n' +
-    'Complete all steps in order.',
+    "Complete all steps in order.",
 
   steps: [
     {

--- a/benchmarks/mcp-vs-slop/scenarios/triage.ts
+++ b/benchmarks/mcp-vs-slop/scenarios/triage.ts
@@ -29,11 +29,7 @@ export const triage: Scenario = {
           if (!issuesNode) continue;
           for (const issue of issuesNode.children ?? []) {
             const props = issue.properties ?? {};
-            if (
-              props.status === "open" &&
-              !props.assignee &&
-              (props.labels as string[])?.includes("bug")
-            ) {
+            if (props.status === "open" && !props.assignee && (props.labels as string[])?.includes("bug")) {
               _targets.push(issue.id);
             }
           }

--- a/biome.json
+++ b/biome.json
@@ -6,10 +6,7 @@
     "useIgnoreFile": true
   },
   "files": {
-    "includes": [
-      "**/*.{js,jsx,cjs,mjs,ts,tsx,cts,mts}",
-      "!examples/full-stack/tanstack-start/src/routeTree.gen.ts"
-    ]
+    "includes": ["**/*.{js,jsx,cjs,mjs,ts,tsx,cts,mts}", "!examples/full-stack/tanstack-start/src/routeTree.gen.ts"]
   },
   "formatter": {
     "indentStyle": "space",

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "includes": [
+      "**/*.{js,jsx,cjs,mjs,ts,tsx,cts,mts}",
+      "!examples/full-stack/tanstack-start/src/routeTree.gen.ts"
+    ]
+  },
+  "formatter": {
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 120
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "jsxQuoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "all",
+      "arrowParentheses": "always",
+      "bracketSpacing": true,
+      "bracketSameLine": false
+    }
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "slop",
+      "devDependencies": {
+        "@biomejs/biome": "^2.4.10",
+      },
     },
     "apps/desktop": {
       "name": "slop-desktop",
@@ -569,6 +572,24 @@
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@biomejs/biome": ["@biomejs/biome@2.4.10", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.10", "@biomejs/cli-darwin-x64": "2.4.10", "@biomejs/cli-linux-arm64": "2.4.10", "@biomejs/cli-linux-arm64-musl": "2.4.10", "@biomejs/cli-linux-x64": "2.4.10", "@biomejs/cli-linux-x64-musl": "2.4.10", "@biomejs/cli-win32-arm64": "2.4.10", "@biomejs/cli-win32-x64": "2.4.10" }, "bin": { "biome": "bin/biome" } }, "sha512-xxA3AphFQ1geij4JTHXv4EeSTda1IFn22ye9LdyVPoJU19fNVl0uzfEuhsfQ4Yue/0FaLs2/ccVi4UDiE7R30w=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vuzzI1cWqDVzOMIkYyHbKqp+AkQq4K7k+UCXWpkYcY/HDn1UxdsbsfgtVpa40shem8Kax4TLDLlx8kMAecgqiw=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-14fzASRo+BPotwp7nWULy2W5xeUyFnTaq1V13Etrrxkrih+ez/2QfgFm5Ehtf5vSjtgx/IJycMMpn5kPd5ZNaA=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-7MH1CMW5uuxQ/s7FLST63qF8B3Hgu2HRdZ7tA1X1+mk+St4JOuIrqdhIBnnyqeyWJNI+Bww7Es5QZ0wIc1Cmkw=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-WrJY6UuiSD/Dh+nwK2qOTu8kdMDlLV3dLMmychIghHPAysWFq1/DGC1pVZx8POE3ZkzKR3PUUnVrtZfMfaJjyQ=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.10", "", { "os": "linux", "cpu": "x64" }, "sha512-tZLvEEi2u9Xu1zAqRjTcpIDGVtldigVvzug2fTuPG0ME/g8/mXpRPcNgLB22bGn6FvLJpHHnqLnwliOu8xjYrg=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.10", "", { "os": "linux", "cpu": "x64" }, "sha512-kDTi3pI6PBN6CiczsWYOyP2zk0IJI08EWEQyDMQWW221rPaaEz6FvjLhnU07KMzLv8q3qSuoB93ua6inSQ55Tw=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.10", "", { "os": "win32", "cpu": "x64" }, "sha512-aW/JU5GuyH4uxMrNYpoC2kjaHlyJGLgIa3XkhPEZI0uKhZhJZU8BuEyJmvgzSPQNGozBwWjC972RaNdcJ9KyJg=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 

--- a/examples/cli/bun/src/cli.ts
+++ b/examples/cli/bun/src/cli.ts
@@ -55,7 +55,7 @@ function timeAgo(date: Date): string {
 
 function formatTags(tags: string[]): string {
   if (!tags.length) return "";
-  return tags.map(t => `${MAGENTA}#${t}${RESET}`).join(" ");
+  return tags.map((t) => `${MAGENTA}#${t}${RESET}`).join(" ");
 }
 
 function taskNumber(id: string): string {
@@ -69,12 +69,12 @@ export async function listTasks(opts: { all?: boolean; tag?: string }): Promise<
   let filtered = tasks;
 
   if (opts.tag) {
-    filtered = filtered.filter(t => t.tags.includes(opts.tag!));
+    filtered = filtered.filter((t) => t.tags.includes(opts.tag!));
   }
 
   if (!opts.all) {
     // Show pending tasks by default, plus recently completed
-    filtered = filtered.filter(t => !t.done);
+    filtered = filtered.filter((t) => !t.done);
   }
 
   if (filtered.length === 0) {
@@ -109,7 +109,7 @@ export async function addTask(title: string, opts: { due?: string; tag?: string 
     id,
     title,
     done: false,
-    tags: opts.tag ? opts.tag.split(",").map(t => t.trim()) : [],
+    tags: opts.tag ? opts.tag.split(",").map((t) => t.trim()) : [],
     notes: "",
     created: new Date().toISOString(),
   };
@@ -150,7 +150,7 @@ export async function editTask(idArg: string, opts: { title?: string; due?: stri
 
   if (opts.title) task.title = opts.title;
   if (opts.due) task.due = parseDate(opts.due);
-  if (opts.tag) task.tags = opts.tag.split(",").map(t => t.trim());
+  if (opts.tag) task.tags = opts.tag.split(",").map((t) => t.trim());
   await save(tasks);
   console.log(`${GREEN}Updated: ${task.title}${RESET}`);
 }
@@ -188,9 +188,8 @@ export async function showNotes(idArg: string, opts: { set?: string }): Promise<
 export async function searchTasks(query: string): Promise<void> {
   const tasks = await load();
   const lower = query.toLowerCase();
-  const matches = tasks.filter(t =>
-    t.title.toLowerCase().includes(lower) ||
-    t.tags.some(tag => tag.toLowerCase().includes(lower))
+  const matches = tasks.filter(
+    (t) => t.title.toLowerCase().includes(lower) || t.tags.some((tag) => tag.toLowerCase().includes(lower)),
   );
 
   if (matches.length === 0) {
@@ -230,13 +229,13 @@ export async function exportTasks(format: string): Promise<void> {
     }
     case "markdown": {
       console.log("# Tasks\n");
-      const pending = tasks.filter(t => !t.done);
-      const done = tasks.filter(t => t.done);
+      const pending = tasks.filter((t) => !t.done);
+      const done = tasks.filter((t) => t.done);
       if (pending.length) {
         console.log("## Pending\n");
         for (const t of pending) {
           const due = t.due ? ` (due: ${t.due})` : "";
-          const tags = t.tags.length ? ` ${t.tags.map(x => `\`${x}\``).join(" ")}` : "";
+          const tags = t.tags.length ? ` ${t.tags.map((x) => `\`${x}\``).join(" ")}` : "";
           console.log(`- [ ] ${t.title}${due}${tags}`);
         }
         console.log();
@@ -244,7 +243,7 @@ export async function exportTasks(format: string): Promise<void> {
       if (done.length) {
         console.log("## Completed\n");
         for (const t of done) {
-          const tags = t.tags.length ? ` ${t.tags.map(x => `\`${x}\``).join(" ")}` : "";
+          const tags = t.tags.length ? ` ${t.tags.map((x) => `\`${x}\``).join(" ")}` : "";
           console.log(`- [x] ${t.title}${tags}`);
         }
       }
@@ -260,7 +259,7 @@ export async function exportTasks(format: string): Promise<void> {
 
 function findTask(tasks: Task[], idArg: string): Task | undefined {
   const id = idArg.startsWith("t-") ? idArg : `t-${idArg}`;
-  const task = tasks.find(t => t.id === id);
+  const task = tasks.find((t) => t.id === id);
   if (!task) {
     console.error(`${RED}Task ${idArg} not found.${RESET}`);
   }
@@ -269,7 +268,7 @@ function findTask(tasks: Task[], idArg: string): Task | undefined {
 
 function findTaskIndex(tasks: Task[], idArg: string): number {
   const id = idArg.startsWith("t-") ? idArg : `t-${idArg}`;
-  const idx = tasks.findIndex(t => t.id === id);
+  const idx = tasks.findIndex((t) => t.id === id);
   if (idx < 0) {
     console.error(`${RED}Task ${idArg} not found.${RESET}`);
   }

--- a/examples/cli/bun/src/index.ts
+++ b/examples/cli/bun/src/index.ts
@@ -1,7 +1,17 @@
 #!/usr/bin/env bun
 
 import { setFilePath } from "./store";
-import { listTasks, addTask, doneTask, undoTask, editTask, deleteTask, showNotes, searchTasks, exportTasks } from "./cli";
+import {
+  listTasks,
+  addTask,
+  doneTask,
+  undoTask,
+  editTask,
+  deleteTask,
+  showNotes,
+  searchTasks,
+  exportTasks,
+} from "./cli";
 import { startSlopMode } from "./slop";
 
 const args = process.argv.slice(2);
@@ -64,21 +74,30 @@ async function runCli(args: string[]) {
 
     case "done": {
       const id = args[1];
-      if (!id) { console.error("Usage: tsk done <id>"); process.exit(1); }
+      if (!id) {
+        console.error("Usage: tsk done <id>");
+        process.exit(1);
+      }
       await doneTask(id);
       break;
     }
 
     case "undo": {
       const id = args[1];
-      if (!id) { console.error("Usage: tsk undo <id>"); process.exit(1); }
+      if (!id) {
+        console.error("Usage: tsk undo <id>");
+        process.exit(1);
+      }
       await undoTask(id);
       break;
     }
 
     case "edit": {
       const id = args[1];
-      if (!id) { console.error("Usage: tsk edit <id> [--title <t>] [--due <d>] [--tag <t>]"); process.exit(1); }
+      if (!id) {
+        console.error("Usage: tsk edit <id> [--title <t>] [--due <d>] [--tag <t>]");
+        process.exit(1);
+      }
       const opts: { title?: string; due?: string; tag?: string } = {};
       for (let i = 2; i < args.length; i++) {
         if (args[i] === "--title" && i + 1 < args.length) opts.title = args[++i];
@@ -91,14 +110,20 @@ async function runCli(args: string[]) {
 
     case "delete": {
       const id = args[1];
-      if (!id) { console.error("Usage: tsk delete <id>"); process.exit(1); }
+      if (!id) {
+        console.error("Usage: tsk delete <id>");
+        process.exit(1);
+      }
       await deleteTask(id);
       break;
     }
 
     case "notes": {
       const id = args[1];
-      if (!id) { console.error("Usage: tsk notes <id> [--set <text>]"); process.exit(1); }
+      if (!id) {
+        console.error("Usage: tsk notes <id> [--set <text>]");
+        process.exit(1);
+      }
       const opts: { set?: string } = {};
       for (let i = 2; i < args.length; i++) {
         if (args[i] === "--set" && i + 1 < args.length) opts.set = args[++i];
@@ -109,7 +134,10 @@ async function runCli(args: string[]) {
 
     case "search": {
       const query = args[1];
-      if (!query) { console.error("Usage: tsk search <query>"); process.exit(1); }
+      if (!query) {
+        console.error("Usage: tsk search <query>");
+        process.exit(1);
+      }
       await searchTasks(query);
       break;
     }

--- a/examples/cli/bun/src/slop.ts
+++ b/examples/cli/bun/src/slop.ts
@@ -1,7 +1,17 @@
 import { SlopServer } from "@slop-ai/server";
 import { listenUnix } from "@slop-ai/server/unix";
 import { load, save, nextId, parseDate, today, computeSalience, sortBySalience, getFilePath, type Task } from "./store";
-import { listTasks, addTask, doneTask, undoTask, editTask, deleteTask, showNotes, searchTasks, exportTasks } from "./cli";
+import {
+  listTasks,
+  addTask,
+  doneTask,
+  undoTask,
+  editTask,
+  deleteTask,
+  showNotes,
+  searchTasks,
+  exportTasks,
+} from "./cli";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { mkdirSync, rmSync } from "node:fs";
@@ -26,7 +36,7 @@ export async function startSlopMode(socketPath?: string): Promise<void> {
 
   // --- User context node ---
   slop.register("user", () => {
-    const totalDone = tasks.filter(t => t.done).length;
+    const totalDone = tasks.filter((t) => t.done).length;
     return {
       type: "context",
       props: {
@@ -39,9 +49,9 @@ export async function startSlopMode(socketPath?: string): Promise<void> {
 
   // --- Tasks collection (dynamic) ---
   slop.register("tasks", () => {
-    const pending = tasks.filter(t => !t.done);
+    const pending = tasks.filter((t) => !t.done);
     const todayStr = today();
-    const overdue = pending.filter(t => t.due && t.due < todayStr);
+    const overdue = pending.filter((t) => t.due && t.due < todayStr);
     const sorted = sortBySalience(tasks);
     const windowed = sorted.slice(0, WINDOW_SIZE);
 
@@ -54,7 +64,7 @@ export async function startSlopMode(socketPath?: string): Promise<void> {
       },
       summary: `${tasks.length} tasks: ${pending.length} pending, ${tasks.length - pending.length} done, ${overdue.length} overdue`,
       window: {
-        items: windowed.map(t => buildTaskItem(t)),
+        items: windowed.map((t) => buildTaskItem(t)),
         total: tasks.length,
         offset: 0,
       },
@@ -67,7 +77,7 @@ export async function startSlopMode(socketPath?: string): Promise<void> {
               id,
               title,
               done: false,
-              tags: params.tags ? (params.tags as string).split(",").map(s => s.trim()) : [],
+              tags: params.tags ? (params.tags as string).split(",").map((s) => s.trim()) : [],
               notes: "",
               created: new Date().toISOString(),
             };
@@ -89,7 +99,7 @@ export async function startSlopMode(socketPath?: string): Promise<void> {
         clear_done: {
           handler: async () => {
             const before = tasks.length;
-            tasks = tasks.filter(t => !t.done);
+            tasks = tasks.filter((t) => !t.done);
             await save(tasks);
             return { removed: before - tasks.length };
           },
@@ -100,14 +110,17 @@ export async function startSlopMode(socketPath?: string): Promise<void> {
         },
         search: {
           handler: async (params) => {
-            const query = (params.query as string ?? "").toLowerCase();
-            const matches = tasks.filter(t =>
-              t.title.toLowerCase().includes(query) ||
-              t.tags.some(tag => tag.toLowerCase().includes(query))
+            const query = ((params.query as string) ?? "").toLowerCase();
+            const matches = tasks.filter(
+              (t) => t.title.toLowerCase().includes(query) || t.tags.some((tag) => tag.toLowerCase().includes(query)),
             );
             return {
-              results: matches.map(t => ({
-                id: t.id, title: t.title, done: t.done, due: t.due, tags: t.tags,
+              results: matches.map((t) => ({
+                id: t.id,
+                title: t.title,
+                done: t.done,
+                due: t.due,
+                tags: t.tags,
               })),
             };
           },
@@ -205,19 +218,27 @@ export async function startSlopMode(socketPath?: string): Promise<void> {
 
   // --- Cleanup on exit ---
   const cleanup = () => {
-    try { rmSync(DISCOVERY_FILE); } catch {}
+    try {
+      rmSync(DISCOVERY_FILE);
+    } catch {}
   };
-  process.on("SIGINT", () => { cleanup(); process.exit(0); });
-  process.on("SIGTERM", () => { cleanup(); process.exit(0); });
+  process.on("SIGINT", () => {
+    cleanup();
+    process.exit(0);
+  });
+  process.on("SIGTERM", () => {
+    cleanup();
+    process.exit(0);
+  });
   process.on("exit", cleanup);
 
   // --- Start Unix socket transport ---
   const handle = listenUnix(slop, sockPath);
 
   // --- Print status to stdout ---
-  const pending = tasks.filter(t => !t.done);
+  const pending = tasks.filter((t) => !t.done);
   const todayStr = today();
-  const overdue = pending.filter(t => t.due && t.due < todayStr);
+  const overdue = pending.filter((t) => t.due && t.due < todayStr);
   console.log(`tsk: listening on ${sockPath}`);
   console.log(`tsk: ${tasks.length} tasks loaded (${pending.length} pending, ${overdue.length} overdue)`);
 
@@ -320,21 +341,30 @@ async function dispatchCliCommand(args: string[], slop: SlopServer): Promise<voi
       }
       case "done": {
         const id = args[1];
-        if (!id) { console.log("Usage: done <id>"); return; }
+        if (!id) {
+          console.log("Usage: done <id>");
+          return;
+        }
         await doneTask(id);
         slop.refresh();
         break;
       }
       case "undo": {
         const id = args[1];
-        if (!id) { console.log("Usage: undo <id>"); return; }
+        if (!id) {
+          console.log("Usage: undo <id>");
+          return;
+        }
         await undoTask(id);
         slop.refresh();
         break;
       }
       case "edit": {
         const id = args[1];
-        if (!id) { console.log("Usage: edit <id> [--title <t>] [--due <d>] [--tag <t>]"); return; }
+        if (!id) {
+          console.log("Usage: edit <id> [--title <t>] [--due <d>] [--tag <t>]");
+          return;
+        }
         const opts: { title?: string; due?: string; tag?: string } = {};
         for (let i = 2; i < args.length; i++) {
           if (args[i] === "--title" && i + 1 < args.length) opts.title = args[++i];
@@ -347,14 +377,20 @@ async function dispatchCliCommand(args: string[], slop: SlopServer): Promise<voi
       }
       case "delete": {
         const id = args[1];
-        if (!id) { console.log("Usage: delete <id>"); return; }
+        if (!id) {
+          console.log("Usage: delete <id>");
+          return;
+        }
         await deleteTask(id);
         slop.refresh();
         break;
       }
       case "notes": {
         const id = args[1];
-        if (!id) { console.log("Usage: notes <id> [--set <text>]"); return; }
+        if (!id) {
+          console.log("Usage: notes <id> [--set <text>]");
+          return;
+        }
         const opts: { set?: string } = {};
         for (let i = 2; i < args.length; i++) {
           if (args[i] === "--set" && i + 1 < args.length) opts.set = args[++i];
@@ -365,7 +401,10 @@ async function dispatchCliCommand(args: string[], slop: SlopServer): Promise<voi
       }
       case "search": {
         const query = args[1];
-        if (!query) { console.log("Usage: search <query>"); return; }
+        if (!query) {
+          console.log("Usage: search <query>");
+          return;
+        }
         await searchTasks(query);
         break;
       }
@@ -429,11 +468,16 @@ function buildTaskItem(task: Task): {
       handler: async () => {
         task.done = false;
         delete task.completed_at;
-        await save(await load().then(all => {
-          const t = all.find(x => x.id === task.id);
-          if (t) { t.done = false; delete t.completed_at; }
-          return all;
-        }));
+        await save(
+          await load().then((all) => {
+            const t = all.find((x) => x.id === task.id);
+            if (t) {
+              t.done = false;
+              delete t.completed_at;
+            }
+            return all;
+          }),
+        );
       },
       label: "Mark incomplete",
       estimate: "instant" as const,
@@ -442,7 +486,7 @@ function buildTaskItem(task: Task): {
     actions.done = {
       handler: async () => {
         const all = await load();
-        const t = all.find(x => x.id === task.id);
+        const t = all.find((x) => x.id === task.id);
         if (t) {
           t.done = true;
           t.completed_at = new Date().toISOString();
@@ -455,11 +499,11 @@ function buildTaskItem(task: Task): {
     actions.edit = {
       handler: async (params: Record<string, unknown>) => {
         const all = await load();
-        const t = all.find(x => x.id === task.id);
+        const t = all.find((x) => x.id === task.id);
         if (t) {
           if (params.title) t.title = params.title as string;
           if (params.due) t.due = parseDate(params.due as string);
-          if (params.tags) t.tags = (params.tags as string).split(",").map(s => s.trim());
+          if (params.tags) t.tags = (params.tags as string).split(",").map((s) => s.trim());
           await save(all);
         }
       },
@@ -476,7 +520,7 @@ function buildTaskItem(task: Task): {
   actions.delete = {
     handler: async () => {
       const all = await load();
-      const idx = all.findIndex(x => x.id === task.id);
+      const idx = all.findIndex((x) => x.id === task.id);
       if (idx >= 0) {
         all.splice(idx, 1);
         await save(all);
@@ -490,7 +534,7 @@ function buildTaskItem(task: Task): {
   actions.read_notes = {
     handler: async () => {
       const all = await load();
-      const t = all.find(x => x.id === task.id);
+      const t = all.find((x) => x.id === task.id);
       return { content: t?.notes ?? "" };
     },
     label: "Read full notes",
@@ -502,7 +546,7 @@ function buildTaskItem(task: Task): {
   actions.write_notes = {
     handler: async (params: Record<string, unknown>) => {
       const all = await load();
-      const t = all.find(x => x.id === task.id);
+      const t = all.find((x) => x.id === task.id);
       if (t) {
         t.notes = params.content as string;
         await save(all);
@@ -521,9 +565,9 @@ function buildTaskItem(task: Task): {
 // --- Discovery file ---
 
 function writeDiscovery(tasks: Task[], sockPath: string) {
-  const pending = tasks.filter(t => !t.done);
+  const pending = tasks.filter((t) => !t.done);
   const todayStr = today();
-  const overdue = pending.filter(t => t.due && t.due < todayStr);
+  const overdue = pending.filter((t) => t.due && t.due < todayStr);
 
   const descriptor = {
     id: "tsk",

--- a/examples/cli/bun/src/store.ts
+++ b/examples/cli/bun/src/store.ts
@@ -117,7 +117,11 @@ export function today(): string {
 }
 
 /** Compute salience and urgency for a task */
-export function computeSalience(task: Task): { salience: number; urgency?: "high" | "medium" | "low"; reason?: string } {
+export function computeSalience(task: Task): {
+  salience: number;
+  urgency?: "high" | "medium" | "low";
+  reason?: string;
+} {
   if (task.done) {
     return { salience: 0.2 };
   }

--- a/examples/cli/test-harness.ts
+++ b/examples/cli/test-harness.ts
@@ -194,7 +194,7 @@ function assertEq(actual: any, expected: any, name: string) {
   assert(
     JSON.stringify(actual) === JSON.stringify(expected),
     name,
-    `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`
+    `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
   );
 }
 
@@ -202,7 +202,7 @@ function assertIncludes(arr: any[], value: any, name: string) {
   assert(
     arr.some((v) => JSON.stringify(v) === JSON.stringify(value)),
     name,
-    `${JSON.stringify(value)} not found in array`
+    `${JSON.stringify(value)} not found in array`,
   );
 }
 
@@ -358,7 +358,7 @@ async function runTests(lang: string) {
     console.log("\n  \x1b[1mComplete task\x1b[0m");
     // Find a pending task to complete
     const pendingTask = updatedTasks?.children?.find(
-      (c: any) => c.properties?.done === false && findAffordance(c, "done")
+      (c: any) => c.properties?.done === false && findAffordance(c, "done"),
     );
     if (pendingTask) {
       client.send({
@@ -405,13 +405,10 @@ async function runTests(lang: string) {
     const notesResult = await client.waitForType("result");
     assertEq(notesResult.id, "inv-notes", "read_notes result has correct id");
     assertEq(notesResult.status, "ok", "read_notes succeeds");
-    assert(
-      notesResult.data?.content != null && notesResult.data.content.length > 0,
-      "read_notes returns content"
-    );
+    assert(notesResult.data?.content != null && notesResult.data.content.length > 0, "read_notes returns content");
     assert(
       notesResult.data?.content?.includes("Milk") || notesResult.data?.content?.includes("milk"),
-      "notes content matches seed data for t-1"
+      "notes content matches seed data for t-1",
     );
 
     // --- Test 7: Search ---
@@ -455,7 +452,6 @@ async function runTests(lang: string) {
     client.send({ type: "unsubscribe", id: "s1" });
     // No response expected for unsubscribe, just verify no crash
     assert(true, "unsubscribe sent without error");
-
   } catch (err: any) {
     console.log(`  \x1b[31m✗ Error: ${err.message}\x1b[0m`);
     failed++;
@@ -484,9 +480,7 @@ async function main() {
     await runTests(lang);
   }
 
-  console.log(
-    `\n\x1b[1mResults: ${passed} passed, ${failed} failed\x1b[0m`
-  );
+  console.log(`\n\x1b[1mResults: ${passed} passed, ${failed} failed\x1b[0m`);
   if (failures.length > 0) {
     console.log("\nFailures:");
     for (const f of failures) {

--- a/examples/desktop/rust/src/app.js
+++ b/examples/desktop/rust/src/app.js
@@ -18,7 +18,7 @@ function invoke(cmd, args = {}) {
   if (window.__TAURI__ && window.__TAURI__.core) {
     return window.__TAURI__.core.invoke(cmd, args);
   }
-  return Promise.reject(new Error('Tauri IPC not available'));
+  return Promise.reject(new Error("Tauri IPC not available"));
 }
 
 // ── Helpers ──
@@ -26,15 +26,15 @@ function invoke(cmd, args = {}) {
 function formatTime(totalSec) {
   const m = Math.floor(totalSec / 60);
   const s = totalSec % 60;
-  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
 }
 
 function formatSessionTime(isoString) {
   try {
     const d = new Date(isoString);
-    return d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+    return d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
   } catch {
-    return '';
+    return "";
   }
 }
 
@@ -45,15 +45,19 @@ function formatDuration(sec) {
 
 function totalDuration(phase, settings) {
   switch (phase) {
-    case 'working': return settings.work_duration_sec;
-    case 'short_break': return settings.short_break_sec;
-    case 'long_break': return settings.long_break_sec;
-    default: return 0;
+    case "working":
+      return settings.work_duration_sec;
+    case "short_break":
+      return settings.short_break_sec;
+    case "long_break":
+      return settings.long_break_sec;
+    default:
+      return 0;
   }
 }
 
 function isBreak(phase) {
-  return phase === 'short_break' || phase === 'long_break';
+  return phase === "short_break" || phase === "long_break";
 }
 
 // ── DOM refs (lazy, grabbed on first render) ──
@@ -61,13 +65,13 @@ let statusLabel, tagDisplay, timerDigits, ringProgress, timerControls, sessionsT
 
 function ensureDom() {
   if (statusLabel) return;
-  statusLabel = document.getElementById('status-label');
-  tagDisplay = document.getElementById('tag-display');
-  timerDigits = document.getElementById('timer-digits');
-  ringProgress = document.getElementById('ring-progress');
-  timerControls = document.getElementById('timer-controls');
-  sessionsTitle = document.getElementById('sessions-title');
-  sessionsList = document.getElementById('sessions-list');
+  statusLabel = document.getElementById("status-label");
+  tagDisplay = document.getElementById("tag-display");
+  timerDigits = document.getElementById("timer-digits");
+  ringProgress = document.getElementById("ring-progress");
+  timerControls = document.getElementById("timer-controls");
+  sessionsTitle = document.getElementById("sessions-title");
+  sessionsList = document.getElementById("sessions-list");
 }
 
 // ── Render ──
@@ -81,33 +85,33 @@ function render(snap) {
   const { phase, paused, time_remaining_sec, current_tag, sessions, settings } = snap;
 
   // Status label
-  statusLabel.textContent = paused ? 'PAUSED' : phase.toUpperCase().replace('_', ' ');
-  statusLabel.className = 'status-label';
+  statusLabel.textContent = paused ? "PAUSED" : phase.toUpperCase().replace("_", " ");
+  statusLabel.className = "status-label";
   if (paused) {
-    statusLabel.classList.add('paused');
-  } else if (phase === 'working') {
-    statusLabel.classList.add('working');
+    statusLabel.classList.add("paused");
+  } else if (phase === "working") {
+    statusLabel.classList.add("working");
   } else if (isBreak(phase)) {
-    statusLabel.classList.add('break');
+    statusLabel.classList.add("break");
   }
 
   // Tag display
-  if (phase === 'working' && current_tag) {
+  if (phase === "working" && current_tag) {
     tagDisplay.innerHTML = `<span class="tag-prefix">WORKING ON:</span><span class="tag-name">"${escapeHtml(current_tag)}"</span>`;
   } else if (isBreak(phase)) {
-    const label = phase === 'short_break' ? 'SHORT BREAK' : 'LONG BREAK';
+    const label = phase === "short_break" ? "SHORT BREAK" : "LONG BREAK";
     tagDisplay.innerHTML = `<span class="tag-prefix">${label}</span><span class="tag-name">Take a break!</span>`;
   } else {
-    tagDisplay.innerHTML = '';
+    tagDisplay.innerHTML = "";
   }
 
   // Timer digits
-  if (phase === 'idle') {
-    timerDigits.textContent = '00:00';
-    timerDigits.className = 'timer-digits idle';
+  if (phase === "idle") {
+    timerDigits.textContent = "00:00";
+    timerDigits.className = "timer-digits idle";
   } else {
     timerDigits.textContent = formatTime(time_remaining_sec);
-    timerDigits.className = 'timer-digits';
+    timerDigits.className = "timer-digits";
   }
 
   // Ring progress
@@ -117,10 +121,10 @@ function render(snap) {
     const fraction = elapsed / total;
     const offset = RING_CIRCUMFERENCE * (1 - fraction);
     ringProgress.style.strokeDashoffset = offset;
-    ringProgress.classList.toggle('break-mode', isBreak(phase));
+    ringProgress.classList.toggle("break-mode", isBreak(phase));
   } else {
     ringProgress.style.strokeDashoffset = RING_CIRCUMFERENCE;
-    ringProgress.classList.remove('break-mode');
+    ringProgress.classList.remove("break-mode");
   }
 
   // Controls
@@ -131,16 +135,16 @@ function render(snap) {
 }
 
 function renderControls(phase, paused) {
-  let html = '';
+  let html = "";
 
-  if (phase === 'idle') {
+  if (phase === "idle") {
     html = `
       <form class="start-form" id="start-form">
         <input type="text" class="start-input" id="tag-input"
           placeholder="What are you working on?" />
         <button type="submit" class="btn btn-primary">START</button>
       </form>`;
-  } else if (phase === 'working' && !paused) {
+  } else if (phase === "working" && !paused) {
     html = `
       <button class="btn btn-secondary" onclick="doCommand('timer_pause')">PAUSE</button>
       <button class="btn btn-secondary" onclick="doCommand('timer_skip')">SKIP</button>
@@ -158,22 +162,22 @@ function renderControls(phase, paused) {
   timerControls.innerHTML = html;
 
   // Bind start form
-  const form = document.getElementById('start-form');
+  const form = document.getElementById("start-form");
   if (form) {
-    form.addEventListener('submit', async (e) => {
+    form.addEventListener("submit", async (e) => {
       e.preventDefault();
-      const input = document.getElementById('tag-input');
+      const input = document.getElementById("tag-input");
       const tag = input.value.trim() || null;
-      await invoke('timer_start', { tag });
+      await invoke("timer_start", { tag });
     });
   }
 }
 
 function renderSessions(sessions) {
   // Show all completed sessions (seed data may have different dates)
-  const todaySessions = sessions.filter(s => s.completed);
+  const todaySessions = sessions.filter((s) => s.completed);
 
-  sessionsTitle.textContent = `TODAY: ${todaySessions.length} POMODORO${todaySessions.length !== 1 ? 'S' : ''}`;
+  sessionsTitle.textContent = `TODAY: ${todaySessions.length} POMODORO${todaySessions.length !== 1 ? "S" : ""}`;
 
   if (todaySessions.length === 0) {
     sessionsList.innerHTML = '<div class="empty-state">No sessions yet today</div>';
@@ -184,18 +188,20 @@ function renderSessions(sessions) {
   const sorted = [...todaySessions].reverse();
 
   sessionsList.innerHTML = sorted
-    .map(s => `
+    .map(
+      (s) => `
       <div class="session-card">
         <span class="session-time">${formatSessionTime(s.started_at)}</span>
         <span class="session-tag">${escapeHtml(s.tag)}</span>
         <span class="session-category">#${escapeHtml(s.category)}</span>
         <span class="session-duration">${formatDuration(s.duration_sec)}</span>
-      </div>`)
-    .join('');
+      </div>`,
+    )
+    .join("");
 }
 
 function escapeHtml(str) {
-  const div = document.createElement('div');
+  const div = document.createElement("div");
   div.textContent = str;
   return div.innerHTML;
 }
@@ -217,10 +223,10 @@ window.doCommand = doCommand;
 
 async function poll() {
   try {
-    const snap = await invoke('get_state');
+    const snap = await invoke("get_state");
     render(snap);
   } catch (e) {
-    console.error('Poll error:', e);
+    console.error("Poll error:", e);
   }
 }
 

--- a/examples/desktop/test-harness.ts
+++ b/examples/desktop/test-harness.ts
@@ -67,12 +67,7 @@ class SlopTestClient {
     this.sockPath = sockPath;
   }
 
-  static async create(
-    cmd: string[],
-    cwd: string,
-    dataFile: string,
-    sockPath: string,
-  ): Promise<SlopTestClient> {
+  static async create(cmd: string[], cwd: string, dataFile: string, sockPath: string): Promise<SlopTestClient> {
     // Desktop apps use env vars, not CLI flags
     const proc = spawn({
       cmd,
@@ -321,7 +316,10 @@ async function runTests(lang: string) {
     assert(timerNode?.properties?.phase != null, "timer has phase property");
     assertEq(timerNode?.properties?.phase, "idle", "timer phase is 'idle'");
     assert(timerNode?.properties?.paused != null, "timer has paused property");
-    assert(timerNode?.properties?.time_remaining_sec != null || timerNode?.properties?.time_remaining_sec === 0, "timer has time_remaining_sec property");
+    assert(
+      timerNode?.properties?.time_remaining_sec != null || timerNode?.properties?.time_remaining_sec === 0,
+      "timer has time_remaining_sec property",
+    );
 
     // Sessions collection properties
     assert(sessionsNode?.properties?.count != null, "sessions has count property");
@@ -511,7 +509,6 @@ async function runTests(lang: string) {
     // No response expected for unsubscribe, just verify no crash
     await Bun.sleep(200);
     assert(true, "unsubscribe sent without error");
-
   } catch (err: any) {
     console.log(`  \x1b[31m✗ Error: ${err.message}\x1b[0m`);
     failed++;
@@ -540,9 +537,7 @@ async function main() {
     await runTests(lang);
   }
 
-  console.log(
-    `\n\x1b[1mResults: ${passed} passed, ${failed} failed\x1b[0m`,
-  );
+  console.log(`\n\x1b[1mResults: ${passed} passed, ${failed} failed\x1b[0m`);
   if (failures.length > 0) {
     console.log("\nFailures:");
     for (const f of failures) {

--- a/examples/desktop/typescript/src/main.js
+++ b/examples/desktop/typescript/src/main.js
@@ -8,8 +8,7 @@ const fs = require("node:fs");
 // ---------------------------------------------------------------------------
 
 const SOCKET_PATH = process.env.POMODORO_SOCK || "/tmp/slop/pomodoro.sock";
-const DATA_FILE =
-  process.env.POMODORO_FILE || path.join(os.homedir(), ".pomodoro", "sessions.json");
+const DATA_FILE = process.env.POMODORO_FILE || path.join(os.homedir(), ".pomodoro", "sessions.json");
 const SEED_FILE = path.join(__dirname, "..", "seed.json");
 const DISCOVERY_DIR = path.join(os.homedir(), ".slop", "providers");
 const DISCOVERY_FILE = path.join(DISCOVERY_DIR, "pomodoro.json");
@@ -256,16 +255,10 @@ function stopTicking() {
 function computeStats() {
   const today = todaySessions();
   const completedToday = today.filter((s) => s.completed);
-  const totalFocusMin = Math.round(
-    completedToday.reduce((a, s) => a + (s.duration_sec || 0), 0) / 60
-  );
+  const totalFocusMin = Math.round(completedToday.reduce((a, s) => a + (s.duration_sec || 0), 0) / 60);
 
   // Streak: count consecutive days with at least 1 completed session
-  const allDates = new Set(
-    sessions
-      .filter((s) => s.completed)
-      .map((s) => s.started_at.slice(0, 10))
-  );
+  const allDates = new Set(sessions.filter((s) => s.completed).map((s) => s.started_at.slice(0, 10)));
   const todayStr = new Date().toISOString().slice(0, 10);
   let streak = 0;
   const d = new Date();
@@ -301,8 +294,7 @@ function notifyRenderer() {
 
 function getState() {
   const stats = computeStats();
-  const pomodorosUntilLong =
-    settings.long_break_interval - (pomodoroCount % settings.long_break_interval);
+  const pomodorosUntilLong = settings.long_break_interval - (pomodoroCount % settings.long_break_interval);
 
   return {
     phase,
@@ -333,8 +325,7 @@ async function startSlopProvider() {
 
   // Timer node — dynamic, returns different affordances based on state
   slop.register("timer", () => {
-    const pomodorosUntilLong =
-      settings.long_break_interval - (pomodoroCount % settings.long_break_interval);
+    const pomodorosUntilLong = settings.long_break_interval - (pomodoroCount % settings.long_break_interval);
 
     const props = {
       phase,
@@ -361,8 +352,7 @@ async function startSlopProvider() {
         params: {
           tag: {
             type: "string",
-            description:
-              "What you're working on (e.g. 'Code review', 'Write docs')",
+            description: "What you're working on (e.g. 'Code review', 'Write docs')",
           },
         },
         estimate: "instant",
@@ -374,26 +364,37 @@ async function startSlopProvider() {
         meta.focus = true;
         meta.reason = `Working: ${formatTime(timeRemaining)} remaining`;
         actions.pause = {
-          handler: async () => { pauseTimer(); return { ok: true }; },
+          handler: async () => {
+            pauseTimer();
+            return { ok: true };
+          },
           label: "Pause timer",
           estimate: "instant",
         };
         actions.skip = {
-          handler: async () => { skipTimer(); return { ok: true }; },
+          handler: async () => {
+            skipTimer();
+            return { ok: true };
+          },
           label: "Skip to next phase",
-          description:
-            "Skip the current timer and advance to the next phase (work -> break, break -> idle)",
+          description: "Skip the current timer and advance to the next phase (work -> break, break -> idle)",
           estimate: "instant",
         };
         actions.stop = {
-          handler: async () => { stopTimer(); return { ok: true }; },
+          handler: async () => {
+            stopTimer();
+            return { ok: true };
+          },
           label: "Stop timer",
           description: "Abandon the current session and return to idle",
           dangerous: true,
           estimate: "instant",
         };
         actions.tag = {
-          handler: async (params) => { tagTimer(params.label); return { ok: true }; },
+          handler: async (params) => {
+            tagTimer(params.label);
+            return { ok: true };
+          },
           label: "Tag session",
           description: "Set or change the tag on the current session",
           params: {
@@ -407,19 +408,28 @@ async function startSlopProvider() {
         meta.urgency = "low";
         meta.reason = `Paused at ${formatTime(timeRemaining)}`;
         actions.resume = {
-          handler: async () => { resumeTimer(); return { ok: true }; },
+          handler: async () => {
+            resumeTimer();
+            return { ok: true };
+          },
           label: "Resume timer",
           estimate: "instant",
         };
         actions.stop = {
-          handler: async () => { stopTimer(); return { ok: true }; },
+          handler: async () => {
+            stopTimer();
+            return { ok: true };
+          },
           label: "Stop timer",
           description: "Abandon the current session and return to idle",
           dangerous: true,
           estimate: "instant",
         };
         actions.tag = {
-          handler: async (params) => { tagTimer(params.label); return { ok: true }; },
+          handler: async (params) => {
+            tagTimer(params.label);
+            return { ok: true };
+          },
           label: "Tag session",
           description: "Set or change the tag on the current session",
           params: {
@@ -431,23 +441,25 @@ async function startSlopProvider() {
     } else {
       // short_break or long_break
       const breakType = phase === "long_break" ? "Long" : "Short";
-      const breakMsg =
-        phase === "long_break"
-          ? "stretch and rest!"
-          : "take a break!";
+      const breakMsg = phase === "long_break" ? "stretch and rest!" : "take a break!";
       if (!paused) {
         meta.salience = 0.9;
         meta.urgency = "medium";
         meta.reason = `${breakType} break: ${formatTime(timeRemaining)} remaining — ${breakMsg}`;
         actions.skip = {
-          handler: async () => { skipTimer(); return { ok: true }; },
+          handler: async () => {
+            skipTimer();
+            return { ok: true };
+          },
           label: "Skip to next phase",
-          description:
-            "Skip the current timer and advance to the next phase (work -> break, break -> idle)",
+          description: "Skip the current timer and advance to the next phase (work -> break, break -> idle)",
           estimate: "instant",
         };
         actions.stop = {
-          handler: async () => { stopTimer(); return { ok: true }; },
+          handler: async () => {
+            stopTimer();
+            return { ok: true };
+          },
           label: "Stop timer",
           description: "Abandon the current session and return to idle",
           dangerous: true,
@@ -458,12 +470,18 @@ async function startSlopProvider() {
         meta.urgency = "low";
         meta.reason = `Paused at ${formatTime(timeRemaining)}`;
         actions.resume = {
-          handler: async () => { resumeTimer(); return { ok: true }; },
+          handler: async () => {
+            resumeTimer();
+            return { ok: true };
+          },
           label: "Resume timer",
           estimate: "instant",
         };
         actions.stop = {
-          handler: async () => { stopTimer(); return { ok: true }; },
+          handler: async () => {
+            stopTimer();
+            return { ok: true };
+          },
           label: "Stop timer",
           description: "Abandon the current session and return to idle",
           dangerous: true,
@@ -577,8 +595,8 @@ function writeDiscovery() {
     phase === "idle"
       ? `Pomodoro timer: idle, ${todaySessions().length} sessions today`
       : phase === "working"
-      ? `Working: ${formatTime(timeRemaining)} remaining on '${currentTag || "Untitled"}'`
-      : `${phase === "long_break" ? "Long" : "Short"} break: ${formatTime(timeRemaining)} remaining`;
+        ? `Working: ${formatTime(timeRemaining)} remaining on '${currentTag || "Untitled"}'`
+        : `${phase === "long_break" ? "Long" : "Short"} break: ${formatTime(timeRemaining)} remaining`;
 
   const descriptor = {
     id: "pomodoro",
@@ -598,8 +616,12 @@ function writeDiscovery() {
 }
 
 function cleanupDiscovery() {
-  try { fs.unlinkSync(DISCOVERY_FILE); } catch {}
-  try { fs.unlinkSync(SOCKET_PATH); } catch {}
+  try {
+    fs.unlinkSync(DISCOVERY_FILE);
+  } catch {}
+  try {
+    fs.unlinkSync(SOCKET_PATH);
+  } catch {}
 }
 
 // ---------------------------------------------------------------------------
@@ -608,12 +630,30 @@ function cleanupDiscovery() {
 
 function setupIPC() {
   ipcMain.handle("get-state", () => getState());
-  ipcMain.handle("start", (_e, tag) => { startTimer(tag); return getState(); });
-  ipcMain.handle("pause", () => { pauseTimer(); return getState(); });
-  ipcMain.handle("resume", () => { resumeTimer(); return getState(); });
-  ipcMain.handle("skip", () => { skipTimer(); return getState(); });
-  ipcMain.handle("stop", () => { stopTimer(); return getState(); });
-  ipcMain.handle("tag", (_e, label) => { tagTimer(label); return getState(); });
+  ipcMain.handle("start", (_e, tag) => {
+    startTimer(tag);
+    return getState();
+  });
+  ipcMain.handle("pause", () => {
+    pauseTimer();
+    return getState();
+  });
+  ipcMain.handle("resume", () => {
+    resumeTimer();
+    return getState();
+  });
+  ipcMain.handle("skip", () => {
+    skipTimer();
+    return getState();
+  });
+  ipcMain.handle("stop", () => {
+    stopTimer();
+    return getState();
+  });
+  ipcMain.handle("tag", (_e, label) => {
+    tagTimer(label);
+    return getState();
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/examples/desktop/typescript/src/renderer/app.js
+++ b/examples/desktop/typescript/src/renderer/app.js
@@ -91,8 +91,7 @@ function updateStatusLabel(phase, paused) {
 function updateTagDisplay(phase, currentTag) {
   if (phase === "working" && currentTag) {
     tagDisplay.innerHTML =
-      `<span class="tag-prefix">WORKING ON:</span>` +
-      `<span class="tag-name">"${escapeHtml(currentTag)}"</span>`;
+      `<span class="tag-prefix">WORKING ON:</span>` + `<span class="tag-name">"${escapeHtml(currentTag)}"</span>`;
   } else if (phase === "short_break" || phase === "long_break") {
     const label = phase === "long_break" ? "LONG BREAK" : "SHORT BREAK";
     tagDisplay.innerHTML = `<span class="tag-prefix">${label}</span>`;

--- a/examples/full-stack/python-react/frontend/src/App.tsx
+++ b/examples/full-stack/python-react/frontend/src/App.tsx
@@ -28,9 +28,7 @@ export default function App() {
     try {
       const data = await api.fetchContacts(search || undefined, activeTag || undefined);
       setContacts(data);
-      setSelectedId((current) => (
-        current && !data.some((contact) => contact.id === current) ? null : current
-      ));
+      setSelectedId((current) => (current && !data.some((contact) => contact.id === current) ? null : current));
     } catch (error) {
       console.warn("[slop] failed to load contacts:", error);
     }
@@ -45,8 +43,12 @@ export default function App() {
     }
   }, []);
 
-  useEffect(() => { loadContacts(); }, [loadContacts]);
-  useEffect(() => { loadTags(); }, [loadTags]);
+  useEffect(() => {
+    loadContacts();
+  }, [loadContacts]);
+  useEffect(() => {
+    loadTags();
+  }, [loadTags]);
 
   const refreshAll = useCallback(async () => {
     await Promise.all([loadContacts(), loadTags()]);
@@ -61,7 +63,9 @@ export default function App() {
       type: "context",
       actions: { refresh: () => refreshRef.current() },
     });
-    return () => { slop.unregister("__adapter"); };
+    return () => {
+      slop.unregister("__adapter");
+    };
   }, []);
 
   // --- Compose handlers ---
@@ -113,11 +117,7 @@ export default function App() {
       <TagFilter activeTag={activeTag} availableTags={tags} onTagChange={setActiveTag} />
 
       <div className="app-body">
-        <ContactList
-          contacts={contacts}
-          selectedId={selectedId}
-          onSelect={setSelectedId}
-        />
+        <ContactList contacts={contacts} selectedId={selectedId} onSelect={setSelectedId} />
         <main className="app-main">
           {selectedId ? (
             <ContactDetail

--- a/examples/full-stack/python-react/frontend/src/api.ts
+++ b/examples/full-stack/python-react/frontend/src/api.ts
@@ -15,9 +15,7 @@ export async function fetchContacts(query?: string, tag?: string): Promise<Conta
   if (query) params.set("q", query);
   if (tag) params.set("tag", tag);
   const qs = params.toString();
-  const data = await json<{ contacts: Contact[] }>(
-    await fetch(`${BASE}/contacts${qs ? `?${qs}` : ""}`, GET_REQUEST)
-  );
+  const data = await json<{ contacts: Contact[] }>(await fetch(`${BASE}/contacts${qs ? `?${qs}` : ""}`, GET_REQUEST));
   return data.contacts;
 }
 
@@ -38,20 +36,20 @@ export async function createContact(data: {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(data),
-    })
+    }),
   );
 }
 
 export async function editContact(
   id: string,
-  data: { name?: string; email?: string; phone?: string; company?: string; title?: string }
+  data: { name?: string; email?: string; phone?: string; company?: string; title?: string },
 ): Promise<Contact> {
   return json(
     await fetch(`${BASE}/contacts/${id}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(data),
-    })
+    }),
   );
 }
 
@@ -101,11 +99,7 @@ export async function addNote(id: string, content: string): Promise<void> {
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
 }
 
-export async function logActivity(
-  id: string,
-  type: string,
-  description: string
-): Promise<void> {
+export async function logActivity(id: string, type: string, description: string): Promise<void> {
   const res = await fetch(`${BASE}/contacts/${id}/activity`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -118,9 +112,9 @@ export async function logActivity(
 
 export async function fetchTags(): Promise<string[]> {
   const data = await json<{ tags: { name: string; contact_count: number }[] }>(
-    await fetch(`${BASE}/tags`, GET_REQUEST)
+    await fetch(`${BASE}/tags`, GET_REQUEST),
   );
-  return data.tags.map(t => t.name);
+  return data.tags.map((t) => t.name);
 }
 
 export async function renameTag(oldName: string, newName: string): Promise<void> {

--- a/examples/full-stack/python-react/frontend/src/components/ComposeForm.tsx
+++ b/examples/full-stack/python-react/frontend/src/components/ComposeForm.tsx
@@ -47,7 +47,9 @@ export default function ComposeForm({
           if (params.company !== undefined) onFieldChange("company", params.company as string);
         },
       },
-      submit: () => { handleSubmit(); },
+      submit: () => {
+        handleSubmit();
+      },
     },
   }));
 
@@ -58,31 +60,22 @@ export default function ComposeForm({
       <div className="compose-form" onClick={(e) => e.stopPropagation()}>
         <div className="compose-header">
           <h3>New Contact</h3>
-          <button className="btn-icon" onClick={onClose}>&times;</button>
+          <button className="btn-icon" onClick={onClose}>
+            &times;
+          </button>
         </div>
         <div className="compose-fields">
-          <input
-            placeholder="Name *"
-            value={name}
-            onChange={(e) => onFieldChange("name", e.target.value)}
-            autoFocus
-          />
-          <input
-            placeholder="Email"
-            value={email}
-            onChange={(e) => onFieldChange("email", e.target.value)}
-          />
-          <input
-            placeholder="Company"
-            value={company}
-            onChange={(e) => onFieldChange("company", e.target.value)}
-          />
+          <input placeholder="Name *" value={name} onChange={(e) => onFieldChange("name", e.target.value)} autoFocus />
+          <input placeholder="Email" value={email} onChange={(e) => onFieldChange("email", e.target.value)} />
+          <input placeholder="Company" value={company} onChange={(e) => onFieldChange("company", e.target.value)} />
         </div>
         <div className="compose-actions">
           <button className="btn-primary" onClick={handleSubmit} disabled={!name.trim()}>
             Create Contact
           </button>
-          <button className="btn-secondary" onClick={onClose}>Cancel</button>
+          <button className="btn-secondary" onClick={onClose}>
+            Cancel
+          </button>
         </div>
       </div>
     </div>

--- a/examples/full-stack/python-react/frontend/src/components/ContactDetail.tsx
+++ b/examples/full-stack/python-react/frontend/src/components/ContactDetail.tsx
@@ -9,12 +9,7 @@ interface Props {
   onContactDeleted: () => void;
 }
 
-export default function ContactDetail({
-  contactId,
-  refreshToken,
-  onContactUpdated,
-  onContactDeleted,
-}: Props) {
+export default function ContactDetail({ contactId, refreshToken, onContactUpdated, onContactDeleted }: Props) {
   const [contact, setContact] = useState<Contact | null>(null);
   const [activity, setActivity] = useState<Activity[]>([]);
   const [editing, setEditing] = useState(false);
@@ -23,23 +18,32 @@ export default function ContactDetail({
 
   useEffect(() => {
     let cancelled = false;
-    void api.fetchContact(contactId).then((data) => {
-      if (cancelled) return;
-      setContact(data);
-      setActivity(data.activity ?? []);
-      setEditing(false);
-      setNewNote("");
-    }).catch((error) => {
-      if (cancelled) return;
-      console.warn("[slop] failed to load contact detail:", error);
-      setContact(null);
-      setActivity([]);
-    });
-    return () => { cancelled = true; };
+    void api
+      .fetchContact(contactId)
+      .then((data) => {
+        if (cancelled) return;
+        setContact(data);
+        setActivity(data.activity ?? []);
+        setEditing(false);
+        setNewNote("");
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        console.warn("[slop] failed to load contact detail:", error);
+        setContact(null);
+        setActivity([]);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [contactId, refreshToken]);
 
   if (!contact) {
-    return <section className="contact-detail"><p className="loading">Loading...</p></section>;
+    return (
+      <section className="contact-detail">
+        <p className="loading">Loading...</p>
+      </section>
+    );
   }
 
   const startEdit = () => {
@@ -122,14 +126,38 @@ export default function ContactDetail({
       <div className="detail-header">
         {editing ? (
           <div className="edit-form">
-            <input value={editForm.name} onChange={(e) => setEditForm({ ...editForm, name: e.target.value })} placeholder="Name" />
-            <input value={editForm.email} onChange={(e) => setEditForm({ ...editForm, email: e.target.value })} placeholder="Email" />
-            <input value={editForm.phone} onChange={(e) => setEditForm({ ...editForm, phone: e.target.value })} placeholder="Phone" />
-            <input value={editForm.company} onChange={(e) => setEditForm({ ...editForm, company: e.target.value })} placeholder="Company" />
-            <input value={editForm.title} onChange={(e) => setEditForm({ ...editForm, title: e.target.value })} placeholder="Title" />
+            <input
+              value={editForm.name}
+              onChange={(e) => setEditForm({ ...editForm, name: e.target.value })}
+              placeholder="Name"
+            />
+            <input
+              value={editForm.email}
+              onChange={(e) => setEditForm({ ...editForm, email: e.target.value })}
+              placeholder="Email"
+            />
+            <input
+              value={editForm.phone}
+              onChange={(e) => setEditForm({ ...editForm, phone: e.target.value })}
+              placeholder="Phone"
+            />
+            <input
+              value={editForm.company}
+              onChange={(e) => setEditForm({ ...editForm, company: e.target.value })}
+              placeholder="Company"
+            />
+            <input
+              value={editForm.title}
+              onChange={(e) => setEditForm({ ...editForm, title: e.target.value })}
+              placeholder="Title"
+            />
             <div className="edit-actions">
-              <button className="btn-primary" onClick={saveEdit}>Save</button>
-              <button className="btn-secondary" onClick={() => setEditing(false)}>Cancel</button>
+              <button className="btn-primary" onClick={saveEdit}>
+                Save
+              </button>
+              <button className="btn-secondary" onClick={() => setEditing(false)}>
+                Cancel
+              </button>
             </div>
           </div>
         ) : (
@@ -152,8 +180,12 @@ export default function ContactDetail({
               </p>
             )}
             <div className="detail-actions">
-              <button className="btn-secondary" onClick={startEdit}>Edit</button>
-              <button className="btn-danger" onClick={handleDelete}>Delete</button>
+              <button className="btn-secondary" onClick={startEdit}>
+                Edit
+              </button>
+              <button className="btn-danger" onClick={handleDelete}>
+                Delete
+              </button>
             </div>
           </>
         )}
@@ -165,10 +197,14 @@ export default function ContactDetail({
           {contact.tags.map((tag) => (
             <span key={tag} className="tag">
               {tag}
-              <button className="tag-remove" onClick={() => handleRemoveTag(tag)}>&times;</button>
+              <button className="tag-remove" onClick={() => handleRemoveTag(tag)}>
+                &times;
+              </button>
             </span>
           ))}
-          <button className="tag-add" onClick={handleAddTag}>+ tag</button>
+          <button className="tag-add" onClick={handleAddTag}>
+            + tag
+          </button>
         </div>
       </div>
 
@@ -180,12 +216,7 @@ export default function ContactDetail({
       )}
 
       <div className="detail-add-note">
-        <textarea
-          placeholder="Add a note..."
-          value={newNote}
-          onChange={(e) => setNewNote(e.target.value)}
-          rows={2}
-        />
+        <textarea placeholder="Add a note..." value={newNote} onChange={(e) => setNewNote(e.target.value)} rows={2} />
         <button className="btn-primary btn-small" onClick={handleAddNote} disabled={!newNote.trim()}>
           Add Note
         </button>

--- a/examples/full-stack/python-react/frontend/src/components/ContactList.tsx
+++ b/examples/full-stack/python-react/frontend/src/components/ContactList.tsx
@@ -53,9 +53,7 @@ export default function ContactList({ contacts, selectedId, onSelect }: Props) {
           </div>
         </button>
       ))}
-      {contacts.length === 0 && (
-        <p className="empty-list">No contacts found.</p>
-      )}
+      {contacts.length === 0 && <p className="empty-list">No contacts found.</p>}
       <div className="contact-count">{contacts.length} contacts</div>
     </aside>
   );

--- a/examples/full-stack/python-react/frontend/src/components/TagFilter.tsx
+++ b/examples/full-stack/python-react/frontend/src/components/TagFilter.tsx
@@ -24,10 +24,7 @@ export default function TagFilter({ activeTag, availableTags, onTagChange }: Pro
 
   return (
     <div className="tag-filter">
-      <button
-        className={`tag-chip ${activeTag === null ? "active" : ""}`}
-        onClick={() => onTagChange(null)}
-      >
+      <button className={`tag-chip ${activeTag === null ? "active" : ""}`} onClick={() => onTagChange(null)}>
         All
       </button>
       {availableTags.map((tag) => (

--- a/examples/full-stack/tanstack-start/src/components/Header.tsx
+++ b/examples/full-stack/tanstack-start/src/components/Header.tsx
@@ -1,26 +1,18 @@
-import { Link } from '@tanstack/react-router'
+import { Link } from "@tanstack/react-router";
 
 export default function Header() {
   return (
     <header className="sticky top-0 z-50 bg-[var(--surface-container-low)] px-4 backdrop-blur-lg">
       <nav className="page-wrap flex items-center gap-x-4 py-3 sm:py-4">
         <div className="flex items-center gap-x-4 text-sm font-semibold">
-          <Link
-            to="/"
-            className="nav-link"
-            activeProps={{ className: 'nav-link is-active' }}
-          >
+          <Link to="/" className="nav-link" activeProps={{ className: "nav-link is-active" }}>
             Home
           </Link>
-          <Link
-            to="/about"
-            className="nav-link"
-            activeProps={{ className: 'nav-link is-active' }}
-          >
+          <Link to="/about" className="nav-link" activeProps={{ className: "nav-link is-active" }}>
             About
           </Link>
         </div>
       </nav>
     </header>
-  )
+  );
 }

--- a/examples/full-stack/tanstack-start/src/router.tsx
+++ b/examples/full-stack/tanstack-start/src/router.tsx
@@ -1,20 +1,20 @@
-import { createRouter as createTanStackRouter } from '@tanstack/react-router'
-import { routeTree } from './routeTree.gen'
+import { createRouter as createTanStackRouter } from "@tanstack/react-router";
+import { routeTree } from "./routeTree.gen";
 
 export function getRouter() {
   const router = createTanStackRouter({
     routeTree,
 
     scrollRestoration: true,
-    defaultPreload: 'intent',
+    defaultPreload: "intent",
     defaultPreloadStaleTime: 0,
-  })
+  });
 
-  return router
+  return router;
 }
 
-declare module '@tanstack/react-router' {
+declare module "@tanstack/react-router" {
   interface Register {
-    router: ReturnType<typeof getRouter>
+    router: ReturnType<typeof getRouter>;
   }
 }

--- a/examples/full-stack/tanstack-start/src/routes/__root.tsx
+++ b/examples/full-stack/tanstack-start/src/routes/__root.tsx
@@ -1,59 +1,59 @@
-import { HeadContent, Outlet, Scripts, createRootRoute } from '@tanstack/react-router'
-import { useSlopUI } from '@slop-ai/tanstack-start'
-import { TanStackRouterDevtoolsPanel } from '@tanstack/react-router-devtools'
-import { TanStackDevtools } from '@tanstack/react-devtools'
-import Header from '../components/Header'
+import { HeadContent, Outlet, Scripts, createRootRoute } from "@tanstack/react-router";
+import { useSlopUI } from "@slop-ai/tanstack-start";
+import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
+import { TanStackDevtools } from "@tanstack/react-devtools";
+import Header from "../components/Header";
 
-import appCss from '../styles.css?url'
+import appCss from "../styles.css?url";
 
-const THEME_INIT_SCRIPT = `(function(){document.documentElement.style.colorScheme='dark'})();`
+const THEME_INIT_SCRIPT = `(function(){document.documentElement.style.colorScheme='dark'})();`;
 
 export const Route = createRootRoute({
   head: () => ({
     meta: [
       {
-        charSet: 'utf-8',
+        charSet: "utf-8",
       },
       {
-        name: 'viewport',
-        content: 'width=device-width, initial-scale=1',
+        name: "viewport",
+        content: "width=device-width, initial-scale=1",
       },
       {
-        title: 'Project Tracker — SLOP + TanStack Start',
+        title: "Project Tracker — SLOP + TanStack Start",
       },
       {
-        name: 'slop',
-        content: 'ws://localhost:3000/slop',
+        name: "slop",
+        content: "ws://localhost:3000/slop",
       },
     ],
     links: [
       {
-        rel: 'icon',
-        type: 'image/svg+xml',
-        href: '/favicon.svg',
+        rel: "icon",
+        type: "image/svg+xml",
+        href: "/favicon.svg",
       },
       {
-        rel: 'preconnect',
-        href: 'https://fonts.googleapis.com',
+        rel: "preconnect",
+        href: "https://fonts.googleapis.com",
       },
       {
-        rel: 'preconnect',
-        href: 'https://fonts.gstatic.com',
-        crossOrigin: 'anonymous',
+        rel: "preconnect",
+        href: "https://fonts.gstatic.com",
+        crossOrigin: "anonymous",
       },
       {
-        rel: 'stylesheet',
+        rel: "stylesheet",
         href: appCss,
       },
     ],
   }),
   shellComponent: RootDocument,
   component: RootLayout,
-})
+});
 
 function RootLayout() {
-  useSlopUI()
-  return <Outlet />
+  useSlopUI();
+  return <Outlet />;
 }
 
 function RootDocument({ children }: { children: React.ReactNode }) {
@@ -68,11 +68,11 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         {children}
         <TanStackDevtools
           config={{
-            position: 'bottom-right',
+            position: "bottom-right",
           }}
           plugins={[
             {
-              name: 'Tanstack Router',
+              name: "Tanstack Router",
               render: <TanStackRouterDevtoolsPanel />,
             },
           ]}
@@ -80,5 +80,5 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <Scripts />
       </body>
     </html>
-  )
+  );
 }

--- a/examples/full-stack/tanstack-start/src/routes/about.tsx
+++ b/examples/full-stack/tanstack-start/src/routes/about.tsx
@@ -1,8 +1,8 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute } from "@tanstack/react-router";
 
-export const Route = createFileRoute('/about')({
+export const Route = createFileRoute("/about")({
   component: About,
-})
+});
 
 function About() {
   return (
@@ -13,11 +13,10 @@ function About() {
           A small starter with room to grow.
         </h1>
         <p className="m-0 max-w-3xl text-base leading-8 text-[var(--on-surface-variant)]">
-          TanStack Start gives you type-safe routing, server functions, and
-          modern SSR defaults. Use this as a clean foundation, then layer in
-          your own routes, styling, and add-ons.
+          TanStack Start gives you type-safe routing, server functions, and modern SSR defaults. Use this as a clean
+          foundation, then layer in your own routes, styling, and add-ons.
         </p>
       </section>
     </main>
-  )
+  );
 }

--- a/examples/full-stack/tanstack-start/src/routes/index.tsx
+++ b/examples/full-stack/tanstack-start/src/routes/index.tsx
@@ -1,76 +1,76 @@
-import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
-import { createServerFn } from '@tanstack/react-start'
-import { useState } from 'react'
-import { useSlop } from '@slop-ai/tanstack-start'
-import { slopMiddleware } from '../server/middleware'
+import { createFileRoute, Link, useRouter } from "@tanstack/react-router";
+import { createServerFn } from "@tanstack/react-start";
+import { useState } from "react";
+import { useSlop } from "@slop-ai/tanstack-start";
+import { slopMiddleware } from "../server/middleware";
 
-const fetchProjects = createServerFn({ method: 'GET' }).handler(async () => {
-  const { setResponseHeaders } = await import('@tanstack/react-start/server')
-  const { getProjects, getTasksForProject } = await import('../server/state')
-  setResponseHeaders({ 'Cache-Control': 'no-store' })
+const fetchProjects = createServerFn({ method: "GET" }).handler(async () => {
+  const { setResponseHeaders } = await import("@tanstack/react-start/server");
+  const { getProjects, getTasksForProject } = await import("../server/state");
+  setResponseHeaders({ "Cache-Control": "no-store" });
   return {
     projects: getProjects().map((p) => ({
       ...p,
       taskCount: getTasksForProject(p.id).length,
       doneCount: getTasksForProject(p.id).filter((t) => t.done).length,
     })),
-  }
-})
+  };
+});
 
-const createProjectFn = createServerFn({ method: 'POST' })
+const createProjectFn = createServerFn({ method: "POST" })
   .middleware([slopMiddleware])
   .inputValidator((d: { name: string }) => d)
   .handler(async ({ data }) => {
-    const { addProject } = await import('../server/state')
-    addProject(data.name)
-  })
+    const { addProject } = await import("../server/state");
+    addProject(data.name);
+  });
 
-export const Route = createFileRoute('/')({
+export const Route = createFileRoute("/")({
   loader: () => fetchProjects(),
   component: ProjectsPage,
-})
+});
 
 function ProjectsPage() {
-  const router = useRouter()
-  const { projects } = Route.useLoaderData()
-  const [filter, setFilter] = useState<'all' | 'active' | 'archived'>('all')
-  const [newName, setNewName] = useState('')
+  const router = useRouter();
+  const { projects } = Route.useLoaderData();
+  const [filter, setFilter] = useState<"all" | "active" | "archived">("all");
+  const [newName, setNewName] = useState("");
 
   const createProject = async () => {
-    const trimmedName = newName.trim()
-    if (!trimmedName) return
-    await createProjectFn({ data: { name: trimmedName } })
-    await router.invalidate()
-    setNewName('')
-  }
+    const trimmedName = newName.trim();
+    if (!trimmedName) return;
+    await createProjectFn({ data: { name: trimmedName } });
+    await router.invalidate();
+    setNewName("");
+  };
 
-  useSlop('filters', {
-    type: 'status',
+  useSlop("filters", {
+    type: "status",
     props: { status: filter },
     actions: {
       set_filter: {
-        params: { status: 'string' },
+        params: { status: "string" },
         handler: (params: any) => setFilter(params.status),
       },
     },
-  })
+  });
 
-  useSlop('create_form', {
-    type: 'view',
+  useSlop("create_form", {
+    type: "view",
     props: { name: newName },
     actions: {
       type: {
-        params: { value: 'string' },
+        params: { value: "string" },
         handler: (params: any) => setNewName(params.value),
       },
       submit: async () => {
-        await createProject()
+        await createProject();
       },
-      clear: () => setNewName(''),
+      clear: () => setNewName(""),
     },
-  })
+  });
 
-  const filtered = projects.filter((p) => filter === 'all' || p.status === filter)
+  const filtered = projects.filter((p) => filter === "all" || p.status === filter);
 
   return (
     <main className="page-wrap px-4 pb-8 pt-14">
@@ -78,14 +78,12 @@ function ProjectsPage() {
         <div className="mb-8 flex items-center justify-between">
           <h1 className="display-title text-2xl font-bold text-[var(--on-surface)]">Projects</h1>
           <div className="flex gap-2">
-            {(['all', 'active', 'archived'] as const).map((f) => (
+            {(["all", "active", "archived"] as const).map((f) => (
               <button
                 key={f}
                 onClick={() => setFilter(f)}
                 className={`filter-chip px-4 py-1.5 transition ${
-                  filter === f
-                    ? 'filter-chip--active'
-                    : 'filter-chip--inactive'
+                  filter === f ? "filter-chip--active" : "filter-chip--inactive"
                 }`}
               >
                 {f}
@@ -99,13 +97,15 @@ function ProjectsPage() {
             value={newName}
             onChange={(e) => setNewName(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') void createProject()
+              if (e.key === "Enter") void createProject();
             }}
             placeholder="New project name..."
             className="slop-input flex-1 px-4 py-2.5 text-sm"
           />
           <button
-            onClick={() => { void createProject() }}
+            onClick={() => {
+              void createProject();
+            }}
             className="btn-primary px-5 py-2.5 text-sm"
           >
             Create
@@ -124,9 +124,7 @@ function ProjectsPage() {
                 <div className="font-semibold text-[var(--on-surface)]">{p.name}</div>
                 <div className="mt-1 font-mono text-xs tracking-[0.05em] text-[var(--on-surface-variant)]">
                   {p.taskCount} tasks · {p.doneCount} done
-                  {p.status === 'archived' && (
-                    <span className="ml-2 text-[var(--secondary)] opacity-60">ARCHIVED</span>
-                  )}
+                  {p.status === "archived" && <span className="ml-2 text-[var(--secondary)] opacity-60">ARCHIVED</span>}
                 </div>
               </div>
               <span className="text-[var(--on-surface-variant)]">&rarr;</span>
@@ -136,7 +134,7 @@ function ProjectsPage() {
 
         {filtered.length === 0 && (
           <p className="py-10 text-center text-[var(--on-surface-variant)]">
-            No {filter === 'all' ? '' : filter} projects.
+            No {filter === "all" ? "" : filter} projects.
           </p>
         )}
 
@@ -145,5 +143,5 @@ function ProjectsPage() {
         </p>
       </div>
     </main>
-  )
+  );
 }

--- a/examples/full-stack/tanstack-start/src/routes/projects.$id.tsx
+++ b/examples/full-stack/tanstack-start/src/routes/projects.$id.tsx
@@ -1,112 +1,115 @@
-import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
-import { createServerFn } from '@tanstack/react-start'
-import { useState } from 'react'
-import { useSlop } from '@slop-ai/tanstack-start'
-import { slopMiddleware } from '../server/middleware'
+import { createFileRoute, Link, useRouter } from "@tanstack/react-router";
+import { createServerFn } from "@tanstack/react-start";
+import { useState } from "react";
+import { useSlop } from "@slop-ai/tanstack-start";
+import { slopMiddleware } from "../server/middleware";
 
-const fetchProject = createServerFn({ method: 'GET' })
+const fetchProject = createServerFn({ method: "GET" })
   .inputValidator((d: string) => d)
   .handler(async ({ data: id }) => {
-    const { setResponseHeaders } = await import('@tanstack/react-start/server')
-    const { getProject, getTasksForProject } = await import('../server/state')
-    setResponseHeaders({ 'Cache-Control': 'no-store' })
-    const project = getProject(id)
-    if (!project) throw new Error('Project not found')
-    return { project, tasks: getTasksForProject(id) }
-  })
+    const { setResponseHeaders } = await import("@tanstack/react-start/server");
+    const { getProject, getTasksForProject } = await import("../server/state");
+    setResponseHeaders({ "Cache-Control": "no-store" });
+    const project = getProject(id);
+    if (!project) throw new Error("Project not found");
+    return { project, tasks: getTasksForProject(id) };
+  });
 
-const addTaskFn = createServerFn({ method: 'POST' })
+const addTaskFn = createServerFn({ method: "POST" })
   .middleware([slopMiddleware])
   .inputValidator((d: { projectId: string; title: string }) => d)
   .handler(async ({ data }) => {
-    const { addTask } = await import('../server/state')
-    addTask(data.projectId, data.title)
-  })
+    const { addTask } = await import("../server/state");
+    addTask(data.projectId, data.title);
+  });
 
-const toggleTaskFn = createServerFn({ method: 'POST' })
+const toggleTaskFn = createServerFn({ method: "POST" })
   .middleware([slopMiddleware])
   .inputValidator((d: string) => d)
   .handler(async ({ data: id }) => {
-    const { toggleTask } = await import('../server/state')
-    toggleTask(id)
-  })
+    const { toggleTask } = await import("../server/state");
+    toggleTask(id);
+  });
 
-const deleteTaskFn = createServerFn({ method: 'POST' })
+const deleteTaskFn = createServerFn({ method: "POST" })
   .middleware([slopMiddleware])
   .inputValidator((d: string) => d)
   .handler(async ({ data: id }) => {
-    const { deleteTask } = await import('../server/state')
-    deleteTask(id)
-  })
+    const { deleteTask } = await import("../server/state");
+    deleteTask(id);
+  });
 
-const renameProjectFn = createServerFn({ method: 'POST' })
+const renameProjectFn = createServerFn({ method: "POST" })
   .middleware([slopMiddleware])
   .inputValidator((d: { id: string; name: string }) => d)
   .handler(async ({ data }) => {
-    const { renameProject } = await import('../server/state')
-    renameProject(data.id, data.name)
-  })
+    const { renameProject } = await import("../server/state");
+    renameProject(data.id, data.name);
+  });
 
-export const Route = createFileRoute('/projects/$id')({
+export const Route = createFileRoute("/projects/$id")({
   loader: ({ params }) => fetchProject({ data: params.id }),
   component: ProjectDetailPage,
-})
+});
 
 function ProjectDetailPage() {
-  const router = useRouter()
-  const { project, tasks } = Route.useLoaderData()
-  const [newTask, setNewTask] = useState('')
-  const [editing, setEditing] = useState(false)
-  const [editName, setEditName] = useState(project.name)
+  const router = useRouter();
+  const { project, tasks } = Route.useLoaderData();
+  const [newTask, setNewTask] = useState("");
+  const [editing, setEditing] = useState(false);
+  const [editName, setEditName] = useState(project.name);
 
   const addTask = async () => {
-    const trimmedTask = newTask.trim()
-    if (!trimmedTask) return
-    await addTaskFn({ data: { projectId: project.id, title: trimmedTask } })
-    await router.invalidate()
-    setNewTask('')
-  }
+    const trimmedTask = newTask.trim();
+    if (!trimmedTask) return;
+    await addTaskFn({ data: { projectId: project.id, title: trimmedTask } });
+    await router.invalidate();
+    setNewTask("");
+  };
 
   const saveProjectName = async () => {
-    await renameProjectFn({ data: { id: project.id, name: editName } })
-    await router.invalidate()
-    setEditing(false)
-  }
+    await renameProjectFn({ data: { id: project.id, name: editName } });
+    await router.invalidate();
+    setEditing(false);
+  };
 
   const toggleTask = async (taskId: string) => {
-    await toggleTaskFn({ data: taskId })
-    await router.invalidate()
-  }
+    await toggleTaskFn({ data: taskId });
+    await router.invalidate();
+  };
 
   const removeTask = async (taskId: string) => {
-    await deleteTaskFn({ data: taskId })
-    await router.invalidate()
-  }
+    await deleteTaskFn({ data: taskId });
+    await router.invalidate();
+  };
 
-  useSlop('task_form', {
-    type: 'view',
+  useSlop("task_form", {
+    type: "view",
     props: { text: newTask },
     actions: {
-      type: { params: { value: 'string' }, handler: (params: any) => setNewTask(params.value) },
+      type: { params: { value: "string" }, handler: (params: any) => setNewTask(params.value) },
       submit: async () => {
-        await addTask()
+        await addTask();
       },
-      clear: () => setNewTask(''),
+      clear: () => setNewTask(""),
     },
-  })
+  });
 
-  useSlop('edit_mode', {
-    type: 'status',
+  useSlop("edit_mode", {
+    type: "status",
     props: { editing, name: editName },
     actions: {
-      start_edit: () => { setEditing(true); setEditName(project.name) },
-      type_name: { params: { value: 'string' }, handler: (params: any) => setEditName(params.value) },
+      start_edit: () => {
+        setEditing(true);
+        setEditName(project.name);
+      },
+      type_name: { params: { value: "string" }, handler: (params: any) => setEditName(params.value) },
       save: async () => {
-        await saveProjectName()
+        await saveProjectName();
       },
       cancel: () => setEditing(false),
     },
-  })
+  });
 
   return (
     <main className="page-wrap px-4 pb-8 pt-14">
@@ -122,22 +125,21 @@ function ProjectDetailPage() {
                 value={editName}
                 onChange={(e) => setEditName(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter') void saveProjectName()
-                  if (e.key === 'Escape') setEditing(false)
+                  if (e.key === "Enter") void saveProjectName();
+                  if (e.key === "Escape") setEditing(false);
                 }}
                 className="slop-input flex-1 px-4 py-2 text-xl font-bold"
                 autoFocus
               />
               <button
-                onClick={() => { void saveProjectName() }}
+                onClick={() => {
+                  void saveProjectName();
+                }}
                 className="btn-primary px-4 py-2 text-sm"
               >
                 Save
               </button>
-              <button
-                onClick={() => setEditing(false)}
-                className="btn-ghost px-4 py-2 text-sm"
-              >
+              <button onClick={() => setEditing(false)} className="btn-ghost px-4 py-2 text-sm">
                 Cancel
               </button>
             </>
@@ -145,7 +147,10 @@ function ProjectDetailPage() {
             <>
               <h1 className="display-title text-2xl font-bold text-[var(--on-surface)]">{project.name}</h1>
               <button
-                onClick={() => { setEditing(true); setEditName(project.name) }}
+                onClick={() => {
+                  setEditing(true);
+                  setEditName(project.name);
+                }}
                 className="btn-ghost rounded-[4px] px-3 py-1 text-xs transition hover:bg-[var(--surface-container)]"
               >
                 Edit
@@ -159,13 +164,15 @@ function ProjectDetailPage() {
             value={newTask}
             onChange={(e) => setNewTask(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') void addTask()
+              if (e.key === "Enter") void addTask();
             }}
             placeholder="Add a task..."
             className="slop-input flex-1 px-4 py-2.5 text-sm"
           />
           <button
-            onClick={() => { void addTask() }}
+            onClick={() => {
+              void addTask();
+            }}
             className="btn-primary px-5 py-2.5 text-sm"
           >
             Add
@@ -178,14 +185,20 @@ function ProjectDetailPage() {
               <input
                 type="checkbox"
                 checked={t.done}
-                onChange={() => { void toggleTask(t.id) }}
+                onChange={() => {
+                  void toggleTask(t.id);
+                }}
                 className="h-4 w-4"
               />
-              <span className={`flex-1 text-sm ${t.done ? 'text-[var(--on-surface-variant)] line-through opacity-50' : 'text-[var(--on-surface)]'}`}>
+              <span
+                className={`flex-1 text-sm ${t.done ? "text-[var(--on-surface-variant)] line-through opacity-50" : "text-[var(--on-surface)]"}`}
+              >
                 {t.title}
               </span>
               <button
-                onClick={() => { void removeTask(t.id) }}
+                onClick={() => {
+                  void removeTask(t.id);
+                }}
                 className="btn-ghost text-sm text-[var(--error)] hover:text-[var(--error)]"
               >
                 &times;
@@ -203,5 +216,5 @@ function ProjectDetailPage() {
         </p>
       </div>
     </main>
-  )
+  );
 }

--- a/examples/full-stack/tanstack-start/src/server/state.ts
+++ b/examples/full-stack/tanstack-start/src/server/state.ts
@@ -42,12 +42,15 @@ export function getTasksForProject(id: string): Task[] {
 }
 
 export function addProject(name: string) {
-  state.projects = [...state.projects, {
-    id: `id-${state.nextId++}`,
-    name,
-    status: "active",
-    created: new Date().toISOString().split("T")[0],
-  }];
+  state.projects = [
+    ...state.projects,
+    {
+      id: `id-${state.nextId++}`,
+      name,
+      status: "active",
+      created: new Date().toISOString().split("T")[0],
+    },
+  ];
 }
 
 export function archiveProject(id: string) {
@@ -57,22 +60,15 @@ export function archiveProject(id: string) {
 }
 
 export function renameProject(id: string, name: string) {
-  state.projects = state.projects.map((project: Project) =>
-    project.id === id ? { ...project, name } : project,
-  );
+  state.projects = state.projects.map((project: Project) => (project.id === id ? { ...project, name } : project));
 }
 
 export function addTask(projectId: string, title: string) {
-  state.tasks = [
-    ...state.tasks,
-    { id: `id-${state.nextId++}`, projectId, title, done: false },
-  ];
+  state.tasks = [...state.tasks, { id: `id-${state.nextId++}`, projectId, title, done: false }];
 }
 
 export function toggleTask(id: string) {
-  state.tasks = state.tasks.map((task: Task) =>
-    task.id === id ? { ...task, done: !task.done } : task,
-  );
+  state.tasks = state.tasks.map((task: Task) => (task.id === id ? { ...task, done: !task.done } : task));
 }
 
 export function deleteTask(id: string) {

--- a/examples/full-stack/tanstack-start/vite.config.ts
+++ b/examples/full-stack/tanstack-start/vite.config.ts
@@ -1,103 +1,105 @@
-import { defineConfig } from 'vite'
-import type { IncomingMessage } from 'node:http'
-import type { Socket } from 'node:net'
-import { devtools } from '@tanstack/devtools-vite'
-import tsconfigPaths from 'vite-tsconfig-paths'
+import { defineConfig } from "vite";
+import type { IncomingMessage } from "node:http";
+import type { Socket } from "node:net";
+import { devtools } from "@tanstack/devtools-vite";
+import tsconfigPaths from "vite-tsconfig-paths";
 
-import { tanstackStart } from '@tanstack/react-start/plugin/vite'
+import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 
-import viteReact from '@vitejs/plugin-react'
-import tailwindcss from '@tailwindcss/vite'
-import type { SlopServer } from '@slop-ai/server'
-import { WebSocket, WebSocketServer } from 'ws'
+import viteReact from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import type { SlopServer } from "@slop-ai/server";
+import { WebSocket, WebSocketServer } from "ws";
 
 interface SlopModule {
-  slop: SlopServer
+  slop: SlopServer;
 }
 
 interface SlopPeer {
-  send(data: string): void
-  close(): void
-  __slopRequest: IncomingMessage
+  send(data: string): void;
+  close(): void;
+  __slopRequest: IncomingMessage;
 }
 
 interface SlopPeerMessage {
-  text(): string
-  toString(): string
+  text(): string;
+  toString(): string;
 }
 
 interface SlopWebSocketHandler {
-  open(peer: SlopPeer): void
-  message(peer: SlopPeer, message: SlopPeerMessage): void
-  close(peer: SlopPeer): void
+  open(peer: SlopPeer): void;
+  message(peer: SlopPeer, message: SlopPeerMessage): void;
+  close(peer: SlopPeer): void;
 }
 
 interface TanstackStartServerModule {
   createWebSocketHandler(options: {
-    resolve: () => SlopServer | Promise<SlopServer>
-    uiMountPath?: string
-  }): SlopWebSocketHandler
+    resolve: () => SlopServer | Promise<SlopServer>;
+    uiMountPath?: string;
+  }): SlopWebSocketHandler;
 }
 
 const config = defineConfig({
   plugins: [
     devtools(),
-    tsconfigPaths({ projects: ['./tsconfig.json'] }),
+    tsconfigPaths({ projects: ["./tsconfig.json"] }),
     tailwindcss(),
     tanstackStart(),
     viteReact(),
     {
-      name: 'slop-adapter',
+      name: "slop-adapter",
       configureServer(server) {
-        const httpServer = server.httpServer
-        if (!httpServer) return
+        const httpServer = server.httpServer;
+        if (!httpServer) return;
 
-        httpServer.once('listening', async () => {
-          const slopModule = await server.ssrLoadModule('./src/server/slop.ts')
-          const tanstackModule = await server.ssrLoadModule('@slop-ai/tanstack-start/server')
+        httpServer.once("listening", async () => {
+          const slopModule = await server.ssrLoadModule("./src/server/slop.ts");
+          const tanstackModule = await server.ssrLoadModule("@slop-ai/tanstack-start/server");
           if (!isSlopModule(slopModule) || !isTanstackStartServerModule(tanstackModule)) {
-            throw new Error('[slop] failed to load TanStack Start SLOP modules')
+            throw new Error("[slop] failed to load TanStack Start SLOP modules");
           }
 
-          const handler = tanstackModule.createWebSocketHandler({ resolve: () => slopModule.slop })
-          const wss = new WebSocketServer({ noServer: true })
+          const handler = tanstackModule.createWebSocketHandler({ resolve: () => slopModule.slop });
+          const wss = new WebSocketServer({ noServer: true });
 
-          httpServer.on('upgrade', (req: IncomingMessage, socket: Socket, head: Buffer) => {
-            if (!req.url) return
-            const url = new URL(req.url, `http://${req.headers.host}`)
-            if (url.pathname === '/slop') {
+          httpServer.on("upgrade", (req: IncomingMessage, socket: Socket, head: Buffer) => {
+            if (!req.url) return;
+            const url = new URL(req.url, `http://${req.headers.host}`);
+            if (url.pathname === "/slop") {
               wss.handleUpgrade(req, socket, head, (wsConn: WebSocket) => {
                 const peer = {
-                  send: (data: string) => { if (wsConn.readyState === WebSocket.OPEN) wsConn.send(data) },
+                  send: (data: string) => {
+                    if (wsConn.readyState === WebSocket.OPEN) wsConn.send(data);
+                  },
                   close: () => wsConn.close(),
                   __slopRequest: req,
-                }
-                handler.open(peer)
-                wsConn.on('message', (data) => {
-                  handler.message(peer, { text: () => data.toString(), toString: () => data.toString() })
-                })
-                wsConn.on('close', () => handler.close(peer))
-              })
+                };
+                handler.open(peer);
+                wsConn.on("message", (data) => {
+                  handler.message(peer, { text: () => data.toString(), toString: () => data.toString() });
+                });
+                wsConn.on("close", () => handler.close(peer));
+              });
             }
-          })
+          });
 
-          console.log('[slop] WebSocket adapter ready at /slop')
-        })
+          console.log("[slop] WebSocket adapter ready at /slop");
+        });
       },
     },
   ],
-})
+});
 
-export default config
+export default config;
 
 function isSlopModule(value: unknown): value is SlopModule {
-  return !!value
-    && typeof value === 'object'
-    && 'slop' in value
+  return !!value && typeof value === "object" && "slop" in value;
 }
 
 function isTanstackStartServerModule(value: unknown): value is TanstackStartServerModule {
-  return !!value
-    && typeof value === 'object'
-    && typeof (value as { createWebSocketHandler?: unknown }).createWebSocketHandler === 'function'
+  return (
+    !!value &&
+    typeof value === "object" &&
+    typeof (value as { createWebSocketHandler?: unknown }).createWebSocketHandler === "function"
+  );
 }

--- a/examples/spa/angular/src/app/app.component.ts
+++ b/examples/spa/angular/src/app/app.component.ts
@@ -12,13 +12,7 @@ import { CardDetailComponent } from "./components/card-detail.component";
 @Component({
   selector: "app-root",
   standalone: true,
-  imports: [
-    BoardSwitcherComponent,
-    ColumnComponent,
-    SearchBarComponent,
-    CreateCardComponent,
-    CardDetailComponent,
-  ],
+  imports: [BoardSwitcherComponent, ColumnComponent, SearchBarComponent, CreateCardComponent, CardDetailComponent],
   template: `
     <div class="app">
       <header class="app-header">
@@ -93,22 +87,18 @@ export class AppComponent {
   detailCardId = signal<string | null>(null);
   version = signal(0);
 
-  activeBoard = computed(() =>
-    this.boards().find((b) => b.id === this.activeBoardId()),
-  );
+  activeBoard = computed(() => this.boards().find((b) => b.id === this.activeBoardId()));
 
   filteredCards = computed(() => {
     const q = this.searchQuery();
     // read version to trigger recomputation
     this.version();
-    return q
-      ? store.searchCards(this.activeBoardId(), q)
-      : this.cards();
+    return q ? store.searchCards(this.activeBoardId(), q) : this.cards();
   });
 
   detailCard = computed(() => {
     const id = this.detailCardId();
-    return id ? this.cards().find((c) => c.id === id) ?? null : null;
+    return id ? (this.cards().find((c) => c.id === id) ?? null) : null;
   });
 
   constructor() {
@@ -118,11 +108,9 @@ export class AppComponent {
       props: { board_count: this.boards().length, active_board: this.activeBoardId() },
       actions: {
         create_board: action({ name: "string" }, ({ name }) => this.handleCreateBoard(name)),
-        navigate: action(
-          { board_id: "string" },
-          ({ board_id }) => this.navigateToBoard(board_id),
-          { idempotent: true },
-        ),
+        navigate: action({ board_id: "string" }, ({ board_id }) => this.navigateToBoard(board_id), {
+          idempotent: true,
+        }),
       },
       children: Object.fromEntries(
         this.boards().map((board) => {
@@ -140,52 +128,57 @@ export class AppComponent {
     }));
 
     // SLOP: active board node (dynamic path — switches when navigating boards)
-    useSlop(slop, () => this.activeBoardId() || "__none__", () => {
-      const ab = this.activeBoard();
-      if (!ab) return { type: "view" };
-      return {
-        type: "view",
-        props: {
-          name: ab.name,
-          card_count: this.cards().length,
-          column_count: ab.columns.length,
-        },
-        meta: { focus: true },
-        actions: {
-          create_card: action(
-            {
-              title: "string",
-              column: { type: "string", description: `Target column. One of: ${ab.columns.join(", ")}` },
-              priority: { type: "string", enum: ["low", "medium", "high", "critical"] },
-              due: { type: "string", description: "ISO date string" },
-              description: { type: "string", description: "Markdown description" },
-              tags: { type: "string", description: "Comma-separated tags" },
-            },
-            ({ title, column, priority, due, description, tags }) => {
-              const tagList = tags ? tags.split(",").map((t) => t.trim()).filter(Boolean) : undefined;
-              this.handleCreateCard(
-                title,
-                column || undefined,
-                priority as Card["priority"] | undefined,
-                due || undefined,
-                description || undefined,
-                tagList,
-              );
-            },
-          ),
-          rename: action(
-            { name: "string" },
-            ({ name }) => this.handleRenameBoard(name),
-            { idempotent: true },
-          ),
-          delete: action(() => this.handleDeleteBoard(), { dangerous: true }),
-          search: action({ query: "string" }, ({ query }) => {
+    useSlop(
+      slop,
+      () => this.activeBoardId() || "__none__",
+      () => {
+        const ab = this.activeBoard();
+        if (!ab) return { type: "view" };
+        return {
+          type: "view",
+          props: {
+            name: ab.name,
+            card_count: this.cards().length,
+            column_count: ab.columns.length,
+          },
+          meta: { focus: true },
+          actions: {
+            create_card: action(
+              {
+                title: "string",
+                column: { type: "string", description: `Target column. One of: ${ab.columns.join(", ")}` },
+                priority: { type: "string", enum: ["low", "medium", "high", "critical"] },
+                due: { type: "string", description: "ISO date string" },
+                description: { type: "string", description: "Markdown description" },
+                tags: { type: "string", description: "Comma-separated tags" },
+              },
+              ({ title, column, priority, due, description, tags }) => {
+                const tagList = tags
+                  ? tags
+                      .split(",")
+                      .map((t) => t.trim())
+                      .filter(Boolean)
+                  : undefined;
+                this.handleCreateCard(
+                  title,
+                  column || undefined,
+                  priority as Card["priority"] | undefined,
+                  due || undefined,
+                  description || undefined,
+                  tagList,
+                );
+              },
+            ),
+            rename: action({ name: "string" }, ({ name }) => this.handleRenameBoard(name), { idempotent: true }),
+            delete: action(() => this.handleDeleteBoard(), { dangerous: true }),
+            search: action({ query: "string" }, ({ query }) => {
               const results = store.searchCards(this.activeBoardId(), query as string);
               return results.map((c) => ({ id: c.id, title: c.title, column: c.column, priority: c.priority }));
-          }),
-        },
-      };
-    });
+            }),
+          },
+        };
+      },
+    );
   }
 
   private refresh() {
@@ -227,14 +220,7 @@ export class AppComponent {
     description?: string;
     tags?: string[];
   }) {
-    this.handleCreateCard(
-      event.title,
-      event.column,
-      event.priority,
-      event.due,
-      event.description,
-      event.tags,
-    );
+    this.handleCreateCard(event.title, event.column, event.priority, event.due, event.description, event.tags);
     this.showCreate.set(false);
   }
 
@@ -286,9 +272,7 @@ export class AppComponent {
     const boardCards = store.getCardsForBoard(board.id);
     const dueThisWeek = boardCards.filter((c) => {
       if (!c.due || c.column === "done") return false;
-      const days = Math.round(
-        (new Date(c.due).getTime() - Date.now()) / (1000 * 60 * 60 * 24),
-      );
+      const days = Math.round((new Date(c.due).getTime() - Date.now()) / (1000 * 60 * 60 * 24));
       return days >= 0 && days <= 7;
     }).length;
     return `${board.columns.length} columns, ${boardCards.length} cards${dueThisWeek > 0 ? `, ${dueThisWeek} due this week` : ""}`;

--- a/examples/spa/angular/src/app/components/card-detail.component.ts
+++ b/examples/spa/angular/src/app/components/card-detail.component.ts
@@ -172,7 +172,10 @@ export class CardDetailComponent {
 
   handleTagsChange(value: string) {
     this.edit.emit({
-      tags: value.split(",").map((t) => t.trim()).filter(Boolean),
+      tags: value
+        .split(",")
+        .map((t) => t.trim())
+        .filter(Boolean),
     });
   }
 }

--- a/examples/spa/angular/src/app/components/column.component.ts
+++ b/examples/spa/angular/src/app/components/column.component.ts
@@ -57,16 +57,18 @@ export class ColumnComponent {
   setDescription = output<{ cardId: string; content: string }>();
   openDetail = output<string>();
 
-  sorted = computed(() =>
-    [...this.cards()].sort((a, b) => a.position - b.position),
-  );
+  sorted = computed(() => [...this.cards()].sort((a, b) => a.position - b.position));
 
   total = computed(() => this.sorted().length);
 
   label = computed(() => COLUMN_LABELS[this.columnId()] || this.columnId());
 
   constructor() {
-    useSlop(slop, () => `${this.boardId()}/${this.columnId()}`, () => this.buildDescriptor());
+    useSlop(
+      slop,
+      () => `${this.boardId()}/${this.columnId()}`,
+      () => this.buildDescriptor(),
+    );
   }
 
   private buildDescriptor(): NodeDescriptor {
@@ -112,7 +114,10 @@ export class ColumnComponent {
               if (priority) updates.priority = priority as Card["priority"];
               if (due) updates.due = due;
               if (tags) {
-                updates.tags = tags.split(",").map((t) => t.trim()).filter(Boolean);
+                updates.tags = tags
+                  .split(",")
+                  .map((t) => t.trim())
+                  .filter(Boolean);
               }
               this.editCard.emit({ cardId: card.id, updates });
             },
@@ -128,9 +133,8 @@ export class ColumnComponent {
             ({ column }) => this.moveCard.emit({ cardId: card.id, column }),
           ),
           delete: action(() => this.deleteCard.emit(card.id), { dangerous: true }),
-          set_description: action(
-            { content: { type: "string", description: "Markdown content" } },
-            ({ content }) => this.setDescription.emit({ cardId: card.id, content }),
+          set_description: action({ content: { type: "string", description: "Markdown content" } }, ({ content }) =>
+            this.setDescription.emit({ cardId: card.id, content }),
           ),
         },
       };
@@ -158,10 +162,8 @@ export class ColumnComponent {
           offset: 0,
         },
         actions: {
-          reorder: action(
-            { card_id: "string", position: "number" },
-            ({ card_id, position }) =>
-              this.reorderCard.emit({ column: columnId, cardId: card_id, position }),
+          reorder: action({ card_id: "string", position: "number" }, ({ card_id, position }) =>
+            this.reorderCard.emit({ column: columnId, cardId: card_id, position }),
           ),
         },
       };
@@ -173,10 +175,8 @@ export class ColumnComponent {
       meta: { window: [0, total] as [number, number], total_children: total },
       items: sortedCards.map(buildItemDescriptor),
       actions: {
-        reorder: action(
-          { card_id: "string", position: "number" },
-          ({ card_id, position }) =>
-            this.reorderCard.emit({ column: columnId, cardId: card_id, position }),
+        reorder: action({ card_id: "string", position: "number" }, ({ card_id, position }) =>
+          this.reorderCard.emit({ column: columnId, cardId: card_id, position }),
         ),
       },
     };

--- a/examples/spa/angular/src/app/components/create-card.component.ts
+++ b/examples/spa/angular/src/app/components/create-card.component.ts
@@ -110,7 +110,10 @@ export class CreateCardComponent {
       due: this.due || undefined,
       description: undefined,
       tags: this.tags
-        ? this.tags.split(",").map((t) => t.trim()).filter(Boolean)
+        ? this.tags
+            .split(",")
+            .map((t) => t.trim())
+            .filter(Boolean)
         : undefined,
     });
   }

--- a/examples/spa/angular/src/app/salience.ts
+++ b/examples/spa/angular/src/app/salience.ts
@@ -28,10 +28,14 @@ export function computeSalience(card: Card): SalienceResult {
   if (isCritical && isDueSoon2) {
     salience = 1.0;
     urgency = "critical";
-    reason = daysUntilDue === 0 ? "critical priority, due today"
-      : daysUntilDue === 1 ? "critical priority, due tomorrow"
-      : isOverdue ? `critical priority, overdue by ${Math.abs(daysUntilDue!)} days`
-      : `critical priority, due in ${daysUntilDue} days`;
+    reason =
+      daysUntilDue === 0
+        ? "critical priority, due today"
+        : daysUntilDue === 1
+          ? "critical priority, due tomorrow"
+          : isOverdue
+            ? `critical priority, overdue by ${Math.abs(daysUntilDue!)} days`
+            : `critical priority, due in ${daysUntilDue} days`;
   } else if (isCritical) {
     salience = 0.9;
     urgency = "high";

--- a/examples/spa/angular/src/app/store.ts
+++ b/examples/spa/angular/src/app/store.ts
@@ -95,10 +95,7 @@ export function createCard(
   return card;
 }
 
-export function editCard(
-  cardId: string,
-  updates: Partial<Pick<Card, "title" | "priority" | "due" | "tags">>,
-) {
+export function editCard(cardId: string, updates: Partial<Pick<Card, "title" | "priority" | "due" | "tags">>) {
   data = {
     ...data,
     cards: data.cards.map((c) => (c.id === cardId ? { ...c, ...updates } : c)),
@@ -112,9 +109,7 @@ export function moveCard(cardId: string, targetColumn: string) {
   const targetCards = getCardsForColumn(card.board_id, targetColumn);
   data = {
     ...data,
-    cards: data.cards.map((c) =>
-      c.id === cardId ? { ...c, column: targetColumn, position: targetCards.length } : c,
-    ),
+    cards: data.cards.map((c) => (c.id === cardId ? { ...c, column: targetColumn, position: targetCards.length } : c)),
   };
   save(data);
 }

--- a/examples/spa/react/src/App.tsx
+++ b/examples/spa/react/src/App.tsx
@@ -26,15 +26,12 @@ export default function App() {
     setVersion((v) => v + 1);
   }, [activeBoardId]);
 
-  const navigateToBoard = useCallback(
-    (boardId: string) => {
-      setActiveBoardId(boardId);
-      setCards(store.getCardsForBoard(boardId));
-      setSearchQuery("");
-      setDetailCardId(null);
-    },
-    [],
-  );
+  const navigateToBoard = useCallback((boardId: string) => {
+    setActiveBoardId(boardId);
+    setCards(store.getCardsForBoard(boardId));
+    setSearchQuery("");
+    setDetailCardId(null);
+  }, []);
 
   const handleCreateBoard = useCallback(
     (name: string) => {
@@ -46,7 +43,14 @@ export default function App() {
   );
 
   const handleCreateCard = useCallback(
-    (title: string, column?: string, priority?: Card["priority"], due?: string, description?: string, tags?: string[]) => {
+    (
+      title: string,
+      column?: string,
+      priority?: Card["priority"],
+      due?: string,
+      description?: string,
+      tags?: string[],
+    ) => {
       store.createCard(activeBoardId, title, column, priority, due, description, tags);
       refresh();
     },
@@ -116,9 +120,7 @@ export default function App() {
     const boardCards = store.getCardsForBoard(board.id);
     const dueThisWeek = boardCards.filter((c) => {
       if (!c.due || c.column === "done") return false;
-      const days = Math.round(
-        (new Date(c.due).getTime() - Date.now()) / (1000 * 60 * 60 * 24),
-      );
+      const days = Math.round((new Date(c.due).getTime() - Date.now()) / (1000 * 60 * 60 * 24));
       return days >= 0 && days <= 7;
     }).length;
     return `${board.columns.length} columns, ${boardCards.length} cards${dueThisWeek > 0 ? `, ${dueThisWeek} due this week` : ""}`;
@@ -130,11 +132,7 @@ export default function App() {
     props: { board_count: boards.length, active_board: activeBoardId },
     actions: {
       create_board: action({ name: "string" }, ({ name }) => handleCreateBoard(name)),
-      navigate: action(
-        { board_id: "string" },
-        ({ board_id }) => navigateToBoard(board_id),
-        { idempotent: true },
-      ),
+      navigate: action({ board_id: "string" }, ({ board_id }) => navigateToBoard(board_id), { idempotent: true }),
     },
     children: Object.fromEntries(
       boards.map((board) => {
@@ -152,60 +150,63 @@ export default function App() {
   }));
 
   // SLOP: active board node
-  useSlop(slop, () => activeBoard?.id ?? "__none__", () => {
-    if (!activeBoard) return { type: "view" as const };
-    return {
-      type: "view" as const,
-      props: {
-        name: activeBoard.name,
-        card_count: cards.length,
-        column_count: activeBoard.columns.length,
-      },
-      meta: { focus: true },
-      actions: {
-        create_card: action(
-          {
-            title: "string",
-            column: { type: "string", description: `Target column. One of: ${activeBoard.columns.join(", ")}` },
-            priority: { type: "string", enum: ["low", "medium", "high", "critical"] },
-            due: { type: "string", description: "ISO date string" },
-            description: { type: "string", description: "Markdown description" },
-            tags: { type: "string", description: "Comma-separated tags" },
-          },
-          ({ title, column, priority, due, description, tags }) => {
-            const tagList = tags ? tags.split(",").map((t) => t.trim()).filter(Boolean) : undefined;
-            handleCreateCard(
-              title,
-              column || undefined,
-              priority as Card["priority"] | undefined,
-              due || undefined,
-              description || undefined,
-              tagList,
-            );
-          },
-        ),
-        rename: action(
-          { name: "string" },
-          ({ name }) => handleRenameBoard(name),
-          { idempotent: true },
-        ),
-        delete: action(() => handleDeleteBoard(), { dangerous: true }),
-        search: action({ query: "string" }, ({ query }) => {
-          const results = store.searchCards(activeBoardId, query);
-          return results.map((c) => ({
-            id: c.id,
-            title: c.title,
-            column: c.column,
-            priority: c.priority,
-          }));
-        }),
-      },
-    };
-  });
+  useSlop(
+    slop,
+    () => activeBoard?.id ?? "__none__",
+    () => {
+      if (!activeBoard) return { type: "view" as const };
+      return {
+        type: "view" as const,
+        props: {
+          name: activeBoard.name,
+          card_count: cards.length,
+          column_count: activeBoard.columns.length,
+        },
+        meta: { focus: true },
+        actions: {
+          create_card: action(
+            {
+              title: "string",
+              column: { type: "string", description: `Target column. One of: ${activeBoard.columns.join(", ")}` },
+              priority: { type: "string", enum: ["low", "medium", "high", "critical"] },
+              due: { type: "string", description: "ISO date string" },
+              description: { type: "string", description: "Markdown description" },
+              tags: { type: "string", description: "Comma-separated tags" },
+            },
+            ({ title, column, priority, due, description, tags }) => {
+              const tagList = tags
+                ? tags
+                    .split(",")
+                    .map((t) => t.trim())
+                    .filter(Boolean)
+                : undefined;
+              handleCreateCard(
+                title,
+                column || undefined,
+                priority as Card["priority"] | undefined,
+                due || undefined,
+                description || undefined,
+                tagList,
+              );
+            },
+          ),
+          rename: action({ name: "string" }, ({ name }) => handleRenameBoard(name), { idempotent: true }),
+          delete: action(() => handleDeleteBoard(), { dangerous: true }),
+          search: action({ query: "string" }, ({ query }) => {
+            const results = store.searchCards(activeBoardId, query);
+            return results.map((c) => ({
+              id: c.id,
+              title: c.title,
+              column: c.column,
+              priority: c.priority,
+            }));
+          }),
+        },
+      };
+    },
+  );
 
-  const filteredCards = searchQuery
-    ? store.searchCards(activeBoardId, searchQuery)
-    : cards;
+  const filteredCards = searchQuery ? store.searchCards(activeBoardId, searchQuery) : cards;
 
   const detailCard = detailCardId ? cards.find((c) => c.id === detailCardId) : null;
 

--- a/examples/spa/react/src/components/BoardSwitcher.tsx
+++ b/examples/spa/react/src/components/BoardSwitcher.tsx
@@ -42,11 +42,17 @@ export default function BoardSwitcher({ boards, activeBoardId, onNavigate, onCre
             onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
             autoFocus
           />
-          <button className="btn-ghost" onClick={handleSubmit}>&#10003;</button>
-          <button className="btn-ghost" onClick={() => setCreating(false)}>&times;</button>
+          <button className="btn-ghost" onClick={handleSubmit}>
+            &#10003;
+          </button>
+          <button className="btn-ghost" onClick={() => setCreating(false)}>
+            &times;
+          </button>
         </span>
       ) : (
-        <button className="board-tab add" onClick={() => setCreating(true)}>+</button>
+        <button className="board-tab add" onClick={() => setCreating(true)}>
+          +
+        </button>
       )}
     </nav>
   );

--- a/examples/spa/react/src/components/Card.tsx
+++ b/examples/spa/react/src/components/Card.tsx
@@ -34,9 +34,7 @@ export default function CardItem({ card, allColumns, onMove, onDelete, onOpenDet
       onClick={() => onOpenDetail(card.id)}
     >
       <div className="card-header">
-        <span className={`card-priority priority-${card.priority}`}>
-          {PRIORITY_LABELS[card.priority]}
-        </span>
+        <span className={`card-priority priority-${card.priority}`}>{PRIORITY_LABELS[card.priority]}</span>
         <button
           className="card-menu-btn"
           onClick={(e) => {
@@ -51,15 +49,13 @@ export default function CardItem({ card, allColumns, onMove, onDelete, onOpenDet
       <h3 className="card-title">{card.title}</h3>
 
       <div className="card-footer">
-        {card.due && (
-          <span className={`card-due ${isOverdue ? "overdue" : ""}`}>
-            {formatDue(card.due)}
-          </span>
-        )}
+        {card.due && <span className={`card-due ${isOverdue ? "overdue" : ""}`}>{formatDue(card.due)}</span>}
         {card.tags.length > 0 && (
           <div className="card-tags">
             {card.tags.map((tag) => (
-              <span key={tag} className="card-tag">{tag}</span>
+              <span key={tag} className="card-tag">
+                {tag}
+              </span>
             ))}
           </div>
         )}

--- a/examples/spa/react/src/components/CardDetail.tsx
+++ b/examples/spa/react/src/components/CardDetail.tsx
@@ -36,14 +36,21 @@ export default function CardDetail({ card, columns, onEdit, onMove, onDelete, on
               }}
               onKeyDown={(e) => {
                 if (e.key === "Enter") (e.target as HTMLInputElement).blur();
-                if (e.key === "Escape") { setTitleDraft(card.title); setEditingTitle(false); }
+                if (e.key === "Escape") {
+                  setTitleDraft(card.title);
+                  setEditingTitle(false);
+                }
               }}
               autoFocus
             />
           ) : (
-            <h2 className="modal-title" onClick={() => setEditingTitle(true)}>{card.title}</h2>
+            <h2 className="modal-title" onClick={() => setEditingTitle(true)}>
+              {card.title}
+            </h2>
           )}
-          <button className="modal-close" onClick={onClose}>&times;</button>
+          <button className="modal-close" onClick={onClose}>
+            &times;
+          </button>
         </div>
 
         <div className="modal-body">
@@ -63,13 +70,11 @@ export default function CardDetail({ card, columns, onEdit, onMove, onDelete, on
 
           <div className="detail-row">
             <span className="detail-label">COLUMN</span>
-            <select
-              className="detail-select"
-              value={card.column}
-              onChange={(e) => onMove(e.target.value)}
-            >
+            <select className="detail-select" value={card.column} onChange={(e) => onMove(e.target.value)}>
               {columns.map((col) => (
-                <option key={col} value={col}>{col}</option>
+                <option key={col} value={col}>
+                  {col}
+                </option>
               ))}
             </select>
           </div>
@@ -80,7 +85,7 @@ export default function CardDetail({ card, columns, onEdit, onMove, onDelete, on
               className="detail-input"
               type="date"
               value={card.due || ""}
-              onChange={(e) => onEdit({ due: e.target.value || null as unknown as string })}
+              onChange={(e) => onEdit({ due: e.target.value || (null as unknown as string) })}
             />
           </div>
 
@@ -92,7 +97,12 @@ export default function CardDetail({ card, columns, onEdit, onMove, onDelete, on
               value={card.tags.join(", ")}
               placeholder="tag1, tag2, ..."
               onChange={(e) =>
-                onEdit({ tags: e.target.value.split(",").map((t) => t.trim()).filter(Boolean) })
+                onEdit({
+                  tags: e.target.value
+                    .split(",")
+                    .map((t) => t.trim())
+                    .filter(Boolean),
+                })
               }
             />
           </div>
@@ -132,7 +142,10 @@ export default function CardDetail({ card, columns, onEdit, onMove, onDelete, on
             ) : (
               <div
                 className="desc-preview"
-                onClick={() => { setDescDraft(card.description); setEditingDesc(true); }}
+                onClick={() => {
+                  setDescDraft(card.description);
+                  setEditingDesc(true);
+                }}
               >
                 {card.description ? (
                   <pre className="desc-content">{card.description}</pre>
@@ -145,7 +158,9 @@ export default function CardDetail({ card, columns, onEdit, onMove, onDelete, on
         </div>
 
         <div className="modal-footer">
-          <button className="btn-danger" onClick={onDelete}>Delete Card</button>
+          <button className="btn-danger" onClick={onDelete}>
+            Delete Card
+          </button>
         </div>
       </div>
     </div>

--- a/examples/spa/react/src/components/Column.tsx
+++ b/examples/spa/react/src/components/Column.tsx
@@ -82,7 +82,10 @@ export default function Column({
             if (priority) updates.priority = priority as Card["priority"];
             if (due) updates.due = due;
             if (tags) {
-              updates.tags = tags.split(",").map((t) => t.trim()).filter(Boolean);
+              updates.tags = tags
+                .split(",")
+                .map((t) => t.trim())
+                .filter(Boolean);
             }
             onEditCard(card.id, updates);
           },
@@ -98,9 +101,8 @@ export default function Column({
           ({ column }) => onMoveCard(card.id, column),
         ),
         delete: action(() => onDeleteCard(card.id), { dangerous: true }),
-        set_description: action(
-          { content: { type: "string", description: "Markdown content" } },
-          ({ content }) => onSetDescription(card.id, content),
+        set_description: action({ content: { type: "string", description: "Markdown content" } }, ({ content }) =>
+          onSetDescription(card.id, content),
         ),
       },
     };
@@ -118,36 +120,37 @@ export default function Column({
     return descriptor;
   };
 
-  useSlop(slop, () => `${boardId}/${columnId}`, () => (
-    useWindow
-      ? {
-        type: "collection",
-        props: { name: label, position, card_count: total },
-        window: {
-          items: windowed.map(buildItemDescriptor),
-          total,
-          offset: 0,
-        },
-        actions: {
-          reorder: action(
-            { card_id: "string", position: "number" },
-            ({ card_id, position }) => onReorderCard(columnId, card_id, position),
-          ),
-        },
-      }
-      : {
-        type: "collection",
-        props: { name: label, position, card_count: total },
-        meta: { window: [0, total] as [number, number], total_children: total },
-        items: sorted.map(buildItemDescriptor),
-        actions: {
-          reorder: action(
-            { card_id: "string", position: "number" },
-            ({ card_id, position }) => onReorderCard(columnId, card_id, position),
-          ),
-        },
-      }
-  ));
+  useSlop(
+    slop,
+    () => `${boardId}/${columnId}`,
+    () =>
+      useWindow
+        ? {
+            type: "collection",
+            props: { name: label, position, card_count: total },
+            window: {
+              items: windowed.map(buildItemDescriptor),
+              total,
+              offset: 0,
+            },
+            actions: {
+              reorder: action({ card_id: "string", position: "number" }, ({ card_id, position }) =>
+                onReorderCard(columnId, card_id, position),
+              ),
+            },
+          }
+        : {
+            type: "collection",
+            props: { name: label, position, card_count: total },
+            meta: { window: [0, total] as [number, number], total_children: total },
+            items: sorted.map(buildItemDescriptor),
+            actions: {
+              reorder: action({ card_id: "string", position: "number" }, ({ card_id, position }) =>
+                onReorderCard(columnId, card_id, position),
+              ),
+            },
+          },
+  );
 
   return (
     <section className="column">

--- a/examples/spa/react/src/components/CreateCard.tsx
+++ b/examples/spa/react/src/components/CreateCard.tsx
@@ -29,7 +29,12 @@ export default function CreateCard({ columns, onSubmit, onClose }: Props) {
       priority,
       due || undefined,
       undefined,
-      tags ? tags.split(",").map((t) => t.trim()).filter(Boolean) : undefined,
+      tags
+        ? tags
+            .split(",")
+            .map((t) => t.trim())
+            .filter(Boolean)
+        : undefined,
     );
   };
 
@@ -38,7 +43,9 @@ export default function CreateCard({ columns, onSubmit, onClose }: Props) {
       <div className="modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h2 className="modal-title">New Card</h2>
-          <button className="modal-close" onClick={onClose}>&times;</button>
+          <button className="modal-close" onClick={onClose}>
+            &times;
+          </button>
         </div>
 
         <div className="modal-body">
@@ -60,14 +67,20 @@ export default function CreateCard({ columns, onSubmit, onClose }: Props) {
               <label className="form-label">COLUMN</label>
               <select className="form-select" value={column} onChange={(e) => setColumn(e.target.value)}>
                 {columns.map((col) => (
-                  <option key={col} value={col}>{col}</option>
+                  <option key={col} value={col}>
+                    {col}
+                  </option>
                 ))}
               </select>
             </div>
 
             <div className="form-field">
               <label className="form-label">PRIORITY</label>
-              <select className="form-select" value={priority} onChange={(e) => setPriority(e.target.value as Card["priority"])}>
+              <select
+                className="form-select"
+                value={priority}
+                onChange={(e) => setPriority(e.target.value as Card["priority"])}
+              >
                 <option value="low">Low</option>
                 <option value="medium">Medium</option>
                 <option value="high">High</option>
@@ -96,7 +109,9 @@ export default function CreateCard({ columns, onSubmit, onClose }: Props) {
         </div>
 
         <div className="modal-footer">
-          <button className="btn-ghost" onClick={onClose}>Cancel</button>
+          <button className="btn-ghost" onClick={onClose}>
+            Cancel
+          </button>
           <button className="btn-primary" onClick={handleSubmit} disabled={!title.trim()}>
             Create
           </button>

--- a/examples/spa/react/src/components/SearchBar.tsx
+++ b/examples/spa/react/src/components/SearchBar.tsx
@@ -6,12 +6,7 @@ interface Props {
 export default function SearchBar({ query, onQueryChange }: Props) {
   return (
     <div className="search-bar">
-      <input
-        type="text"
-        placeholder="Search cards..."
-        value={query}
-        onChange={(e) => onQueryChange(e.target.value)}
-      />
+      <input type="text" placeholder="Search cards..." value={query} onChange={(e) => onQueryChange(e.target.value)} />
       {query && (
         <button className="search-clear" onClick={() => onQueryChange("")}>
           &times;

--- a/examples/spa/react/src/salience.ts
+++ b/examples/spa/react/src/salience.ts
@@ -28,10 +28,14 @@ export function computeSalience(card: Card): SalienceResult {
   if (isCritical && isDueSoon2) {
     salience = 1.0;
     urgency = "critical";
-    reason = daysUntilDue === 0 ? "critical priority, due today"
-      : daysUntilDue === 1 ? "critical priority, due tomorrow"
-      : isOverdue ? `critical priority, overdue by ${Math.abs(daysUntilDue!)} days`
-      : `critical priority, due in ${daysUntilDue} days`;
+    reason =
+      daysUntilDue === 0
+        ? "critical priority, due today"
+        : daysUntilDue === 1
+          ? "critical priority, due tomorrow"
+          : isOverdue
+            ? `critical priority, overdue by ${Math.abs(daysUntilDue!)} days`
+            : `critical priority, due in ${daysUntilDue} days`;
   } else if (isCritical) {
     salience = 0.9;
     urgency = "high";

--- a/examples/spa/react/src/store.ts
+++ b/examples/spa/react/src/store.ts
@@ -95,10 +95,7 @@ export function createCard(
   return card;
 }
 
-export function editCard(
-  cardId: string,
-  updates: Partial<Pick<Card, "title" | "priority" | "due" | "tags">>,
-) {
+export function editCard(cardId: string, updates: Partial<Pick<Card, "title" | "priority" | "due" | "tags">>) {
   data = {
     ...data,
     cards: data.cards.map((c) => (c.id === cardId ? { ...c, ...updates } : c)),
@@ -112,9 +109,7 @@ export function moveCard(cardId: string, targetColumn: string) {
   const targetCards = getCardsForColumn(card.board_id, targetColumn);
   data = {
     ...data,
-    cards: data.cards.map((c) =>
-      c.id === cardId ? { ...c, column: targetColumn, position: targetCards.length } : c,
-    ),
+    cards: data.cards.map((c) => (c.id === cardId ? { ...c, column: targetColumn, position: targetCards.length } : c)),
   };
   save(data);
 }

--- a/examples/spa/solid/src/App.tsx
+++ b/examples/spa/solid/src/App.tsx
@@ -95,9 +95,7 @@ export default function App() {
     const boardCards = store.getCardsForBoard(board.id);
     const dueThisWeek = boardCards.filter((c) => {
       if (!c.due || c.column === "done") return false;
-      const days = Math.round(
-        (new Date(c.due).getTime() - Date.now()) / (1000 * 60 * 60 * 24),
-      );
+      const days = Math.round((new Date(c.due).getTime() - Date.now()) / (1000 * 60 * 60 * 24));
       return days >= 0 && days <= 7;
     }).length;
     return `${board.columns.length} columns, ${boardCards.length} cards${dueThisWeek > 0 ? `, ${dueThisWeek} due this week` : ""}`;
@@ -109,11 +107,7 @@ export default function App() {
     props: { board_count: boards().length, active_board: activeBoardId() },
     actions: {
       create_board: action({ name: "string" }, ({ name }) => handleCreateBoard(name)),
-      navigate: action(
-        { board_id: "string" },
-        ({ board_id }) => navigateToBoard(board_id),
-        { idempotent: true },
-      ),
+      navigate: action({ board_id: "string" }, ({ board_id }) => navigateToBoard(board_id), { idempotent: true }),
     },
     children: Object.fromEntries(
       boards().map((board) => {
@@ -131,61 +125,63 @@ export default function App() {
   }));
 
   // SLOP: active board node (dynamic path via adapter)
-  useSlop(slop, () => activeBoard()?.id ?? "__none__", () => {
-    const ab = activeBoard();
-    if (!ab) return { type: "view" as const };
-    return {
-      type: "view" as const,
-      props: {
-        name: ab.name,
-        card_count: cards().length,
-        column_count: ab.columns.length,
-      },
-      meta: { focus: true },
-      actions: {
-        create_card: action(
-          {
-            title: "string",
-            column: { type: "string", description: `Target column. One of: ${ab.columns.join(", ")}` },
-            priority: { type: "string", enum: ["low", "medium", "high", "critical"] },
-            due: { type: "string", description: "ISO date string" },
-            description: { type: "string", description: "Markdown description" },
-            tags: { type: "string", description: "Comma-separated tags" },
-          },
-          ({ title, column, priority, due, description, tags }) => {
-            const tagList = tags ? tags.split(",").map((t) => t.trim()).filter(Boolean) : undefined;
-            handleCreateCard(
-              title,
-              column || undefined,
-              priority as Card["priority"] | undefined,
-              due || undefined,
-              description || undefined,
-              tagList,
-            );
-          },
-        ),
-        rename: action(
-          { name: "string" },
-          ({ name }) => handleRenameBoard(name),
-          { idempotent: true },
-        ),
-        delete: action(() => handleDeleteBoard(), { dangerous: true }),
-        search: action({ query: "string" }, ({ query }) => {
+  useSlop(
+    slop,
+    () => activeBoard()?.id ?? "__none__",
+    () => {
+      const ab = activeBoard();
+      if (!ab) return { type: "view" as const };
+      return {
+        type: "view" as const,
+        props: {
+          name: ab.name,
+          card_count: cards().length,
+          column_count: ab.columns.length,
+        },
+        meta: { focus: true },
+        actions: {
+          create_card: action(
+            {
+              title: "string",
+              column: { type: "string", description: `Target column. One of: ${ab.columns.join(", ")}` },
+              priority: { type: "string", enum: ["low", "medium", "high", "critical"] },
+              due: { type: "string", description: "ISO date string" },
+              description: { type: "string", description: "Markdown description" },
+              tags: { type: "string", description: "Comma-separated tags" },
+            },
+            ({ title, column, priority, due, description, tags }) => {
+              const tagList = tags
+                ? tags
+                    .split(",")
+                    .map((t) => t.trim())
+                    .filter(Boolean)
+                : undefined;
+              handleCreateCard(
+                title,
+                column || undefined,
+                priority as Card["priority"] | undefined,
+                due || undefined,
+                description || undefined,
+                tagList,
+              );
+            },
+          ),
+          rename: action({ name: "string" }, ({ name }) => handleRenameBoard(name), { idempotent: true }),
+          delete: action(() => handleDeleteBoard(), { dangerous: true }),
+          search: action({ query: "string" }, ({ query }) => {
             const results = store.searchCards(activeBoardId(), query as string);
             return results.map((c) => ({ id: c.id, title: c.title, column: c.column, priority: c.priority }));
-        }),
-      },
-    };
-  });
+          }),
+        },
+      };
+    },
+  );
 
-  const filteredCards = () =>
-    searchQuery()
-      ? store.searchCards(activeBoardId(), searchQuery())
-      : cards();
+  const filteredCards = () => (searchQuery() ? store.searchCards(activeBoardId(), searchQuery()) : cards());
 
   const detailCard = () => {
     const id = detailCardId();
-    return id ? cards().find((c) => c.id === id) ?? null : null;
+    return id ? (cards().find((c) => c.id === id) ?? null) : null;
   };
 
   return (

--- a/examples/spa/solid/src/components/BoardSwitcher.tsx
+++ b/examples/spa/solid/src/components/BoardSwitcher.tsx
@@ -35,7 +35,9 @@ export default function BoardSwitcher(props: Props) {
       <Show
         when={creating()}
         fallback={
-          <button class="board-tab add" onClick={() => setCreating(true)}>+</button>
+          <button class="board-tab add" onClick={() => setCreating(true)}>
+            +
+          </button>
         }
       >
         <span class="board-tab-create">
@@ -48,8 +50,12 @@ export default function BoardSwitcher(props: Props) {
             onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
             autofocus
           />
-          <button class="btn-ghost" onClick={handleSubmit}>&#10003;</button>
-          <button class="btn-ghost" onClick={() => setCreating(false)}>&times;</button>
+          <button class="btn-ghost" onClick={handleSubmit}>
+            &#10003;
+          </button>
+          <button class="btn-ghost" onClick={() => setCreating(false)}>
+            &times;
+          </button>
         </span>
       </Show>
     </nav>

--- a/examples/spa/solid/src/components/Card.tsx
+++ b/examples/spa/solid/src/components/Card.tsx
@@ -34,9 +34,7 @@ export default function CardItem(props: Props) {
       onClick={() => props.onOpenDetail(props.card.id)}
     >
       <div class="card-header">
-        <span class={`card-priority priority-${props.card.priority}`}>
-          {PRIORITY_LABELS[props.card.priority]}
-        </span>
+        <span class={`card-priority priority-${props.card.priority}`}>{PRIORITY_LABELS[props.card.priority]}</span>
         <button
           class="card-menu-btn"
           onClick={(e) => {
@@ -52,15 +50,11 @@ export default function CardItem(props: Props) {
 
       <div class="card-footer">
         <Show when={props.card.due}>
-          <span class={`card-due ${isOverdue() ? "overdue" : ""}`}>
-            {formatDue(props.card.due!)}
-          </span>
+          <span class={`card-due ${isOverdue() ? "overdue" : ""}`}>{formatDue(props.card.due!)}</span>
         </Show>
         <Show when={props.card.tags.length > 0}>
           <div class="card-tags">
-            <For each={props.card.tags}>
-              {(tag) => <span class="card-tag">{tag}</span>}
-            </For>
+            <For each={props.card.tags}>{(tag) => <span class="card-tag">{tag}</span>}</For>
           </div>
         </Show>
         <Show when={props.card.description}>

--- a/examples/spa/solid/src/components/CardDetail.tsx
+++ b/examples/spa/solid/src/components/CardDetail.tsx
@@ -24,7 +24,9 @@ export default function CardDetail(props: Props) {
           <Show
             when={editingTitle()}
             fallback={
-              <h2 class="modal-title" onClick={() => setEditingTitle(true)}>{props.card.title}</h2>
+              <h2 class="modal-title" onClick={() => setEditingTitle(true)}>
+                {props.card.title}
+              </h2>
             }
           >
             <input
@@ -39,12 +41,17 @@ export default function CardDetail(props: Props) {
               }}
               onKeyDown={(e) => {
                 if (e.key === "Enter") (e.target as HTMLInputElement).blur();
-                if (e.key === "Escape") { setTitleDraft(props.card.title); setEditingTitle(false); }
+                if (e.key === "Escape") {
+                  setTitleDraft(props.card.title);
+                  setEditingTitle(false);
+                }
               }}
               autofocus
             />
           </Show>
-          <button class="modal-close" onClick={props.onClose}>&times;</button>
+          <button class="modal-close" onClick={props.onClose}>
+            &times;
+          </button>
         </div>
 
         <div class="modal-body">
@@ -69,9 +76,7 @@ export default function CardDetail(props: Props) {
               value={props.card.column}
               onChange={(e) => props.onMove(e.currentTarget.value)}
             >
-              <For each={props.columns}>
-                {(col) => <option value={col}>{col}</option>}
-              </For>
+              <For each={props.columns}>{(col) => <option value={col}>{col}</option>}</For>
             </select>
           </div>
 
@@ -81,7 +86,7 @@ export default function CardDetail(props: Props) {
               class="detail-input"
               type="date"
               value={props.card.due || ""}
-              onChange={(e) => props.onEdit({ due: e.currentTarget.value || null as unknown as string })}
+              onChange={(e) => props.onEdit({ due: e.currentTarget.value || (null as unknown as string) })}
             />
           </div>
 
@@ -93,7 +98,12 @@ export default function CardDetail(props: Props) {
               value={props.card.tags.join(", ")}
               placeholder="tag1, tag2, ..."
               onChange={(e) =>
-                props.onEdit({ tags: e.currentTarget.value.split(",").map((t) => t.trim()).filter(Boolean) })
+                props.onEdit({
+                  tags: e.currentTarget.value
+                    .split(",")
+                    .map((t) => t.trim())
+                    .filter(Boolean),
+                })
               }
             />
           </div>
@@ -105,7 +115,10 @@ export default function CardDetail(props: Props) {
               fallback={
                 <div
                   class="desc-preview"
-                  onClick={() => { setDescDraft(props.card.description); setEditingDesc(true); }}
+                  onClick={() => {
+                    setDescDraft(props.card.description);
+                    setEditingDesc(true);
+                  }}
                 >
                   <Show
                     when={props.card.description}
@@ -150,7 +163,9 @@ export default function CardDetail(props: Props) {
         </div>
 
         <div class="modal-footer">
-          <button class="btn-danger" onClick={props.onDelete}>Delete Card</button>
+          <button class="btn-danger" onClick={props.onDelete}>
+            Delete Card
+          </button>
         </div>
       </div>
     </div>

--- a/examples/spa/solid/src/components/Column.tsx
+++ b/examples/spa/solid/src/components/Column.tsx
@@ -69,7 +69,10 @@ export default function Column(props: Props) {
             if (priority) updates.priority = priority as Card["priority"];
             if (due) updates.due = due;
             if (tags) {
-              updates.tags = tags.split(",").map((t) => t.trim()).filter(Boolean);
+              updates.tags = tags
+                .split(",")
+                .map((t) => t.trim())
+                .filter(Boolean);
             }
             props.onEditCard(card.id, updates);
           },
@@ -85,9 +88,8 @@ export default function Column(props: Props) {
           ({ column }) => props.onMoveCard(card.id, column),
         ),
         delete: action(() => props.onDeleteCard(card.id), { dangerous: true }),
-        set_description: action(
-          { content: { type: "string", description: "Markdown content" } },
-          ({ content }) => props.onSetDescription(card.id, content),
+        set_description: action({ content: { type: "string", description: "Markdown content" } }, ({ content }) =>
+          props.onSetDescription(card.id, content),
         ),
       },
     };
@@ -105,43 +107,45 @@ export default function Column(props: Props) {
     return descriptor;
   };
 
-  useSlop(slop, () => `${props.boardId}/${props.columnId}`, () => {
-    const s = sorted();
-    const t = total();
-    const windowed = s.slice(0, WINDOW_SIZE);
-    const useWindow = t > WINDOW_SIZE;
+  useSlop(
+    slop,
+    () => `${props.boardId}/${props.columnId}`,
+    () => {
+      const s = sorted();
+      const t = total();
+      const windowed = s.slice(0, WINDOW_SIZE);
+      const useWindow = t > WINDOW_SIZE;
 
-    if (useWindow) {
+      if (useWindow) {
+        return {
+          type: "collection",
+          props: { name: label(), position: props.position, card_count: t },
+          window: {
+            items: windowed.map(buildItemDescriptor),
+            total: t,
+            offset: 0,
+          },
+          actions: {
+            reorder: action({ card_id: "string", position: "number" }, ({ card_id, position }) =>
+              props.onReorderCard(props.columnId, card_id, position),
+            ),
+          },
+        };
+      }
+
       return {
         type: "collection",
         props: { name: label(), position: props.position, card_count: t },
-        window: {
-          items: windowed.map(buildItemDescriptor),
-          total: t,
-          offset: 0,
-        },
+        meta: { window: [0, t] as [number, number], total_children: t },
+        items: s.map(buildItemDescriptor),
         actions: {
-          reorder: action(
-            { card_id: "string", position: "number" },
-            ({ card_id, position }) => props.onReorderCard(props.columnId, card_id, position),
+          reorder: action({ card_id: "string", position: "number" }, ({ card_id, position }) =>
+            props.onReorderCard(props.columnId, card_id, position),
           ),
         },
       };
-    }
-
-    return {
-      type: "collection",
-      props: { name: label(), position: props.position, card_count: t },
-      meta: { window: [0, t] as [number, number], total_children: t },
-      items: s.map(buildItemDescriptor),
-      actions: {
-        reorder: action(
-          { card_id: "string", position: "number" },
-          ({ card_id, position }) => props.onReorderCard(props.columnId, card_id, position),
-        ),
-      },
-    };
-  });
+    },
+  );
 
   return (
     <section class="column">

--- a/examples/spa/solid/src/components/CreateCard.tsx
+++ b/examples/spa/solid/src/components/CreateCard.tsx
@@ -29,7 +29,12 @@ export default function CreateCard(props: Props) {
       priority(),
       due() || undefined,
       undefined,
-      tags() ? tags().split(",").map((t) => t.trim()).filter(Boolean) : undefined,
+      tags()
+        ? tags()
+            .split(",")
+            .map((t) => t.trim())
+            .filter(Boolean)
+        : undefined,
     );
   };
 
@@ -38,7 +43,9 @@ export default function CreateCard(props: Props) {
       <div class="modal" onClick={(e) => e.stopPropagation()}>
         <div class="modal-header">
           <h2 class="modal-title">New Card</h2>
-          <button class="modal-close" onClick={props.onClose}>&times;</button>
+          <button class="modal-close" onClick={props.onClose}>
+            &times;
+          </button>
         </div>
 
         <div class="modal-body">
@@ -59,15 +66,17 @@ export default function CreateCard(props: Props) {
             <div class="form-field">
               <label class="form-label">COLUMN</label>
               <select class="form-select" value={column()} onChange={(e) => setColumn(e.currentTarget.value)}>
-                <For each={props.columns}>
-                  {(col) => <option value={col}>{col}</option>}
-                </For>
+                <For each={props.columns}>{(col) => <option value={col}>{col}</option>}</For>
               </select>
             </div>
 
             <div class="form-field">
               <label class="form-label">PRIORITY</label>
-              <select class="form-select" value={priority()} onChange={(e) => setPriority(e.currentTarget.value as Card["priority"])}>
+              <select
+                class="form-select"
+                value={priority()}
+                onChange={(e) => setPriority(e.currentTarget.value as Card["priority"])}
+              >
                 <option value="low">Low</option>
                 <option value="medium">Medium</option>
                 <option value="high">High</option>
@@ -96,7 +105,9 @@ export default function CreateCard(props: Props) {
         </div>
 
         <div class="modal-footer">
-          <button class="btn-ghost" onClick={props.onClose}>Cancel</button>
+          <button class="btn-ghost" onClick={props.onClose}>
+            Cancel
+          </button>
           <button class="btn-primary" onClick={handleSubmit} disabled={!title().trim()}>
             Create
           </button>

--- a/examples/spa/solid/src/salience.ts
+++ b/examples/spa/solid/src/salience.ts
@@ -28,10 +28,14 @@ export function computeSalience(card: Card): SalienceResult {
   if (isCritical && isDueSoon2) {
     salience = 1.0;
     urgency = "critical";
-    reason = daysUntilDue === 0 ? "critical priority, due today"
-      : daysUntilDue === 1 ? "critical priority, due tomorrow"
-      : isOverdue ? `critical priority, overdue by ${Math.abs(daysUntilDue!)} days`
-      : `critical priority, due in ${daysUntilDue} days`;
+    reason =
+      daysUntilDue === 0
+        ? "critical priority, due today"
+        : daysUntilDue === 1
+          ? "critical priority, due tomorrow"
+          : isOverdue
+            ? `critical priority, overdue by ${Math.abs(daysUntilDue!)} days`
+            : `critical priority, due in ${daysUntilDue} days`;
   } else if (isCritical) {
     salience = 0.9;
     urgency = "high";

--- a/examples/spa/solid/src/store.ts
+++ b/examples/spa/solid/src/store.ts
@@ -95,10 +95,7 @@ export function createCard(
   return card;
 }
 
-export function editCard(
-  cardId: string,
-  updates: Partial<Pick<Card, "title" | "priority" | "due" | "tags">>,
-) {
+export function editCard(cardId: string, updates: Partial<Pick<Card, "title" | "priority" | "due" | "tags">>) {
   data = {
     ...data,
     cards: data.cards.map((c) => (c.id === cardId ? { ...c, ...updates } : c)),
@@ -112,9 +109,7 @@ export function moveCard(cardId: string, targetColumn: string) {
   const targetCards = getCardsForColumn(card.board_id, targetColumn);
   data = {
     ...data,
-    cards: data.cards.map((c) =>
-      c.id === cardId ? { ...c, column: targetColumn, position: targetCards.length } : c,
-    ),
+    cards: data.cards.map((c) => (c.id === cardId ? { ...c, column: targetColumn, position: targetCards.length } : c)),
   };
   save(data);
 }

--- a/examples/spa/svelte/src/salience.ts
+++ b/examples/spa/svelte/src/salience.ts
@@ -28,10 +28,14 @@ export function computeSalience(card: Card): SalienceResult {
   if (isCritical && isDueSoon2) {
     salience = 1.0;
     urgency = "critical";
-    reason = daysUntilDue === 0 ? "critical priority, due today"
-      : daysUntilDue === 1 ? "critical priority, due tomorrow"
-      : isOverdue ? `critical priority, overdue by ${Math.abs(daysUntilDue!)} days`
-      : `critical priority, due in ${daysUntilDue} days`;
+    reason =
+      daysUntilDue === 0
+        ? "critical priority, due today"
+        : daysUntilDue === 1
+          ? "critical priority, due tomorrow"
+          : isOverdue
+            ? `critical priority, overdue by ${Math.abs(daysUntilDue!)} days`
+            : `critical priority, due in ${daysUntilDue} days`;
   } else if (isCritical) {
     salience = 0.9;
     urgency = "high";

--- a/examples/spa/svelte/src/store.ts
+++ b/examples/spa/svelte/src/store.ts
@@ -95,10 +95,7 @@ export function createCard(
   return card;
 }
 
-export function editCard(
-  cardId: string,
-  updates: Partial<Pick<Card, "title" | "priority" | "due" | "tags">>,
-) {
+export function editCard(cardId: string, updates: Partial<Pick<Card, "title" | "priority" | "due" | "tags">>) {
   data = {
     ...data,
     cards: data.cards.map((c) => (c.id === cardId ? { ...c, ...updates } : c)),
@@ -112,9 +109,7 @@ export function moveCard(cardId: string, targetColumn: string) {
   const targetCards = getCardsForColumn(card.board_id, targetColumn);
   data = {
     ...data,
-    cards: data.cards.map((c) =>
-      c.id === cardId ? { ...c, column: targetColumn, position: targetCards.length } : c,
-    ),
+    cards: data.cards.map((c) => (c.id === cardId ? { ...c, column: targetColumn, position: targetCards.length } : c)),
   };
   save(data);
 }

--- a/examples/spa/test-spa.ts
+++ b/examples/spa/test-spa.ts
@@ -138,7 +138,13 @@ async function run() {
   // Test: invoke search
   console.log(`\n=== TEST: search for "auth" ===\n`);
   const searchId = `search-${Date.now()}`;
-  send({ type: "invoke", id: searchId, path: snapshot.tree.children?.[0]?.id || "board-1", action: "search", params: { query: "auth" } });
+  send({
+    type: "invoke",
+    id: searchId,
+    path: snapshot.tree.children?.[0]?.id || "board-1",
+    action: "search",
+    params: { query: "auth" },
+  });
   const searchResult = await waitForMessage("result", searchId);
   console.log("Search result:", JSON.stringify(searchResult.data, null, 2));
 

--- a/examples/spa/test-ws-relay.ts
+++ b/examples/spa/test-ws-relay.ts
@@ -75,4 +75,6 @@ const consumerServer = Bun.serve({
 
 console.log(`[relay] Provider port: ws://localhost:${providerServer.port}/slop`);
 console.log(`[relay] Consumer port: ws://localhost:${consumerServer.port}/slop`);
-console.log(`[relay] Start an SPA example, then connect CLI: go run ./cli --connect ws://localhost:${consumerServer.port}/slop`);
+console.log(
+  `[relay] Start an SPA example, then connect CLI: go run ./cli --connect ws://localhost:${consumerServer.port}/slop`,
+);

--- a/examples/spa/vue/src/salience.ts
+++ b/examples/spa/vue/src/salience.ts
@@ -28,10 +28,14 @@ export function computeSalience(card: Card): SalienceResult {
   if (isCritical && isDueSoon2) {
     salience = 1.0;
     urgency = "critical";
-    reason = daysUntilDue === 0 ? "critical priority, due today"
-      : daysUntilDue === 1 ? "critical priority, due tomorrow"
-      : isOverdue ? `critical priority, overdue by ${Math.abs(daysUntilDue!)} days`
-      : `critical priority, due in ${daysUntilDue} days`;
+    reason =
+      daysUntilDue === 0
+        ? "critical priority, due today"
+        : daysUntilDue === 1
+          ? "critical priority, due tomorrow"
+          : isOverdue
+            ? `critical priority, overdue by ${Math.abs(daysUntilDue!)} days`
+            : `critical priority, due in ${daysUntilDue} days`;
   } else if (isCritical) {
     salience = 0.9;
     urgency = "high";

--- a/examples/spa/vue/src/store.ts
+++ b/examples/spa/vue/src/store.ts
@@ -95,10 +95,7 @@ export function createCard(
   return card;
 }
 
-export function editCard(
-  cardId: string,
-  updates: Partial<Pick<Card, "title" | "priority" | "due" | "tags">>,
-) {
+export function editCard(cardId: string, updates: Partial<Pick<Card, "title" | "priority" | "due" | "tags">>) {
   data = {
     ...data,
     cards: data.cards.map((c) => (c.id === cardId ? { ...c, ...updates } : c)),
@@ -112,9 +109,7 @@ export function moveCard(cardId: string, targetColumn: string) {
   const targetCards = getCardsForColumn(card.board_id, targetColumn);
   data = {
     ...data,
-    cards: data.cards.map((c) =>
-      c.id === cardId ? { ...c, column: targetColumn, position: targetCards.length } : c,
-    ),
+    cards: data.cards.map((c) => (c.id === cardId ? { ...c, column: targetColumn, position: targetCards.length } : c)),
   };
   save(data);
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "build": "bun run scripts/build-typescript-packages.ts",
     "test": "for d in packages/typescript/*/*/; do if ls \"$d\"__tests__/*.test.* >/dev/null 2>&1; then echo \"Testing $d\" && (cd \"$d\" && bun test); fi; done",
     "clean": "for d in packages/typescript/*/*/; do (cd \"$d\" && rm -rf dist); done",
+    "format": "biome format --write .",
+    "format:check": "biome check --formatter-enabled=true --linter-enabled=false --assist-enabled=false .",
     "demo": "cd website/demo && bunx vite --port 3001",
     "preflight": "bun run scripts/preflight.ts",
     "preflight:list": "bun run scripts/preflight.ts --list",
@@ -34,5 +36,8 @@
     "release:publish-rust": "bun run scripts/release/publish-rust.ts",
     "release:stage-extension": "bun run scripts/release/stage-extension.ts",
     "release:publish-extension": "bun run scripts/release/publish-chrome-web-store.ts"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.10"
   }
 }

--- a/packages/typescript/adapters/angular/src/index.ts
+++ b/packages/typescript/adapters/angular/src/index.ts
@@ -42,7 +42,7 @@ import type { SlopClient, NodeDescriptor } from "@slop-ai/core";
 export function useSlop<S = unknown>(
   client: SlopClient<S>,
   path: string | (() => string),
-  descriptor: () => NodeDescriptor
+  descriptor: () => NodeDescriptor,
 ): void {
   const destroyRef = inject(DestroyRef);
   let currentPath: string | null = null;

--- a/packages/typescript/adapters/react/__tests__/use-slop.test.tsx
+++ b/packages/typescript/adapters/react/__tests__/use-slop.test.tsx
@@ -72,7 +72,11 @@ describe("useSlop", () => {
     const client = createMockClient();
 
     function Harness({ path }: { path: string }) {
-      useSlop(client, () => path, () => ({ type: "collection", props: { path } }));
+      useSlop(
+        client,
+        () => path,
+        () => ({ type: "collection", props: { path } }),
+      );
       return null;
     }
 

--- a/packages/typescript/adapters/react/src/index.ts
+++ b/packages/typescript/adapters/react/src/index.ts
@@ -38,7 +38,7 @@ import type { SlopClient, NodeDescriptor } from "@slop-ai/core";
 export function useSlop<S = unknown>(
   client: SlopClient<S>,
   path: string | (() => string),
-  descriptor: () => NodeDescriptor
+  descriptor: () => NodeDescriptor,
 ): void {
   useEffect(() => {
     const resolvedPath = resolvePath(path);

--- a/packages/typescript/adapters/solid/src/index.ts
+++ b/packages/typescript/adapters/solid/src/index.ts
@@ -40,7 +40,7 @@ import type { SlopClient, NodeDescriptor } from "@slop-ai/core";
 export function useSlop<S = unknown>(
   client: SlopClient<S>,
   path: string | (() => string),
-  descriptor: () => NodeDescriptor
+  descriptor: () => NodeDescriptor,
 ): void {
   let currentPath = resolvePath(path);
 

--- a/packages/typescript/adapters/tanstack-start/__tests__/ws-handler.test.ts
+++ b/packages/typescript/adapters/tanstack-start/__tests__/ws-handler.test.ts
@@ -136,9 +136,7 @@ describe("createWebSocketHandler", () => {
       params: { status: "archived" },
     });
 
-    const invokeMessage = sent.find(
-      (message) => message.type === "invoke" && message.id !== undefined,
-    );
+    const invokeMessage = sent.find((message) => message.type === "invoke" && message.id !== undefined);
     expect(invokeMessage).toMatchObject({
       type: "invoke",
       path: "/ui/filters",

--- a/packages/typescript/adapters/tanstack-start/src/hooks.ts
+++ b/packages/typescript/adapters/tanstack-start/src/hooks.ts
@@ -168,7 +168,7 @@ export function useSlop(path: string, descriptor: NodeDescriptor): void {
 
     return () => {
       slopClient?.unregister(path);
-      pendingRegistrations = pendingRegistrations.filter(p => p.path !== path);
+      pendingRegistrations = pendingRegistrations.filter((p) => p.path !== path);
     };
   }, [path]);
 

--- a/packages/typescript/adapters/tanstack-start/src/mount-registry.ts
+++ b/packages/typescript/adapters/tanstack-start/src/mount-registry.ts
@@ -2,15 +2,13 @@ import type { SlopServer } from "@slop-ai/server";
 import type { UiMountSession } from "./ui-mount";
 
 declare global {
-  var __slop_ui_mounts:
-    | WeakMap<SlopServer<unknown>, Map<string, UiMountSession>>
-    | undefined;
+  var __slop_ui_mounts: WeakMap<SlopServer<unknown>, Map<string, UiMountSession>> | undefined;
 }
 
-const activeMounts = (
-  globalThis.__slop_ui_mounts ??=
-    new WeakMap<SlopServer<unknown>, Map<string, UiMountSession>>()
-) as WeakMap<SlopServer, Map<string, UiMountSession>>;
+const activeMounts = (globalThis.__slop_ui_mounts ??= new WeakMap<
+  SlopServer<unknown>,
+  Map<string, UiMountSession>
+>()) as WeakMap<SlopServer, Map<string, UiMountSession>>;
 
 export function registerUiMountSession(
   slop: SlopServer,
@@ -23,11 +21,7 @@ export function registerUiMountSession(
   return existing;
 }
 
-export function unregisterUiMountSession(
-  slop: SlopServer,
-  mountPath: string,
-  session: UiMountSession,
-): void {
+export function unregisterUiMountSession(slop: SlopServer, mountPath: string, session: UiMountSession): void {
   const mounts = activeMounts.get(slop);
   if (!mounts) return;
   if (mounts.get(mountPath) === session) {
@@ -35,10 +29,7 @@ export function unregisterUiMountSession(
   }
 }
 
-export async function refreshMountedUi(
-  slop: SlopServer,
-  options?: { skipPath?: string },
-): Promise<void> {
+export async function refreshMountedUi(slop: SlopServer, options?: { skipPath?: string }): Promise<void> {
   const mounts = activeMounts.get(slop);
   if (!mounts || mounts.size === 0) return;
 

--- a/packages/typescript/adapters/tanstack-start/src/ui-mount.ts
+++ b/packages/typescript/adapters/tanstack-start/src/ui-mount.ts
@@ -1,13 +1,5 @@
-import {
-  AsyncActionResult,
-} from "@slop-ai/core";
-import type {
-  SlopNode,
-  PatchOp,
-  NodeDescriptor,
-  JsonSchema,
-  ParamDef,
-} from "@slop-ai/core";
+import { AsyncActionResult } from "@slop-ai/core";
+import type { SlopNode, PatchOp, NodeDescriptor, JsonSchema, ParamDef } from "@slop-ai/core";
 import type { Connection, SlopServer } from "@slop-ai/server";
 
 const NODE_FIELDS = new Set(["properties", "meta", "affordances", "content_ref"]);
@@ -140,10 +132,7 @@ export class UiMountSession {
         break;
 
       case "error":
-        this.rejectPendingResult(
-          message.id,
-          new Error(message.error?.message ?? "Remote UI invoke failed"),
-        );
+        this.rejectPendingResult(message.id, new Error(message.error?.message ?? "Remote UI invoke failed"));
         break;
 
       case "batch":
@@ -181,11 +170,7 @@ export class UiMountSession {
       return Promise.resolve(undefined);
     }
 
-    return this.invokeRemote(
-      `/${this.remoteRootId}/__adapter`,
-      "refresh",
-      {},
-    );
+    return this.invokeRemote(`/${this.remoteRootId}/__adapter`, "refresh", {});
   }
 
   private applySnapshot(tree: SlopNode): void {
@@ -220,11 +205,7 @@ export class UiMountSession {
     );
   }
 
-  private invokeRemote(
-    path: string,
-    action: string,
-    params: Record<string, unknown>,
-  ): Promise<unknown> {
+  private invokeRemote(path: string, action: string, params: Record<string, unknown>): Promise<unknown> {
     if (!this.active) {
       return Promise.reject(new Error("Remote UI session is no longer active"));
     }
@@ -261,10 +242,7 @@ export class UiMountSession {
 
 function normalizeInvokeResult(message: ResultMessage): unknown {
   if (message.status === "accepted") {
-    const payload =
-      message.data && typeof message.data === "object"
-        ? message.data as Record<string, unknown>
-        : {};
+    const payload = message.data && typeof message.data === "object" ? (message.data as Record<string, unknown>) : {};
     const { taskId, ...rest } = payload;
 
     if (typeof taskId !== "string") {
@@ -312,11 +290,8 @@ function nodeToDescriptor(
           ...(affordance.dangerous ? { dangerous: true } : {}),
           ...(affordance.idempotent ? { idempotent: true } : {}),
           ...(affordance.estimate ? { estimate: affordance.estimate } : {}),
-          ...(affordance.params
-            ? { params: schemaToParamDefs(affordance.params) }
-            : {}),
-          handler: (params: Record<string, unknown>) =>
-            invoke(remotePath, affordance.action, params),
+          ...(affordance.params ? { params: schemaToParamDefs(affordance.params) } : {}),
+          handler: (params: Record<string, unknown>) => invoke(remotePath, affordance.action, params),
         },
       ]),
     );
@@ -324,10 +299,7 @@ function nodeToDescriptor(
 
   if (node.children?.length) {
     descriptor.children = Object.fromEntries(
-      node.children.map((child) => [
-        child.id,
-        nodeToDescriptor(child, `${remotePath}/${child.id}`, invoke),
-      ]),
+      node.children.map((child) => [child.id, nodeToDescriptor(child, `${remotePath}/${child.id}`, invoke)]),
     );
   }
 
@@ -404,10 +376,7 @@ function applyReplace(root: SlopNode, segments: string[], value: unknown): void 
   }
 }
 
-function navigate(
-  root: SlopNode,
-  segments: string[],
-): { parent: Record<string, unknown>; key: string } | null {
+function navigate(root: SlopNode, segments: string[]): { parent: Record<string, unknown>; key: string } | null {
   let current: Record<string, unknown> = root as unknown as Record<string, unknown>;
   for (let index = 0; index < segments.length - 1; index++) {
     const segment = segments[index];
@@ -419,9 +388,7 @@ function navigate(
     }
 
     const children = current.children as SlopNode[] | undefined;
-    const child = children?.find(
-      (candidate) => candidate.id === segment,
-    );
+    const child = children?.find((candidate) => candidate.id === segment);
     if (!child) return null;
     current = child as unknown as Record<string, unknown>;
   }

--- a/packages/typescript/adapters/tanstack-start/src/vite-plugin.ts
+++ b/packages/typescript/adapters/tanstack-start/src/vite-plugin.ts
@@ -34,9 +34,7 @@ interface VitePeerMessage {
  * });
  * ```
  */
-export function slopVitePlugin(
-  options: SlopHandlerOptions & { path?: string }
-) {
+export function slopVitePlugin(options: SlopHandlerOptions & { path?: string }) {
   const path = options.path ?? "/slop";
 
   return {
@@ -64,7 +62,9 @@ export function slopVitePlugin(
           send(data: string) {
             if (ws.readyState === WebSocket.OPEN) ws.send(data);
           },
-          close() { ws.close(); },
+          close() {
+            ws.close();
+          },
           __slopRequest: req,
         };
 
@@ -73,8 +73,12 @@ export function slopVitePlugin(
         ws.on("message", (data) => {
           // Wrap raw data in a peer message-like object
           const msg: VitePeerMessage = {
-            text() { return data.toString(); },
-            toString() { return data.toString(); },
+            text() {
+              return data.toString();
+            },
+            toString() {
+              return data.toString();
+            },
           };
           handler.message(peer, msg);
         });
@@ -91,13 +95,15 @@ export function slopVitePlugin(
         if (req.url === "/.well-known/slop") {
           const host = req.headers.host ?? "localhost";
           res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({
-            id: "slop",
-            name: "SLOP",
-            slop_version: "0.1",
-            transport: { type: "ws", url: `ws://${host}${path}` },
-            capabilities: ["state", "patches", "affordances"],
-          }));
+          res.end(
+            JSON.stringify({
+              id: "slop",
+              name: "SLOP",
+              slop_version: "0.1",
+              transport: { type: "ws", url: `ws://${host}${path}` },
+              capabilities: ["state", "patches", "affordances"],
+            }),
+          );
           return;
         }
         for (const listener of originalListeners) {

--- a/packages/typescript/adapters/tanstack-start/src/ws-handler.ts
+++ b/packages/typescript/adapters/tanstack-start/src/ws-handler.ts
@@ -1,10 +1,6 @@
 import type { SlopServer, Connection } from "@slop-ai/server";
 import { UiMountSession } from "./ui-mount";
-import {
-  refreshMountedUi,
-  registerUiMountSession,
-  unregisterUiMountSession,
-} from "./mount-registry";
+import { refreshMountedUi, registerUiMountSession, unregisterUiMountSession } from "./mount-registry";
 
 type RequestLike = {
   url?: string;
@@ -34,9 +30,9 @@ export interface SlopHandlerOptions {
    * For single-user apps, return a singleton.
    * For multi-user apps, use the context (e.g., auth cookie from the upgrade request)
    * to look up or create a per-session instance.
-  *
-  * @param context - The peer context (contains request headers, cookies, etc.)
-  */
+   *
+   * @param context - The peer context (contains request headers, cookies, etc.)
+   */
   resolve: (context: PeerContext) => SlopServer | Promise<SlopServer>;
   /**
    * Path to mount the browser-owned UI subtree under.
@@ -69,11 +65,14 @@ export interface SlopHandlerOptions {
  */
 export function createWebSocketHandler(options: SlopHandlerOptions) {
   const clients = new Map<HandlerPeer, { conn: Connection; slop: SlopServer }>();
-  const providerClients = new Map<HandlerPeer, {
-    session: UiMountSession;
-    slop: SlopServer;
-    mountPath: string;
-  }>();
+  const providerClients = new Map<
+    HandlerPeer,
+    {
+      session: UiMountSession;
+      slop: SlopServer;
+      mountPath: string;
+    }
+  >();
 
   return {
     async open(peer: HandlerPeer) {
@@ -83,8 +82,7 @@ export function createWebSocketHandler(options: SlopHandlerOptions) {
       const isProvider = url?.searchParams.get("slop_role") === "provider";
 
       if (isProvider) {
-        const mountPath =
-          url?.searchParams.get("mount") || options.uiMountPath || "ui";
+        const mountPath = url?.searchParams.get("mount") || options.uiMountPath || "ui";
         const session = new UiMountSession(slop, peerToConnection(peer), mountPath);
         const existing = registerUiMountSession(slop, mountPath, session);
         if (existing && existing !== session) {
@@ -134,11 +132,7 @@ export function createWebSocketHandler(options: SlopHandlerOptions) {
     close(peer: HandlerPeer) {
       const providerClient = providerClients.get(peer);
       if (providerClient) {
-        unregisterUiMountSession(
-          providerClient.slop,
-          providerClient.mountPath,
-          providerClient.session,
-        );
+        unregisterUiMountSession(providerClient.slop, providerClient.mountPath, providerClient.session);
         providerClient.session.deactivate("Browser UI session disconnected");
         providerClients.delete(peer);
         return;
@@ -201,10 +195,7 @@ function getPeerUrl(peer: HandlerPeer): URL | null {
   if (!request?.url) return null;
 
   try {
-    return new URL(
-      request.url,
-      `http://${request.headers?.host ?? "localhost"}`,
-    );
+    return new URL(request.url, `http://${request.headers?.host ?? "localhost"}`);
   } catch (e) {
     console.warn("[slop] failed to parse peer URL:", e);
     return null;
@@ -212,14 +203,14 @@ function getPeerUrl(peer: HandlerPeer): URL | null {
 }
 
 function isProviderMessage(value: unknown): value is Parameters<UiMountSession["handleMessage"]>[0] {
-  return !!value
-    && typeof value === "object"
-    && typeof (value as { type?: unknown }).type === "string";
+  return !!value && typeof value === "object" && typeof (value as { type?: unknown }).type === "string";
 }
 
 function isInvokeMessage(value: unknown): value is { type: "invoke"; path: string } {
-  return !!value
-    && typeof value === "object"
-    && (value as { type?: unknown }).type === "invoke"
-    && typeof (value as { path?: unknown }).path === "string";
+  return (
+    !!value &&
+    typeof value === "object" &&
+    (value as { type?: unknown }).type === "invoke" &&
+    typeof (value as { path?: unknown }).path === "string"
+  );
 }

--- a/packages/typescript/adapters/vue/src/index.ts
+++ b/packages/typescript/adapters/vue/src/index.ts
@@ -38,21 +38,24 @@ import type { SlopClient, NodeDescriptor } from "@slop-ai/core";
 export function useSlop<S = unknown>(
   client: SlopClient<S>,
   path: string | (() => string),
-  descriptor: () => NodeDescriptor
+  descriptor: () => NodeDescriptor,
 ): void {
   let currentPath = resolvePath(path);
 
-  watchEffect(() => {
-    const p = resolvePath(path);
-    const desc = descriptor();
+  watchEffect(
+    () => {
+      const p = resolvePath(path);
+      const desc = descriptor();
 
-    if (p !== currentPath) {
-      client.unregister(currentPath);
-      currentPath = p;
-    }
+      if (p !== currentPath) {
+        client.unregister(currentPath);
+        currentPath = p;
+      }
 
-    client.register(currentPath, deepUnwrap(desc) as NodeDescriptor);
-  }, { flush: "post" });
+      client.register(currentPath, deepUnwrap(desc) as NodeDescriptor);
+    },
+    { flush: "post" },
+  );
 
   onUnmounted(() => {
     client.unregister(currentPath);

--- a/packages/typescript/integrations/claude/slop-mcp-proxy/servers/slop-bridge.mjs
+++ b/packages/typescript/integrations/claude/slop-mcp-proxy/servers/slop-bridge.mjs
@@ -19,10 +19,7 @@
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { createDiscoveryService } from "@slop-ai/discovery";
 import { createToolHandlers } from "@slop-ai/discovery";
 import { formatTree } from "@slop-ai/consumer";
@@ -88,10 +85,7 @@ function writeStateFile() {
       };
     });
 
-    fs.writeFileSync(
-      STATE_FILE,
-      JSON.stringify({ lastUpdated: Date.now(), providers, available }, null, 2),
-    );
+    fs.writeFileSync(STATE_FILE, JSON.stringify({ lastUpdated: Date.now(), providers, available }, null, 2));
   } catch (err) {
     log.error("Failed to write state file:", err.message);
   }
@@ -127,8 +121,7 @@ const TOOLS = [
       properties: {
         app: {
           type: "string",
-          description:
-            "App name or ID to connect. Omit to list all apps.",
+          description: "App name or ID to connect. Omit to list all apps.",
         },
       },
     },
@@ -219,10 +212,7 @@ const TOOLS = [
 // MCP Server
 // ---------------------------------------------------------------------------
 
-const server = new Server(
-  { name: "slop-bridge", version: "0.1.0" },
-  { capabilities: { tools: {} } }
-);
+const server = new Server({ name: "slop-bridge", version: "0.1.0" }, { capabilities: { tools: {} } });
 
 // --- List tools (static only) ---
 
@@ -255,25 +245,26 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           };
         }
         try {
-          const result = await p.consumer.invoke(
-            args.path,
-            args.action,
-            args.params ?? {},
-          );
+          const result = await p.consumer.invoke(args.path, args.action, args.params ?? {});
           if (result.status === "ok") {
             return {
-              content: [{
-                type: "text",
-                text: `Done. ${args.action} on ${args.path} succeeded.` +
-                  (result.data ? ` Result: ${JSON.stringify(result.data)}` : ""),
-              }],
+              content: [
+                {
+                  type: "text",
+                  text:
+                    `Done. ${args.action} on ${args.path} succeeded.` +
+                    (result.data ? ` Result: ${JSON.stringify(result.data)}` : ""),
+                },
+              ],
             };
           }
           return {
-            content: [{
-              type: "text",
-              text: `Action failed: [${result.error?.code}] ${result.error?.message}`,
-            }],
+            content: [
+              {
+                type: "text",
+                text: `Action failed: [${result.error?.code}] ${result.error?.message}`,
+              },
+            ],
             isError: true,
           };
         } catch (err) {
@@ -309,11 +300,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           }
         }
         return {
-          content: [{
-            type: "text",
-            text: `Batch complete: ${args.actions.length - failed}/${args.actions.length} succeeded.\n` +
-              results.join("\n"),
-          }],
+          content: [
+            {
+              type: "text",
+              text:
+                `Batch complete: ${args.actions.length - failed}/${args.actions.length} succeeded.\n` +
+                results.join("\n"),
+            },
+          ],
           isError: failed > 0,
         };
       }
@@ -346,12 +340,16 @@ async function main() {
 
   process.on("SIGINT", () => {
     discovery.stop();
-    try { fs.unlinkSync(STATE_FILE); } catch {}
+    try {
+      fs.unlinkSync(STATE_FILE);
+    } catch {}
     process.exit(0);
   });
   process.on("SIGTERM", () => {
     discovery.stop();
-    try { fs.unlinkSync(STATE_FILE); } catch {}
+    try {
+      fs.unlinkSync(STATE_FILE);
+    } catch {}
     process.exit(0);
   });
 }

--- a/packages/typescript/integrations/claude/slop-native/servers/slop-bridge.mjs
+++ b/packages/typescript/integrations/claude/slop-native/servers/slop-bridge.mjs
@@ -17,10 +17,7 @@
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { createDiscoveryService } from "@slop-ai/discovery";
 import { createToolHandlers, createDynamicTools } from "@slop-ai/discovery";
 import { formatTree } from "@slop-ai/consumer";
@@ -92,10 +89,7 @@ function writeStateFile() {
       };
     });
 
-    fs.writeFileSync(
-      STATE_FILE,
-      JSON.stringify({ lastUpdated: Date.now(), providers, available }, null, 2),
-    );
+    fs.writeFileSync(STATE_FILE, JSON.stringify({ lastUpdated: Date.now(), providers, available }, null, 2));
   } catch (err) {
     log.error("Failed to write state file:", err.message);
   }
@@ -138,8 +132,7 @@ const STATIC_TOOLS = [
       properties: {
         app: {
           type: "string",
-          description:
-            "App name or ID to connect. Omit to list all apps.",
+          description: "App name or ID to connect. Omit to list all apps.",
         },
       },
     },
@@ -168,7 +161,7 @@ const STATIC_TOOLS = [
 
 const server = new Server(
   { name: "slop-bridge", version: "0.1.0" },
-  { capabilities: { tools: { listChanged: true } } }
+  { capabilities: { tools: { listChanged: true } } },
 );
 
 // --- List tools (static + dynamic) ---
@@ -234,13 +227,23 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const { target, ...rest } = invokeArgs;
         if (!target || typeof target !== "string") {
           return {
-            content: [{ type: "text", text: `Missing required "target" parameter. Specify the path to the target node (see state tree for valid paths).` }],
+            content: [
+              {
+                type: "text",
+                text: `Missing required "target" parameter. Specify the path to the target node (see state tree for valid paths).`,
+              },
+            ],
             isError: true,
           };
         }
         if (resolved.targets && !resolved.targets.includes(target)) {
           return {
-            content: [{ type: "text", text: `Invalid target "${target}". Valid targets: ${resolved.targets.join(", ")}. Check the state tree for current paths.` }],
+            content: [
+              {
+                type: "text",
+                text: `Invalid target "${target}". Valid targets: ${resolved.targets.join(", ")}. Check the state tree for current paths.`,
+              },
+            ],
             isError: true,
           };
         }
@@ -249,26 +252,26 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       try {
-        const result = await provider.consumer.invoke(
-          invokePath,
-          resolved.action,
-          invokeArgs,
-        );
+        const result = await provider.consumer.invoke(invokePath, resolved.action, invokeArgs);
 
         if (result.status === "ok") {
           return {
-            content: [{
-              type: "text",
-              text: `Done.` + (result.data ? ` Result: ${JSON.stringify(result.data)}` : ""),
-            }],
+            content: [
+              {
+                type: "text",
+                text: `Done.` + (result.data ? ` Result: ${JSON.stringify(result.data)}` : ""),
+              },
+            ],
           };
         }
 
         return {
-          content: [{
-            type: "text",
-            text: `Action failed: [${result.error?.code}] ${result.error?.message}`,
-          }],
+          content: [
+            {
+              type: "text",
+              text: `Action failed: [${result.error?.code}] ${result.error?.message}`,
+            },
+          ],
           isError: true,
         };
       } catch (err) {
@@ -308,12 +311,16 @@ async function main() {
   // Cleanup on exit
   process.on("SIGINT", () => {
     discovery.stop();
-    try { fs.unlinkSync(STATE_FILE); } catch {}
+    try {
+      fs.unlinkSync(STATE_FILE);
+    } catch {}
     process.exit(0);
   });
   process.on("SIGTERM", () => {
     discovery.stop();
-    try { fs.unlinkSync(STATE_FILE); } catch {}
+    try {
+      fs.unlinkSync(STATE_FILE);
+    } catch {}
     process.exit(0);
   });
 }

--- a/packages/typescript/integrations/codex/slop/servers/slop-bridge.mjs
+++ b/packages/typescript/integrations/codex/slop/servers/slop-bridge.mjs
@@ -11,10 +11,7 @@
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { createDiscoveryService, createToolHandlers } from "@slop-ai/discovery";
 import { formatTree } from "@slop-ai/consumer";
 import fs from "node:fs";
@@ -62,10 +59,7 @@ function writeStateFile() {
       };
     });
 
-    fs.writeFileSync(
-      STATE_FILE,
-      JSON.stringify({ lastUpdated: Date.now(), providers, available }, null, 2),
-    );
+    fs.writeFileSync(STATE_FILE, JSON.stringify({ lastUpdated: Date.now(), providers, available }, null, 2));
   } catch (err) {
     log.error("Failed to write state file:", err.message);
   }
@@ -103,8 +97,7 @@ const TOOLS = [
   },
   {
     name: "disconnect_app",
-    description:
-      "Disconnect from an application when you're done interacting with it.",
+    description: "Disconnect from an application when you're done interacting with it.",
     inputSchema: {
       type: "object",
       properties: {
@@ -184,10 +177,7 @@ const TOOLS = [
   },
 ];
 
-const server = new Server(
-  { name: "slop-bridge", version: "0.1.0" },
-  { capabilities: { tools: {} } },
-);
+const server = new Server({ name: "slop-bridge", version: "0.1.0" }, { capabilities: { tools: {} } });
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
 
@@ -215,28 +205,28 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
 
         try {
-          const result = await provider.consumer.invoke(
-            args.path,
-            args.action,
-            args.params ?? {},
-          );
+          const result = await provider.consumer.invoke(args.path, args.action, args.params ?? {});
 
           if (result.status === "ok") {
             return {
-              content: [{
-                type: "text",
-                text:
-                  `Done. ${args.action} on ${args.path} succeeded.` +
-                  (result.data ? ` Result: ${JSON.stringify(result.data)}` : ""),
-              }],
+              content: [
+                {
+                  type: "text",
+                  text:
+                    `Done. ${args.action} on ${args.path} succeeded.` +
+                    (result.data ? ` Result: ${JSON.stringify(result.data)}` : ""),
+                },
+              ],
             };
           }
 
           return {
-            content: [{
-              type: "text",
-              text: `Action failed: [${result.error?.code}] ${result.error?.message}`,
-            }],
+            content: [
+              {
+                type: "text",
+                text: `Action failed: [${result.error?.code}] ${result.error?.message}`,
+              },
+            ],
             isError: true,
           };
         } catch (err) {
@@ -275,12 +265,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
 
         return {
-          content: [{
-            type: "text",
-            text:
-              `Batch complete: ${args.actions.length - failed}/${args.actions.length} succeeded.\n` +
-              results.join("\n"),
-          }],
+          content: [
+            {
+              type: "text",
+              text:
+                `Batch complete: ${args.actions.length - failed}/${args.actions.length} succeeded.\n` +
+                results.join("\n"),
+            },
+          ],
           isError: failed > 0,
         };
       }

--- a/packages/typescript/integrations/discovery/__tests__/bridge-client.test.ts
+++ b/packages/typescript/integrations/discovery/__tests__/bridge-client.test.ts
@@ -19,20 +19,24 @@ describe("createBridgeClient", () => {
       await waitUntil(() => server.clients.size === 1);
       const [socket] = Array.from(server.clients);
 
-      socket.send(JSON.stringify({
-        type: "provider-available",
-        tabId: 1,
-        providerKey: "browser-app",
-        provider: { id: "browser-app", name: "Browser App", transport: "postmessage" },
-      }));
+      socket.send(
+        JSON.stringify({
+          type: "provider-available",
+          tabId: 1,
+          providerKey: "browser-app",
+          provider: { id: "browser-app", name: "Browser App", transport: "postmessage" },
+        }),
+      );
 
       await waitUntil(() => client.providers().length === 1);
       expect(client.providers()[0].providerKey).toBe("browser-app");
 
-      socket.send(JSON.stringify({
-        type: "provider-unavailable",
-        providerKey: "browser-app",
-      }));
+      socket.send(
+        JSON.stringify({
+          type: "provider-unavailable",
+          providerKey: "browser-app",
+        }),
+      );
 
       await waitUntil(() => client.providers().length === 0);
       expect(client.running()).toBe(true);

--- a/packages/typescript/integrations/discovery/__tests__/bridge-server.test.ts
+++ b/packages/typescript/integrations/discovery/__tests__/bridge-server.test.ts
@@ -11,12 +11,14 @@ describe("createBridgeServer", () => {
     const first = await connectWebSocket(`ws://127.0.0.1:${port}/slop-bridge`);
 
     try {
-      first.send(JSON.stringify({
-        type: "provider-available",
-        tabId: 1,
-        providerKey: "browser-app",
-        provider: { id: "browser-app", name: "Browser App", transport: "postmessage" },
-      }));
+      first.send(
+        JSON.stringify({
+          type: "provider-available",
+          tabId: 1,
+          providerKey: "browser-app",
+          provider: { id: "browser-app", name: "Browser App", transport: "postmessage" },
+        }),
+      );
 
       await waitUntil(() => server.providers().length === 1);
 

--- a/packages/typescript/integrations/discovery/__tests__/discovery.test.ts
+++ b/packages/typescript/integrations/discovery/__tests__/discovery.test.ts
@@ -60,13 +60,15 @@ describe("createDiscoveryService", () => {
     try {
       service.start();
 
-      bridge.setProviders([{
-        providerKey: "browser-app",
-        tabId: 1,
-        id: "browser-app",
-        name: "Browser App",
-        transport: "postmessage",
-      }]);
+      bridge.setProviders([
+        {
+          providerKey: "browser-app",
+          tabId: 1,
+          id: "browser-app",
+          name: "Browser App",
+          transport: "postmessage",
+        },
+      ]);
 
       await waitUntil(() => service.getDiscovered().some((provider) => provider.id === "browser-app"));
 

--- a/packages/typescript/integrations/discovery/__tests__/helpers.ts
+++ b/packages/typescript/integrations/discovery/__tests__/helpers.ts
@@ -116,12 +116,7 @@ export async function createMockSlopProviderServer(options: {
   providerName?: string;
   helloDelayMs?: number;
 }) {
-  const {
-    port,
-    providerId = "test-provider",
-    providerName = "Test Provider",
-    helloDelayMs = 0,
-  } = options;
+  const { port, providerId = "test-provider", providerName = "Test Provider", helloDelayMs = 0 } = options;
   const clients = new Set<WebSocket>();
   let connectionCount = 0;
 
@@ -132,40 +127,46 @@ export async function createMockSlopProviderServer(options: {
 
     setTimeout(() => {
       if (ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({
-          type: "hello",
-          provider: {
-            id: providerId,
-            name: providerName,
-            slop_version: "0.1",
-            capabilities: [],
-          },
-        }));
+        ws.send(
+          JSON.stringify({
+            type: "hello",
+            provider: {
+              id: providerId,
+              name: providerName,
+              slop_version: "0.1",
+              capabilities: [],
+            },
+          }),
+        );
       }
     }, helloDelayMs);
 
     ws.on("message", (raw) => {
       const message = JSON.parse(raw.toString()) as Record<string, unknown>;
       if (message.type === "subscribe") {
-        ws.send(JSON.stringify({
-          type: "snapshot",
-          id: message.id,
-          version: 1,
-          tree: {
-            id: providerId,
-            type: "root",
-            properties: { label: providerName },
-            children: [],
-            affordances: [],
-          },
-        }));
+        ws.send(
+          JSON.stringify({
+            type: "snapshot",
+            id: message.id,
+            version: 1,
+            tree: {
+              id: providerId,
+              type: "root",
+              properties: { label: providerName },
+              children: [],
+              affordances: [],
+            },
+          }),
+        );
       }
       if (message.type === "invoke") {
-        ws.send(JSON.stringify({
-          type: "result",
-          id: message.id,
-          status: "ok",
-        }));
+        ws.send(
+          JSON.stringify({
+            type: "result",
+            id: message.id,
+            status: "ok",
+          }),
+        );
       }
     });
 

--- a/packages/typescript/integrations/discovery/__tests__/tools.test.ts
+++ b/packages/typescript/integrations/discovery/__tests__/tools.test.ts
@@ -6,12 +6,14 @@ const tree = {
   id: "root",
   type: "root",
   properties: { label: "Test App" },
-  children: [{
-    id: "todo-1",
-    type: "item",
-    properties: { label: "Todo 1" },
-    affordances: [{ action: "complete", description: "Complete item" }],
-  }],
+  children: [
+    {
+      id: "todo-1",
+      type: "item",
+      properties: { label: "Todo 1" },
+      affordances: [{ action: "complete", description: "Complete item" }],
+    },
+  ],
 };
 
 describe("discovery tools", () => {

--- a/packages/typescript/integrations/discovery/src/anthropic-agent-sdk.ts
+++ b/packages/typescript/integrations/discovery/src/anthropic-agent-sdk.ts
@@ -33,9 +33,7 @@ export function createSlopAgentTools(discovery: ReturnType<typeof createDiscover
     "connect_app",
     "Connect to an application running on this computer and see its full current state and every action you can perform.",
     {
-      app: z
-        .string()
-        .describe("App name or ID to connect and inspect."),
+      app: z.string().describe("App name or ID to connect and inspect."),
     },
     async (args) => handlers.connectApp(args),
   );
@@ -58,10 +56,7 @@ export function createSlopAgentTools(discovery: ReturnType<typeof createDiscover
  *
  * Programmatic use: pass `server` to `query()` via `mcpServers`.
  */
-export function createSlopMcpServer(options?: {
-  name?: string;
-  version?: string;
-}) {
+export function createSlopMcpServer(options?: { name?: string; version?: string }) {
   const discovery = createDiscoveryService();
   discovery.start();
 

--- a/packages/typescript/integrations/discovery/src/bridge-client.ts
+++ b/packages/typescript/integrations/discovery/src/bridge-client.ts
@@ -61,14 +61,8 @@ export function parseBridgeProvider(msg: Record<string, unknown>): BridgeProvide
 // Bridge Client
 // ---------------------------------------------------------------------------
 
-export function createBridgeClient(
-  options: BridgeClientOptions = {},
-): Bridge & { connectOnce(): Promise<void> } {
-  const {
-    logger: log,
-    url,
-    reconnectIntervalMs,
-  } = normalizeOptions(options);
+export function createBridgeClient(options: BridgeClientOptions = {}): Bridge & { connectOnce(): Promise<void> } {
+  const { logger: log, url, reconnectIntervalMs } = normalizeOptions(options);
 
   let ws: WebSocket | null = null;
   let isRunning = false;
@@ -148,10 +142,12 @@ export function createBridgeClient(
 
   function scheduleReconnect() {
     if (!started || reconnectTimer) return;
-    reconnectTimer = unrefTimer(setTimeout(() => {
-      reconnectTimer = null;
-      void doConnect().catch(() => {});
-    }, reconnectIntervalMs));
+    reconnectTimer = unrefTimer(
+      setTimeout(() => {
+        reconnectTimer = null;
+        void doConnect().catch(() => {});
+      }, reconnectIntervalMs),
+    );
   }
 
   function handleMessage(msg: Record<string, unknown>) {

--- a/packages/typescript/integrations/discovery/src/bridge-server.ts
+++ b/packages/typescript/integrations/discovery/src/bridge-server.ts
@@ -22,15 +22,8 @@ export interface BridgeServerOptions {
  * Accepts connections from the browser extension and other consumers,
  * tracks provider announcements, and relays SLOP messages for postMessage providers.
  */
-export function createBridgeServer(
-  options: BridgeServerOptions = {},
-): Bridge & { start(): Promise<void> } {
-  const {
-    logger: log,
-    host,
-    port,
-    path,
-  } = normalizeOptions(options);
+export function createBridgeServer(options: BridgeServerOptions = {}): Bridge & { start(): Promise<void> } {
+  const { logger: log, host, port, path } = normalizeOptions(options);
 
   let wss: WebSocketServer | null = null;
   let isRunning = false;

--- a/packages/typescript/integrations/discovery/src/cli.ts
+++ b/packages/typescript/integrations/discovery/src/cli.ts
@@ -37,12 +37,10 @@ server.tool(
   "connect_app",
   isPluginMode
     ? "Connect to a discovered application and refresh its full current state. " +
-      "Use this when you need to inspect a newly discovered app or refresh the active app state."
+        "Use this when you need to inspect a newly discovered app or refresh the active app state."
     : "Connect to an application running on this computer and see its full current state and every action you can perform.",
   {
-    app: z
-      .string()
-      .describe("App name or ID to connect and inspect."),
+    app: z.string().describe("App name or ID to connect and inspect."),
   },
   async (args) => handlers.connectApp(args),
 );

--- a/packages/typescript/integrations/discovery/src/discovery.ts
+++ b/packages/typescript/integrations/discovery/src/discovery.ts
@@ -7,23 +7,13 @@ import {
   NodeSocketClientTransport,
   type ClientTransport,
 } from "@slop-ai/consumer";
-import {
-  DEFAULT_BRIDGE_URL,
-  createBridgeClient,
-  type Bridge,
-  type BridgeProvider,
-} from "./bridge-client";
-import {
-  DEFAULT_BRIDGE_HOST,
-  DEFAULT_BRIDGE_PATH,
-  DEFAULT_BRIDGE_PORT,
-  createBridgeServer,
-} from "./bridge-server";
+import { DEFAULT_BRIDGE_URL, createBridgeClient, type Bridge, type BridgeProvider } from "./bridge-client";
+import { DEFAULT_BRIDGE_HOST, DEFAULT_BRIDGE_PATH, DEFAULT_BRIDGE_PORT, createBridgeServer } from "./bridge-server";
 import { BridgeRelayTransport } from "./relay-transport";
 
 const DEFAULT_PROVIDERS_DIRS = [
-  join(homedir(), ".slop", "providers"),  // persistent user-level
-  "/tmp/slop/providers",                   // session-level ephemeral
+  join(homedir(), ".slop", "providers"), // persistent user-level
+  "/tmp/slop/providers", // session-level ephemeral
 ];
 const DEFAULT_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
@@ -101,9 +91,7 @@ export interface DiscoveryService {
   stop(): void;
 }
 
-export function createDiscoveryService(
-  options: DiscoveryOptions = {},
-): DiscoveryService {
+export function createDiscoveryService(options: DiscoveryOptions = {}): DiscoveryService {
   const opts = normalizeOptions(options);
   const {
     log,
@@ -193,9 +181,7 @@ export function createDiscoveryService(
     // WS providers from the bridge can be connected directly
     // postMessage providers need the relay transport
     const transport =
-      bp.transport === "ws" && bp.url
-        ? { type: "ws" as const, url: bp.url }
-        : { type: "relay" as const };
+      bp.transport === "ws" && bp.url ? { type: "ws" as const, url: bp.url } : { type: "relay" as const };
 
     return {
       id: bp.providerKey,
@@ -240,98 +226,106 @@ export function createDiscoveryService(
     }
 
     const generation = lifecycleVersion;
-    const trackedPromise = Promise.resolve().then(async () => {
-      const transport = createTransport(desc);
-      if (!transport) {
-        log.info(`[slop] Skipping ${desc.name}: unsupported transport ${desc.transport.type}`);
-        return null;
-      }
-
-      clearReconnectTimer(desc.id);
-
-      const entry: ConnectedProvider = {
-        id: desc.id,
-        name: desc.name,
-        descriptor: desc,
-        consumer: new SlopConsumer(transport),
-        subscriptionId: "",
-        status: "connecting",
-      };
-      providers.set(desc.id, entry);
-
-      try {
-        const hello = await withTimeout(
-          entry.consumer.connect(),
-          connectTimeoutMs,
-          `Connection timed out after ${Math.round(connectTimeoutMs / 1000)}s`,
-        );
-        const { id: subId } = await withTimeout(
-          entry.consumer.subscribe("/", -1),
-          connectTimeoutMs,
-          `Subscription timed out after ${Math.round(connectTimeoutMs / 1000)}s`,
-        );
-
-        if (lifecycleVersion !== generation || !providers.has(desc.id)) {
-          entry.consumer.disconnect();
+    const trackedPromise = Promise.resolve()
+      .then(async () => {
+        const transport = createTransport(desc);
+        if (!transport) {
+          log.info(`[slop] Skipping ${desc.name}: unsupported transport ${desc.transport.type}`);
           return null;
         }
 
-        entry.name = hello.provider.name;
-        entry.subscriptionId = subId;
-        entry.status = "connected";
-        lastAccessed.set(desc.id, Date.now());
-        reconnectAttempts.delete(desc.id);
-        intentionalDisconnects.delete(desc.id);
-        log.info(`[slop] Connected to ${entry.name} (${desc.id}) via ${desc.transport.type}`);
-        stateChangeCallback?.();
+        clearReconnectTimer(desc.id);
 
-        entry.consumer.on("patch", () => {
+        const entry: ConnectedProvider = {
+          id: desc.id,
+          name: desc.name,
+          descriptor: desc,
+          consumer: new SlopConsumer(transport),
+          subscriptionId: "",
+          status: "connecting",
+        };
+        providers.set(desc.id, entry);
+
+        try {
+          const hello = await withTimeout(
+            entry.consumer.connect(),
+            connectTimeoutMs,
+            `Connection timed out after ${Math.round(connectTimeoutMs / 1000)}s`,
+          );
+          const { id: subId } = await withTimeout(
+            entry.consumer.subscribe("/", -1),
+            connectTimeoutMs,
+            `Subscription timed out after ${Math.round(connectTimeoutMs / 1000)}s`,
+          );
+
+          if (lifecycleVersion !== generation || !providers.has(desc.id)) {
+            entry.consumer.disconnect();
+            return null;
+          }
+
+          entry.name = hello.provider.name;
+          entry.subscriptionId = subId;
+          entry.status = "connected";
+          lastAccessed.set(desc.id, Date.now());
+          reconnectAttempts.delete(desc.id);
+          intentionalDisconnects.delete(desc.id);
+          log.info(`[slop] Connected to ${entry.name} (${desc.id}) via ${desc.transport.type}`);
           stateChangeCallback?.();
-        });
 
-        entry.consumer.on("disconnect", () => {
-          const wasIntentional = intentionalDisconnects.delete(desc.id);
-          log.info(`[slop] Disconnected from ${entry.name}`);
-          entry.status = "disconnected";
+          entry.consumer.on("patch", () => {
+            stateChangeCallback?.();
+          });
+
+          entry.consumer.on("disconnect", () => {
+            const wasIntentional = intentionalDisconnects.delete(desc.id);
+            log.info(`[slop] Disconnected from ${entry.name}`);
+            entry.status = "disconnected";
+            providers.delete(desc.id);
+            lastAccessed.delete(desc.id);
+            stateChangeCallback?.();
+
+            if (wasIntentional || lifecycleVersion !== generation) {
+              reconnectAttempts.delete(desc.id);
+              clearReconnectTimer(desc.id);
+              return;
+            }
+
+            if (getAllDescriptors().some((d) => d.id === desc.id)) {
+              const attempt = (reconnectAttempts.get(desc.id) ?? 0) + 1;
+              reconnectAttempts.set(desc.id, attempt);
+              const delay = Math.min(reconnectBaseDelayMs * Math.pow(2, attempt - 1), maxReconnectDelayMs);
+              log.info(`[slop] Will reconnect to ${entry.name} in ${delay / 1000}s (attempt ${attempt})`);
+              clearReconnectTimer(desc.id);
+              reconnectTimers.set(
+                desc.id,
+                unrefTimer(
+                  setTimeout(() => {
+                    reconnectTimers.delete(desc.id);
+                    if (
+                      lifecycleVersion === generation &&
+                      !providers.has(desc.id) &&
+                      getAllDescriptors().some((d) => d.id === desc.id)
+                    ) {
+                      void connectProvider(desc).catch(() => {});
+                    }
+                  }, delay),
+                ),
+              );
+            }
+          });
+
+          return entry;
+        } catch (err: any) {
+          log.error(`[slop] Failed to connect to ${desc.name}: ${err.message}`);
           providers.delete(desc.id);
-          lastAccessed.delete(desc.id);
-          stateChangeCallback?.();
-
-          if (wasIntentional || lifecycleVersion !== generation) {
-            reconnectAttempts.delete(desc.id);
-            clearReconnectTimer(desc.id);
-            return;
-          }
-
-          if (getAllDescriptors().some(d => d.id === desc.id)) {
-            const attempt = (reconnectAttempts.get(desc.id) ?? 0) + 1;
-            reconnectAttempts.set(desc.id, attempt);
-            const delay = Math.min(
-              reconnectBaseDelayMs * Math.pow(2, attempt - 1),
-              maxReconnectDelayMs,
-            );
-            log.info(`[slop] Will reconnect to ${entry.name} in ${delay / 1000}s (attempt ${attempt})`);
-            clearReconnectTimer(desc.id);
-            reconnectTimers.set(desc.id, unrefTimer(setTimeout(() => {
-              reconnectTimers.delete(desc.id);
-              if (lifecycleVersion === generation && !providers.has(desc.id) && getAllDescriptors().some(d => d.id === desc.id)) {
-                void connectProvider(desc).catch(() => {});
-              }
-            }, delay)));
-          }
-        });
-
-        return entry;
-      } catch (err: any) {
-        log.error(`[slop] Failed to connect to ${desc.name}: ${err.message}`);
-        providers.delete(desc.id);
-        return null;
-      }
-    }).finally(() => {
-      if (connecting.get(desc.id) === trackedPromise) {
-        connecting.delete(desc.id);
-      }
-    });
+          return null;
+        }
+      })
+      .finally(() => {
+        if (connecting.get(desc.id) === trackedPromise) {
+          connecting.delete(desc.id);
+        }
+      });
     connecting.set(desc.id, trackedPromise);
     return trackedPromise;
   }
@@ -340,7 +334,7 @@ export function createDiscoveryService(
 
   function scan() {
     lastLocalDescriptors = readDescriptors();
-    const allIds = new Set(getAllDescriptors().map(d => d.id));
+    const allIds = new Set(getAllDescriptors().map((d) => d.id));
     let changed = false;
 
     // Clean up connected providers whose descriptors are gone
@@ -389,9 +383,7 @@ export function createDiscoveryService(
 
   // --- Lookup ---
 
-  async function initBridge(
-    logger: Logger,
-  ): Promise<Bridge> {
+  async function initBridge(logger: Logger): Promise<Bridge> {
     // 1. Try connecting as a client (Desktop or another consumer hosts the bridge)
     const client = createBridgeClient({
       logger,
@@ -448,10 +440,12 @@ export function createDiscoveryService(
     if (watchDebounceTimer) {
       clearTimeout(watchDebounceTimer);
     }
-    watchDebounceTimer = unrefTimer(setTimeout(() => {
-      watchDebounceTimer = null;
-      scan();
-    }, watchDebounceMs));
+    watchDebounceTimer = unrefTimer(
+      setTimeout(() => {
+        watchDebounceTimer = null;
+        scan();
+      }, watchDebounceMs),
+    );
   }
 
   function clearReconnectTimer(id: string) {
@@ -470,8 +464,8 @@ export function createDiscoveryService(
   function findDescriptor(idOrName: string): ProviderDescriptor | null {
     const all = getAllDescriptors();
     return (
-      all.find(d => d.id === idOrName) ??
-      all.find(d => d.name.toLowerCase().includes(idOrName.toLowerCase())) ??
+      all.find((d) => d.id === idOrName) ??
+      all.find((d) => d.name.toLowerCase().includes(idOrName.toLowerCase())) ??
       null
     );
   }
@@ -486,7 +480,7 @@ export function createDiscoveryService(
     },
 
     getProviders() {
-      return Array.from(providers.values()).filter(p => p.status === "connected");
+      return Array.from(providers.values()).filter((p) => p.status === "connected");
     },
 
     getProvider(id: string) {
@@ -599,10 +593,22 @@ export function createDiscoveryService(
       lifecycleVersion += 1;
       for (const w of watchers) w.close();
       watchers = [];
-      if (scanTimer) { clearInterval(scanTimer); scanTimer = null; }
-      if (idleTimer) { clearInterval(idleTimer); idleTimer = null; }
-      if (watchDebounceTimer) { clearTimeout(watchDebounceTimer); watchDebounceTimer = null; }
-      if (bridge) { bridge.stop(); bridge = null; }
+      if (scanTimer) {
+        clearInterval(scanTimer);
+        scanTimer = null;
+      }
+      if (idleTimer) {
+        clearInterval(idleTimer);
+        idleTimer = null;
+      }
+      if (watchDebounceTimer) {
+        clearTimeout(watchDebounceTimer);
+        watchDebounceTimer = null;
+      }
+      if (bridge) {
+        bridge.stop();
+        bridge = null;
+      }
       for (const [, promise] of connecting) {
         void promise.catch(() => {});
       }

--- a/packages/typescript/integrations/discovery/src/relay-transport.ts
+++ b/packages/typescript/integrations/discovery/src/relay-transport.ts
@@ -48,7 +48,9 @@ export class BridgeRelayTransport implements ClientTransport {
     const RETRY_DELAY = 300;
     const MAX_RETRIES = 3;
     let gotResponse = false;
-    const sentinel = () => { gotResponse = true; };
+    const sentinel = () => {
+      gotResponse = true;
+    };
     messageHandlers.push(sentinel);
 
     for (let attempt = 0; attempt <= MAX_RETRIES && !gotResponse; attempt++) {

--- a/packages/typescript/integrations/discovery/src/state-cache.ts
+++ b/packages/typescript/integrations/discovery/src/state-cache.ts
@@ -20,9 +20,7 @@ function formatProviderState(p: ConnectedProvider): string {
     .map((t) => {
       const resolved = toolSet.resolve(t.function.name);
       const action = resolved?.action ?? t.function.name;
-      const pathInfo = resolved?.path
-        ? `on \`${resolved.path}\``
-        : `${resolved?.targets?.length ?? 0} targets`;
+      const pathInfo = resolved?.path ? `on \`${resolved.path}\`` : `${resolved?.targets?.length ?? 0} targets`;
       return `  - **${action}** ${pathInfo}: ${t.function.description}`;
     })
     .join("\n");
@@ -39,10 +37,7 @@ export interface StateCache {
   stop(): void;
 }
 
-export function createStateCache(
-  cacheDir: string,
-  discovery: DiscoveryService,
-): StateCache {
+export function createStateCache(cacheDir: string, discovery: DiscoveryService): StateCache {
   const cachePath = join(cacheDir, "state-cache.txt");
   const tmpPath = join(cacheDir, "state-cache.txt.tmp");
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -50,7 +45,9 @@ export function createStateCache(
   function write() {
     const connected = discovery.getProviders();
     if (connected.length === 0) {
-      try { unlinkSync(cachePath); } catch {}
+      try {
+        unlinkSync(cachePath);
+      } catch {}
       return;
     }
 
@@ -77,7 +74,9 @@ export function createStateCache(
     },
     stop() {
       if (debounceTimer) clearTimeout(debounceTimer);
-      try { unlinkSync(cachePath); } catch {}
+      try {
+        unlinkSync(cachePath);
+      } catch {}
     },
   };
 }

--- a/packages/typescript/integrations/discovery/src/tools.ts
+++ b/packages/typescript/integrations/discovery/src/tools.ts
@@ -13,7 +13,10 @@ export interface ToolResult {
 
 /** Sanitize a string for use as a tool name prefix (alphanumeric + underscore). */
 function sanitizePrefix(s: string): string {
-  return s.replace(/[^a-zA-Z0-9]/g, "_").replace(/_+/g, "_").replace(/^_|_$/g, "");
+  return s
+    .replace(/[^a-zA-Z0-9]/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_|_$/g, "");
 }
 
 export interface DynamicToolEntry {
@@ -116,15 +119,11 @@ export function createToolHandlers(discovery: DiscoveryService) {
 
     const lines = discovered.map((desc) => {
       const isConnected = connectedIds.has(desc.id);
-      const provider = isConnected
-        ? connected.find((p) => p.id === desc.id)
-        : null;
+      const provider = isConnected ? connected.find((p) => p.id === desc.id) : null;
       const tree = provider?.consumer.getTree(provider.subscriptionId);
       const actionCount = tree ? affordancesToTools(tree).tools.length : 0;
       const label = (tree?.properties?.label as string) ?? desc.name;
-      const status = isConnected
-        ? `connected, ${actionCount} actions`
-        : "available";
+      const status = isConnected ? `connected, ${actionCount} actions` : "available";
       return `- **${label}** (id: \`${desc.id}\`, ${desc.transport.type}) — ${status}`;
     });
 
@@ -145,9 +144,7 @@ export function createToolHandlers(discovery: DiscoveryService) {
     const p = await discovery.ensureConnected(app);
     if (!p) {
       const discovered = discovery.getDiscovered();
-      const available = discovered
-        .map((d) => `${d.name} (${d.id})`)
-        .join(", ");
+      const available = discovered.map((d) => `${d.name} (${d.id})`).join(", ");
       return {
         content: [
           {
@@ -175,9 +172,7 @@ export function createToolHandlers(discovery: DiscoveryService) {
       .map((t) => {
         const resolved = toolSet.resolve(t.function.name);
         const action = resolved?.action ?? t.function.name;
-        const pathInfo = resolved?.path
-          ? `on \`${resolved.path}\``
-          : `${resolved?.targets?.length ?? 0} targets`;
+        const pathInfo = resolved?.path ? `on \`${resolved.path}\`` : `${resolved?.targets?.length ?? 0} targets`;
         return `  - **${action}** ${pathInfo}: ${t.function.description}`;
       })
       .join("\n");

--- a/packages/typescript/integrations/openclaw-plugin/src/tools.ts
+++ b/packages/typescript/integrations/openclaw-plugin/src/tools.ts
@@ -11,8 +11,7 @@ interface ToolHandlers {
 export function registerSlopTools(api: any, discovery: DiscoveryService, handlers: ToolHandlers) {
   api.registerTool({
     name: "list_apps",
-    description:
-      "List the applications currently available on this computer and whether they are already connected.",
+    description: "List the applications currently available on this computer and whether they are already connected.",
     parameters: Type.Object({}),
     async execute(_id: string) {
       return handlers.listApps();
@@ -38,8 +37,7 @@ export function registerSlopTools(api: any, discovery: DiscoveryService, handler
   api.registerTool({
     name: "disconnect_app",
     description:
-      "Disconnect from an application. Stops state updates. " +
-      "Use when you're done interacting with an app.",
+      "Disconnect from an application. Stops state updates. " + "Use when you're done interacting with an app.",
     parameters: Type.Object({
       app: Type.String({
         description: "App name or ID to disconnect from.",
@@ -72,10 +70,7 @@ export function registerSlopTools(api: any, discovery: DiscoveryService, handler
         }),
       ),
     }),
-    async execute(
-      _id: string,
-      args: { app: string; path: string; action: string; params?: Record<string, unknown> },
-    ) {
+    async execute(_id: string, args: { app: string; path: string; action: string; params?: Record<string, unknown> }) {
       const p = await discovery.ensureConnected(args.app);
       if (!p) {
         return {
@@ -87,18 +82,23 @@ export function registerSlopTools(api: any, discovery: DiscoveryService, handler
         const result = await p.consumer.invoke(args.path, args.action, args.params ?? {});
         if (result.status === "ok") {
           return {
-            content: [{
-              type: "text" as const,
-              text: `Done. ${args.action} on ${args.path} succeeded.` +
-                (result.data ? ` Result: ${JSON.stringify(result.data)}` : ""),
-            }],
+            content: [
+              {
+                type: "text" as const,
+                text:
+                  `Done. ${args.action} on ${args.path} succeeded.` +
+                  (result.data ? ` Result: ${JSON.stringify(result.data)}` : ""),
+              },
+            ],
           };
         }
         return {
-          content: [{
-            type: "text" as const,
-            text: `Action failed: [${result.error?.code}] ${result.error?.message}`,
-          }],
+          content: [
+            {
+              type: "text" as const,
+              text: `Action failed: [${result.error?.code}] ${result.error?.message}`,
+            },
+          ],
           isError: true,
         };
       } catch (err: any) {
@@ -161,11 +161,14 @@ export function registerSlopTools(api: any, discovery: DiscoveryService, handler
         }
       }
       return {
-        content: [{
-          type: "text" as const,
-          text: `Batch complete: ${args.actions.length - failed}/${args.actions.length} succeeded.\n` +
-            results.join("\n"),
-        }],
+        content: [
+          {
+            type: "text" as const,
+            text:
+              `Batch complete: ${args.actions.length - failed}/${args.actions.length} succeeded.\n` +
+              results.join("\n"),
+          },
+        ],
         isError: failed > 0,
       };
     },

--- a/packages/typescript/sdk/client/__tests__/async-actions.test.ts
+++ b/packages/typescript/sdk/client/__tests__/async-actions.test.ts
@@ -20,7 +20,7 @@ function createClient() {
 }
 
 function delay(ms: number) {
-  return new Promise(r => setTimeout(r, ms));
+  return new Promise((r) => setTimeout(r, ms));
 }
 
 function findNode(root: SlopNode, id: string): SlopNode | null {
@@ -35,10 +35,7 @@ function findNode(root: SlopNode, id: string): SlopNode | null {
 describe("asyncAction", () => {
   test("returns an Action with estimate 'async'", () => {
     const client = createClient();
-    const a = client.asyncAction(
-      { env: "string" },
-      async () => {},
-    );
+    const a = client.asyncAction({ env: "string" }, async () => {});
     expect((a as any).estimate).toBe("async");
     expect(typeof (a as any).handler).toBe("function");
   });
@@ -61,7 +58,7 @@ describe("asyncAction", () => {
         await delay(10);
         return { done: true };
       },
-      { label: "Deploy" }
+      { label: "Deploy" },
     );
 
     const result = (a as any).handler({ env: "prod" });
@@ -76,16 +73,15 @@ describe("asyncAction", () => {
   test("task completes and sets status to done", async () => {
     const client = createClient();
     let resolveWork: () => void;
-    const workDone = new Promise<void>(r => { resolveWork = r; });
+    const workDone = new Promise<void>((r) => {
+      resolveWork = r;
+    });
 
-    const a = client.asyncAction(
-      {},
-      async (_params, task) => {
-        task.update(0.5, "Working...");
-        await delay(20);
-        return { result: "success" };
-      },
-    );
+    const a = client.asyncAction({}, async (_params, task) => {
+      task.update(0.5, "Working...");
+      await delay(20);
+      return { result: "success" };
+    });
 
     (a as any).handler({});
 
@@ -99,12 +95,9 @@ describe("asyncAction", () => {
 
   test("task fails and sets status to failed", async () => {
     const client = createClient();
-    const a = client.asyncAction(
-      {},
-      async () => {
-        throw new Error("Deploy exploded");
-      },
-    );
+    const a = client.asyncAction({}, async () => {
+      throw new Error("Deploy exploded");
+    });
 
     (a as any).handler({});
     await delay(20);
@@ -126,7 +119,7 @@ describe("asyncAction", () => {
         completionOrder.push("fast");
         return { speed: "fast" };
       },
-      { label: "Fast task" }
+      { label: "Fast task" },
     );
 
     const slow = client.asyncAction(
@@ -139,7 +132,7 @@ describe("asyncAction", () => {
         completionOrder.push("slow");
         return { speed: "slow" };
       },
-      { label: "Slow task" }
+      { label: "Slow task" },
     );
 
     const medium = client.asyncAction(
@@ -150,7 +143,7 @@ describe("asyncAction", () => {
         completionOrder.push("medium");
         return { speed: "medium" };
       },
-      { label: "Medium task" }
+      { label: "Medium task" },
     );
 
     // Start all three at the same time
@@ -185,7 +178,7 @@ describe("asyncAction", () => {
         await delay(60);
         completionOrder.push("A");
       },
-      { label: "Task A" }
+      { label: "Task A" },
     );
 
     const taskB = client.asyncAction(
@@ -195,7 +188,7 @@ describe("asyncAction", () => {
         await delay(30);
         completionOrder.push("B");
       },
-      { label: "Task B" }
+      { label: "Task B" },
     );
 
     const taskC = client.asyncAction(
@@ -205,7 +198,7 @@ describe("asyncAction", () => {
         await delay(10);
         completionOrder.push("C");
       },
-      { label: "Task C" }
+      { label: "Task C" },
     );
 
     // Start A first (longest), then B after 10ms, then C after 20ms
@@ -263,12 +256,14 @@ describe("asyncAction", () => {
     const a = client.asyncAction(
       {},
       async (_params, task) => {
-        task.signal.addEventListener("abort", () => { wasAborted = true; });
+        task.signal.addEventListener("abort", () => {
+          wasAborted = true;
+        });
         task.update(0, "Running...");
         await delay(100);
         return "done";
       },
-      { cancelable: true }
+      { cancelable: true },
     );
 
     (a as any).handler({});
@@ -292,20 +287,17 @@ describe("asyncAction", () => {
       origRegister(path, desc);
     };
 
-    const a = client.asyncAction(
-      {},
-      async (_params, task) => {
-        task.update(0, "Starting");
-        await delay(5);
-        task.update(0.25, "Quarter done");
-        await delay(5);
-        task.update(0.5, "Halfway");
-        await delay(5);
-        task.update(0.75, "Almost done");
-        await delay(5);
-        return "done";
-      },
-    );
+    const a = client.asyncAction({}, async (_params, task) => {
+      task.update(0, "Starting");
+      await delay(5);
+      task.update(0.25, "Quarter done");
+      await delay(5);
+      task.update(0.5, "Halfway");
+      await delay(5);
+      task.update(0.75, "Almost done");
+      await delay(5);
+      return "done";
+    });
 
     (a as any).handler({});
     await delay(50);
@@ -315,7 +307,7 @@ describe("asyncAction", () => {
     expect(progressLog.length).toBeGreaterThanOrEqual(5);
 
     // Filter to unique progress values
-    const progressValues = progressLog.map(p => p.progress);
+    const progressValues = progressLog.map((p) => p.progress);
     expect(progressValues).toContain(0);
     expect(progressValues).toContain(0.25);
     expect(progressValues).toContain(0.5);

--- a/packages/typescript/sdk/client/__tests__/client.test.ts
+++ b/packages/typescript/sdk/client/__tests__/client.test.ts
@@ -8,8 +8,12 @@ const incomingHandlers: ((msg: any) => void)[] = [];
 
 function createMockTransport(): Transport {
   return {
-    send(message: unknown) { sentMessages.push(message); },
-    onMessage(handler: (msg: any) => void) { incomingHandlers.push(handler); },
+    send(message: unknown) {
+      sentMessages.push(message);
+    },
+    onMessage(handler: (msg: any) => void) {
+      incomingHandlers.push(handler);
+    },
     start() {},
     stop() {},
   };
@@ -47,7 +51,7 @@ describe("SlopClient", () => {
     client.register("c", { type: "group" });
 
     // All three should be batched — wait for microtask
-    await new Promise(r => queueMicrotask(r));
+    await new Promise((r) => queueMicrotask(r));
     // No crash = success. Batching verified by the queueMicrotask mechanism.
   });
 
@@ -117,11 +121,13 @@ describe("SlopClient", () => {
 
     client.register("todos", {
       type: "collection",
-      items: [{
-        id: "t1",
-        props: { title: "Test" },
-        actions: { delete: deleteFn },
-      }],
+      items: [
+        {
+          id: "t1",
+          props: { title: "Test" },
+          actions: { delete: deleteFn },
+        },
+      ],
     });
     client.flush();
     // Handler should be registered at "todos/t1/delete"
@@ -191,14 +197,18 @@ describe("SlopClient scaling integration", () => {
     const sent: any[] = [];
     const handlers: ((msg: any) => void)[] = [];
     const transport: Transport = {
-      send(msg) { sent.push(msg); },
-      onMessage(h) { handlers.push(h); },
+      send(msg) {
+        sent.push(msg);
+      },
+      onMessage(h) {
+        handlers.push(h);
+      },
       start() {},
       stop() {},
     };
     const client = new SlopClientImpl({ id: "app", name: "App", ...opts }, transport);
     client.start();
-    const simulate = (msg: any) => handlers.forEach(h => h(msg));
+    const simulate = (msg: any) => handlers.forEach((h) => h(msg));
     return { client, sent, simulate };
   }
 
@@ -210,7 +220,7 @@ describe("SlopClient scaling integration", () => {
     client.flush();
 
     simulate({ type: "subscribe", id: "sub-1", path: "/", depth: 1 });
-    const snapshot = sent.find(m => m.type === "snapshot" && m.id === "sub-1");
+    const snapshot = sent.find((m) => m.type === "snapshot" && m.id === "sub-1");
     expect(snapshot).toBeDefined();
     // At depth 1, a should be present but its children truncated
     const a = snapshot.tree.children?.find((c: any) => c.id === "a");
@@ -226,7 +236,7 @@ describe("SlopClient scaling integration", () => {
     client.flush();
 
     simulate({ type: "subscribe", id: "sub-1", filter: { min_salience: 0.5 } });
-    const snapshot = sent.find(m => m.type === "snapshot" && m.id === "sub-1");
+    const snapshot = sent.find((m) => m.type === "snapshot" && m.id === "sub-1");
     const ids = snapshot.tree.children?.map((c: any) => c.id) ?? [];
     expect(ids).toContain("high");
     expect(ids).not.toContain("low");
@@ -239,7 +249,7 @@ describe("SlopClient scaling integration", () => {
     client.flush();
 
     simulate({ type: "subscribe", id: "sub-1", filter: { types: ["notification"] } });
-    const snapshot = sent.find(m => m.type === "snapshot" && m.id === "sub-1");
+    const snapshot = sent.find((m) => m.type === "snapshot" && m.id === "sub-1");
     const ids = snapshot.tree.children?.map((c: any) => c.id) ?? [];
     expect(ids).toContain("alert");
     expect(ids).not.toContain("data");
@@ -253,7 +263,7 @@ describe("SlopClient scaling integration", () => {
     client.flush();
 
     simulate({ type: "subscribe", id: "sub-1", path: "/inbox" });
-    const snapshot = sent.find(m => m.type === "snapshot" && m.id === "sub-1");
+    const snapshot = sent.find((m) => m.type === "snapshot" && m.id === "sub-1");
     // Should get the inbox subtree, not the full tree
     expect(snapshot.tree.id).toBe("inbox");
     expect(snapshot.tree.children?.[0]?.id).toBe("messages");
@@ -267,7 +277,7 @@ describe("SlopClient scaling integration", () => {
     client.flush();
 
     simulate({ type: "query", id: "q-1", depth: 1, filter: { min_salience: 0.5 } });
-    const snapshot = sent.find(m => m.type === "snapshot" && m.id === "q-1");
+    const snapshot = sent.find((m) => m.type === "snapshot" && m.id === "q-1");
     const ids = snapshot.tree.children?.map((c: any) => c.id) ?? [];
     expect(ids).toContain("a");
     expect(ids).not.toContain("noise");
@@ -287,8 +297,8 @@ describe("SlopClient scaling integration", () => {
     simulate({ type: "subscribe", id: "filtered", path: "/", filter: { min_salience: 0.5 } });
 
     // Verify initial snapshots have correct filtering
-    const allSnap = sent.find(m => m.type === "snapshot" && m.id === "all");
-    const filteredSnap = sent.find(m => m.type === "snapshot" && m.id === "filtered");
+    const allSnap = sent.find((m) => m.type === "snapshot" && m.id === "all");
+    const filteredSnap = sent.find((m) => m.type === "snapshot" && m.id === "filtered");
     expect(allSnap.tree.children?.map((c: any) => c.id)).toContain("low");
     expect(filteredSnap.tree.children?.map((c: any) => c.id)).not.toContain("low");
 
@@ -299,8 +309,8 @@ describe("SlopClient scaling integration", () => {
     client.flush();
 
     // After change, we should get patch messages (not snapshots)
-    const allPatch = sent.find(m => m.type === "patch" && m.subscription === "all");
-    const filteredPatch = sent.find(m => m.type === "patch" && m.subscription === "filtered");
+    const allPatch = sent.find((m) => m.type === "patch" && m.subscription === "all");
+    const filteredPatch = sent.find((m) => m.type === "patch" && m.subscription === "filtered");
     expect(allPatch).toBeDefined();
     expect(filteredPatch).toBeDefined();
     expect(allPatch.ops.length).toBeGreaterThan(0);

--- a/packages/typescript/sdk/client/src/client.ts
+++ b/packages/typescript/sdk/client/src/client.ts
@@ -1,8 +1,17 @@
 import { ProviderBase, diffNodes, AsyncActionResult } from "@slop-ai/core";
 import type {
-  SlopNode, PatchOp, ActionHandler, Action, ParamDef,
-  NodeDescriptor, SlopClient, SlopClientOptions, TaskHandle, InferParams,
-  SubscriptionFilter, Transport,
+  SlopNode,
+  PatchOp,
+  ActionHandler,
+  Action,
+  ParamDef,
+  NodeDescriptor,
+  SlopClient,
+  SlopClientOptions,
+  TaskHandle,
+  InferParams,
+  SubscriptionFilter,
+  Transport,
 } from "@slop-ai/core";
 
 interface Subscription {
@@ -67,7 +76,7 @@ export class SlopClientImpl<S = unknown> extends ProviderBase<S> implements Slop
   asyncAction<P extends Record<string, ParamDef>>(
     params: P,
     fn: (params: InferParams<P>, task: TaskHandle) => Promise<unknown>,
-    options?: { label?: string; description?: string; cancelable?: boolean }
+    options?: { label?: string; description?: string; cancelable?: boolean },
   ): Action {
     return {
       estimate: "async" as const,
@@ -227,9 +236,7 @@ export class SlopClientImpl<S = unknown> extends ProviderBase<S> implements Slop
         break;
 
       case "query":
-        transport.send(
-          this.snapshotMessage(msg.id, { path: msg.path, depth: msg.depth, filter: msg.filter })
-        );
+        transport.send(this.snapshotMessage(msg.id, { path: msg.path, depth: msg.depth, filter: msg.filter }));
         break;
 
       case "invoke":
@@ -238,7 +245,10 @@ export class SlopClientImpl<S = unknown> extends ProviderBase<S> implements Slop
     }
   }
 
-  private async handleInvoke(msg: { id: string; path: string; action: string; params?: Record<string, unknown> }, transport: Transport): Promise<void> {
+  private async handleInvoke(
+    msg: { id: string; path: string; action: string; params?: Record<string, unknown> },
+    transport: Transport,
+  ): Promise<void> {
     const result = await this.executeInvoke(msg);
     transport.send(result);
   }
@@ -260,8 +270,7 @@ function createScopedClient<S>(parent: SlopClientImpl<unknown>, prefix: string):
         };
       }
       if (prop === "scope") {
-        return (path: string, descriptor?: NodeDescriptor) =>
-          parent.scope(`${prefix}/${path}`, descriptor);
+        return (path: string, descriptor?: NodeDescriptor) => parent.scope(`${prefix}/${path}`, descriptor);
       }
       if (prop === "flush") {
         return () => parent.flush();

--- a/packages/typescript/sdk/client/src/index.ts
+++ b/packages/typescript/sdk/client/src/index.ts
@@ -38,9 +38,7 @@ export interface CreateSlopOptions<S = unknown> extends SlopClientOptions<S> {
  * });
  * ```
  */
-export function createSlop<S = unknown>(
-  options: CreateSlopOptions<S>
-): SlopClient<S> {
+export function createSlop<S = unknown>(options: CreateSlopOptions<S>): SlopClient<S> {
   const transports: Transport[] = [];
   const enabledTransports = options.transports ?? [
     "postmessage",
@@ -49,16 +47,12 @@ export function createSlop<S = unknown>(
   const websocketUrl = options.websocketUrl ?? options.desktopUrl;
 
   if (enabledTransports.includes("postmessage")) {
-    transports.push(
-      createPostMessageTransport({ discover: options.postmessageDiscover })
-    );
+    transports.push(createPostMessageTransport({ discover: options.postmessageDiscover }));
   }
 
   if (enabledTransports.includes("websocket")) {
     const url = typeof websocketUrl === "string" ? websocketUrl : undefined;
-    transports.push(
-      createWebSocketTransport(url, { discover: options.websocketDiscover })
-    );
+    transports.push(createWebSocketTransport(url, { discover: options.websocketDiscover }));
   }
 
   const client = new SlopClientImpl<S>(options, transports);
@@ -72,9 +66,17 @@ export { SlopClientImpl } from "./client";
 // Re-export core types and utilities for convenience
 export {
   ProviderBase,
-  pick, omit, action,
-  assembleTree, diffNodes,
-  prepareTree, getSubtree, truncateTree, autoCompact, filterTree, countNodes,
+  pick,
+  omit,
+  action,
+  assembleTree,
+  diffNodes,
+  prepareTree,
+  getSubtree,
+  truncateTree,
+  autoCompact,
+  filterTree,
+  countNodes,
 } from "@slop-ai/core";
 
 export type {

--- a/packages/typescript/sdk/client/src/postmessage-transport.ts
+++ b/packages/typescript/sdk/client/src/postmessage-transport.ts
@@ -4,9 +4,7 @@ import type { Transport } from "@slop-ai/core";
  * postMessage transport for in-browser SLOP providers.
  * Wraps all messages in { slop: true, message } envelope.
  */
-export function createPostMessageTransport(
-  options: { discover?: boolean } = {}
-): Transport {
+export function createPostMessageTransport(options: { discover?: boolean } = {}): Transport {
   const messageHandlers: ((msg: any) => void)[] = [];
   let listener: ((event: MessageEvent) => void) | null = null;
   let metaTag: HTMLMetaElement | null = null;

--- a/packages/typescript/sdk/client/src/websocket-transport.ts
+++ b/packages/typescript/sdk/client/src/websocket-transport.ts
@@ -17,7 +17,7 @@ const DEFAULT_DESKTOP_URL = "ws://localhost:9339/slop";
  */
 export function createWebSocketTransport(
   url: string = DEFAULT_DESKTOP_URL,
-  options: { discover?: boolean } = {}
+  options: { discover?: boolean } = {},
 ): Transport {
   const messageHandlers: ((msg: any) => void)[] = [];
   let ws: WebSocket | null = null;

--- a/packages/typescript/sdk/consumer/__tests__/consumer.test.ts
+++ b/packages/typescript/sdk/consumer/__tests__/consumer.test.ts
@@ -11,10 +11,18 @@ function mockTransport() {
   const transport = {
     connect: () =>
       Promise.resolve({
-        send(msg: SlopMessage) { sent.push(msg); },
-        onMessage(fn: (msg: SlopMessage) => void) { handler = fn; },
-        onClose(fn: () => void) { closeHandler = fn; },
-        close() { closeHandler?.(); },
+        send(msg: SlopMessage) {
+          sent.push(msg);
+        },
+        onMessage(fn: (msg: SlopMessage) => void) {
+          handler = fn;
+        },
+        onClose(fn: () => void) {
+          closeHandler = fn;
+        },
+        close() {
+          closeHandler?.();
+        },
       }),
   };
 
@@ -26,7 +34,7 @@ function mockTransport() {
   return { transport, sent, inject };
 }
 
-const tick = () => new Promise(r => setTimeout(r, 0));
+const tick = () => new Promise((r) => setTimeout(r, 0));
 
 async function setupConsumer() {
   const { transport, sent, inject } = mockTransport();

--- a/packages/typescript/sdk/consumer/__tests__/state-mirror.test.ts
+++ b/packages/typescript/sdk/consumer/__tests__/state-mirror.test.ts
@@ -34,7 +34,9 @@ describe("StateMirror", () => {
   test("applies property replace", () => {
     const mirror = new StateMirror(snapshot);
     mirror.applyPatch({
-      type: "patch", subscription: "sub-1", version: 2,
+      type: "patch",
+      subscription: "sub-1",
+      version: 2,
       ops: [{ op: "replace", path: "/todos/t1/properties/done", value: true }],
     });
     expect(mirror.getTree().children![0].children![0].properties?.done).toBe(true);
@@ -44,7 +46,9 @@ describe("StateMirror", () => {
   test("applies child add", () => {
     const mirror = new StateMirror(snapshot);
     mirror.applyPatch({
-      type: "patch", subscription: "sub-1", version: 2,
+      type: "patch",
+      subscription: "sub-1",
+      version: 2,
       ops: [{ op: "add", path: "/todos/t3", value: { id: "t3", type: "item", properties: { title: "Third" } } }],
     });
     expect(mirror.getTree().children![0].children).toHaveLength(3);
@@ -53,7 +57,9 @@ describe("StateMirror", () => {
   test("applies child remove", () => {
     const mirror = new StateMirror(snapshot);
     mirror.applyPatch({
-      type: "patch", subscription: "sub-1", version: 2,
+      type: "patch",
+      subscription: "sub-1",
+      version: 2,
       ops: [{ op: "remove", path: "/todos/t1" }],
     });
     expect(mirror.getTree().children![0].children).toHaveLength(1);
@@ -63,7 +69,9 @@ describe("StateMirror", () => {
   test("applies multiple ops in sequence", () => {
     const mirror = new StateMirror(snapshot);
     mirror.applyPatch({
-      type: "patch", subscription: "sub-1", version: 2,
+      type: "patch",
+      subscription: "sub-1",
+      version: 2,
       ops: [
         { op: "replace", path: "/todos/t1/properties/done", value: true },
         { op: "replace", path: "/todos/properties/count", value: 3 },

--- a/packages/typescript/sdk/consumer/__tests__/tools.test.ts
+++ b/packages/typescript/sdk/consumer/__tests__/tools.test.ts
@@ -5,12 +5,16 @@ import type { SlopNode } from "../src/types";
 describe("affordancesToTools", () => {
   test("singleton affordances keep nodeId__action naming", () => {
     const tree: SlopNode = {
-      id: "root", type: "root",
+      id: "root",
+      type: "root",
       affordances: [{ action: "create", label: "Create" }],
-      children: [{
-        id: "item-1", type: "item",
-        affordances: [{ action: "delete", dangerous: true }],
-      }],
+      children: [
+        {
+          id: "item-1",
+          type: "item",
+          affordances: [{ action: "delete", dangerous: true }],
+        },
+      ],
     };
     const toolSet = affordancesToTools(tree);
     expect(toolSet.tools).toHaveLength(2);
@@ -21,14 +25,21 @@ describe("affordancesToTools", () => {
 
   test("resolve maps singleton tool name back to path + action", () => {
     const tree: SlopNode = {
-      id: "root", type: "root",
-      children: [{
-        id: "inbox", type: "view",
-        children: [{
-          id: "msg-1", type: "item",
-          affordances: [{ action: "archive", label: "Archive message" }],
-        }],
-      }],
+      id: "root",
+      type: "root",
+      children: [
+        {
+          id: "inbox",
+          type: "view",
+          children: [
+            {
+              id: "msg-1",
+              type: "item",
+              affordances: [{ action: "archive", label: "Archive message" }],
+            },
+          ],
+        },
+      ],
     };
     const toolSet = affordancesToTools(tree);
     const resolved = toolSet.resolve("msg_1__archive");
@@ -37,13 +48,48 @@ describe("affordancesToTools", () => {
 
   test("groups same action + schema into one tool with target param", () => {
     const tree: SlopNode = {
-      id: "root", type: "root",
+      id: "root",
+      type: "root",
       children: [
-        { id: "backlog", type: "collection", children: [
-          { id: "card-1", type: "item", affordances: [{ action: "edit", label: "Edit card", params: { type: "object", properties: { title: { type: "string" } } } }] },
-          { id: "card-2", type: "item", affordances: [{ action: "edit", label: "Edit card", params: { type: "object", properties: { title: { type: "string" } } } }] },
-          { id: "card-3", type: "item", affordances: [{ action: "edit", label: "Edit card", params: { type: "object", properties: { title: { type: "string" } } } }] },
-        ]},
+        {
+          id: "backlog",
+          type: "collection",
+          children: [
+            {
+              id: "card-1",
+              type: "item",
+              affordances: [
+                {
+                  action: "edit",
+                  label: "Edit card",
+                  params: { type: "object", properties: { title: { type: "string" } } },
+                },
+              ],
+            },
+            {
+              id: "card-2",
+              type: "item",
+              affordances: [
+                {
+                  action: "edit",
+                  label: "Edit card",
+                  params: { type: "object", properties: { title: { type: "string" } } },
+                },
+              ],
+            },
+            {
+              id: "card-3",
+              type: "item",
+              affordances: [
+                {
+                  action: "edit",
+                  label: "Edit card",
+                  params: { type: "object", properties: { title: { type: "string" } } },
+                },
+              ],
+            },
+          ],
+        },
       ],
     };
     const toolSet = affordancesToTools(tree);
@@ -62,12 +108,17 @@ describe("affordancesToTools", () => {
 
   test("grouped tool resolve returns null path with targets list", () => {
     const tree: SlopNode = {
-      id: "root", type: "root",
+      id: "root",
+      type: "root",
       children: [
-        { id: "backlog", type: "collection", children: [
-          { id: "card-1", type: "item", affordances: [{ action: "delete" }] },
-          { id: "card-2", type: "item", affordances: [{ action: "delete" }] },
-        ]},
+        {
+          id: "backlog",
+          type: "collection",
+          children: [
+            { id: "card-1", type: "item", affordances: [{ action: "delete" }] },
+            { id: "card-2", type: "item", affordances: [{ action: "delete" }] },
+          ],
+        },
       ],
     };
     const toolSet = affordancesToTools(tree);
@@ -80,22 +131,47 @@ describe("affordancesToTools", () => {
 
   test("different schemas with same action produce separate tools", () => {
     const tree: SlopNode = {
-      id: "root", type: "root",
+      id: "root",
+      type: "root",
       children: [
-        { id: "cards", type: "collection", children: [
-          { id: "card-1", type: "item", affordances: [{ action: "edit", params: { type: "object", properties: { title: { type: "string" } } } }] },
-          { id: "card-2", type: "item", affordances: [{ action: "edit", params: { type: "object", properties: { title: { type: "string" } } } }] },
-        ]},
-        { id: "comments", type: "collection", children: [
-          { id: "comment-1", type: "item", affordances: [{ action: "edit", params: { type: "object", properties: { body: { type: "string" } } } }] },
-          { id: "comment-2", type: "item", affordances: [{ action: "edit", params: { type: "object", properties: { body: { type: "string" } } } }] },
-        ]},
+        {
+          id: "cards",
+          type: "collection",
+          children: [
+            {
+              id: "card-1",
+              type: "item",
+              affordances: [{ action: "edit", params: { type: "object", properties: { title: { type: "string" } } } }],
+            },
+            {
+              id: "card-2",
+              type: "item",
+              affordances: [{ action: "edit", params: { type: "object", properties: { title: { type: "string" } } } }],
+            },
+          ],
+        },
+        {
+          id: "comments",
+          type: "collection",
+          children: [
+            {
+              id: "comment-1",
+              type: "item",
+              affordances: [{ action: "edit", params: { type: "object", properties: { body: { type: "string" } } } }],
+            },
+            {
+              id: "comment-2",
+              type: "item",
+              affordances: [{ action: "edit", params: { type: "object", properties: { body: { type: "string" } } } }],
+            },
+          ],
+        },
       ],
     };
     const toolSet = affordancesToTools(tree);
     // Two groups: edit(title) and edit(body) — disambiguated names
     expect(toolSet.tools).toHaveLength(2);
-    const names = toolSet.tools.map(t => t.function.name);
+    const names = toolSet.tools.map((t) => t.function.name);
     expect(names[0]).not.toBe(names[1]);
     // Both should be resolvable
     expect(toolSet.resolve(names[0])).not.toBeNull();
@@ -105,14 +181,19 @@ describe("affordancesToTools", () => {
   test("groups across different parent containers", () => {
     // Cards in backlog AND done should merge (same action + schema)
     const tree: SlopNode = {
-      id: "root", type: "root",
+      id: "root",
+      type: "root",
       children: [
-        { id: "backlog", type: "collection", children: [
-          { id: "card-1", type: "item", affordances: [{ action: "move" }] },
-        ]},
-        { id: "done", type: "collection", children: [
-          { id: "card-2", type: "item", affordances: [{ action: "move" }] },
-        ]},
+        {
+          id: "backlog",
+          type: "collection",
+          children: [{ id: "card-1", type: "item", affordances: [{ action: "move" }] }],
+        },
+        {
+          id: "done",
+          type: "collection",
+          children: [{ id: "card-2", type: "item", affordances: [{ action: "move" }] }],
+        },
       ],
     };
     const toolSet = affordancesToTools(tree);
@@ -124,7 +205,8 @@ describe("affordancesToTools", () => {
 
   test("dangerous flag propagates if any entry in group is dangerous", () => {
     const tree: SlopNode = {
-      id: "root", type: "root",
+      id: "root",
+      type: "root",
       children: [
         { id: "a", type: "item", affordances: [{ action: "purge", dangerous: true }] },
         { id: "b", type: "item", affordances: [{ action: "purge" }] },
@@ -139,29 +221,37 @@ describe("affordancesToTools", () => {
 describe("formatTree", () => {
   // Canonical test tree matching spec/core/state-tree.md "Consumer display format"
   const canonicalTree: SlopNode = {
-    id: "store", type: "root",
+    id: "store",
+    type: "root",
     properties: { label: "Pet Store" },
     meta: { salience: 0.9 },
-    affordances: [{
-      action: "search",
-      params: { type: "object", properties: { query: { type: "string" } } },
-    }],
+    affordances: [
+      {
+        action: "search",
+        params: { type: "object", properties: { query: { type: "string" } } },
+      },
+    ],
     children: [
       {
-        id: "catalog", type: "collection",
+        id: "catalog",
+        type: "collection",
         properties: { label: "Catalog", count: 142 },
         meta: { total_children: 142, window: [0, 25], summary: "142 products, 12 on sale" },
-        children: [{
-          id: "prod-1", type: "item",
-          properties: { label: "Rubber Duck", price: 4.99, in_stock: true },
-          affordances: [
-            { action: "add_to_cart", params: { type: "object", properties: { quantity: { type: "number" } } } },
-            { action: "view" },
-          ],
-        }],
+        children: [
+          {
+            id: "prod-1",
+            type: "item",
+            properties: { label: "Rubber Duck", price: 4.99, in_stock: true },
+            affordances: [
+              { action: "add_to_cart", params: { type: "object", properties: { quantity: { type: "number" } } } },
+              { action: "view" },
+            ],
+          },
+        ],
       },
       {
-        id: "cart", type: "collection",
+        id: "cart",
+        type: "collection",
         properties: { label: "Cart" },
         meta: { total_children: 3, summary: "3 items, $24.97" },
       },
@@ -220,10 +310,10 @@ describe("formatTree", () => {
     // Root at indent 0
     expect(lines[0]).toMatch(/^\[root\]/);
     // Catalog at indent 1
-    const catalogLine = lines.find(l => l.includes("catalog"))!;
+    const catalogLine = lines.find((l) => l.includes("catalog"))!;
     expect(catalogLine).toMatch(/^  \[collection\]/);
     // prod-1 at indent 2
-    const prodLine = lines.find(l => l.includes("prod-1"))!;
+    const prodLine = lines.find((l) => l.includes("prod-1"))!;
     expect(prodLine).toMatch(/^    \[item\]/);
   });
 });

--- a/packages/typescript/sdk/consumer/src/consumer.ts
+++ b/packages/typescript/sdk/consumer/src/consumer.ts
@@ -1,7 +1,15 @@
 import type {
-  ClientTransport, Connection, HelloMessage, SlopNode,
-  ResultMessage, PatchOp, SlopMessage, ProviderMessage,
-  ErrorMessage, EventMessage, BatchMessage,
+  ClientTransport,
+  Connection,
+  HelloMessage,
+  SlopNode,
+  ResultMessage,
+  PatchOp,
+  SlopMessage,
+  ProviderMessage,
+  ErrorMessage,
+  EventMessage,
+  BatchMessage,
 } from "./types";
 import { StateMirror } from "./state-mirror";
 import { Emitter } from "./emitter";
@@ -28,9 +36,7 @@ export class SlopConsumer extends Emitter {
         const m = msg as ProviderMessage;
         if (m.type === "hello") {
           resolve(m);
-          this.connection!.onMessage((msg2: SlopMessage) =>
-            this.handleMessage(msg2 as ProviderMessage)
-          );
+          this.connection!.onMessage((msg2: SlopMessage) => this.handleMessage(msg2 as ProviderMessage));
         }
       });
       this.connection!.onClose(() => this.emit("disconnect"));
@@ -49,7 +55,10 @@ export class SlopConsumer extends Emitter {
         reject,
       });
       this.connection!.send({
-        type: "subscribe", id, path, depth,
+        type: "subscribe",
+        id,
+        path,
+        depth,
         ...(options?.max_nodes != null && { max_nodes: options.max_nodes }),
         ...(options?.filter && { filter: options.filter }),
       });
@@ -70,7 +79,10 @@ export class SlopConsumer extends Emitter {
     return new Promise((resolve, reject) => {
       this.pending.set(id, { resolve, reject });
       this.connection!.send({
-        type: "query", id, path, depth,
+        type: "query",
+        id,
+        path,
+        depth,
         ...(options?.max_nodes != null && { max_nodes: options.max_nodes }),
         ...(options?.filter && { filter: options.filter }),
         ...(options?.window && { window: options.window }),
@@ -92,12 +104,16 @@ export class SlopConsumer extends Emitter {
 
   onError(fn: (error: ErrorMessage["error"], id?: string) => void): () => void {
     this.errorCallbacks.add(fn);
-    return () => { this.errorCallbacks.delete(fn); };
+    return () => {
+      this.errorCallbacks.delete(fn);
+    };
   }
 
   onEvent(fn: (name: string, data: unknown) => void): () => void {
     this.eventCallbacks.add(fn);
-    return () => { this.eventCallbacks.delete(fn); };
+    return () => {
+      this.eventCallbacks.delete(fn);
+    };
   }
 
   disconnect(): void {
@@ -131,7 +147,10 @@ export class SlopConsumer extends Emitter {
       }
       case "result": {
         const p = this.pending.get(msg.id);
-        if (p) { this.pending.delete(msg.id); p.resolve(msg); }
+        if (p) {
+          this.pending.delete(msg.id);
+          p.resolve(msg);
+        }
         break;
       }
       case "error": {

--- a/packages/typescript/sdk/consumer/src/state-mirror.ts
+++ b/packages/typescript/sdk/consumer/src/state-mirror.ts
@@ -18,16 +18,26 @@ export class StateMirror {
     this.version = patch.version;
   }
 
-  getTree(): SlopNode { return this.tree; }
-  getVersion(): number { return this.version; }
+  getTree(): SlopNode {
+    return this.tree;
+  }
+  getVersion(): number {
+    return this.version;
+  }
 
   private applyOp(op: PatchOp): void {
     const segments = op.path.split("/").filter(Boolean);
     if (segments.length === 0) return;
     switch (op.op) {
-      case "add": this.applyAdd(segments, op.value); break;
-      case "remove": this.applyRemove(segments); break;
-      case "replace": this.applyReplace(segments, op.value); break;
+      case "add":
+        this.applyAdd(segments, op.value);
+        break;
+      case "remove":
+        this.applyRemove(segments);
+        break;
+      case "replace":
+        this.applyReplace(segments, op.value);
+        break;
     }
   }
 
@@ -44,7 +54,7 @@ export class StateMirror {
         if (current === undefined) return null;
       } else {
         // Child ID lookup
-        const child = (current.children as SlopNode[])?.find(c => c.id === seg);
+        const child = (current.children as SlopNode[])?.find((c) => c.id === seg);
         if (!child) return null;
         current = child;
       }
@@ -107,7 +117,7 @@ export class StateMirror {
     let current: SlopNode = this.tree;
     for (const seg of segments) {
       if (NODE_FIELDS.has(seg)) continue; // skip field keywords
-      const child = current.children?.find(c => c.id === seg);
+      const child = current.children?.find((c) => c.id === seg);
       if (!child) return null;
       current = child;
     }

--- a/packages/typescript/sdk/consumer/src/tools.ts
+++ b/packages/typescript/sdk/consumer/src/tools.ts
@@ -112,9 +112,7 @@ export function affordancesToTools(node: SlopNode, path = ""): ToolSet {
       if (!baseParams.properties) baseParams.properties = {};
       baseParams.properties.target = {
         type: "string",
-        description:
-          `Path to the target node (e.g. ${targets[0]}).` +
-          ` See the state tree for valid paths.`,
+        description: `Path to the target node (e.g. ${targets[0]}).` + ` See the state tree for valid paths.`,
       };
       if (!baseParams.required) baseParams.required = [];
       baseParams.required = ["target", ...baseParams.required];
@@ -182,12 +180,7 @@ function sortKeysDeep(obj: any): any {
 }
 
 /** Recursively collect all affordances from the tree. */
-function collectAffordances(
-  node: SlopNode,
-  path: string,
-  ancestors: string[],
-  out: AffordanceEntry[],
-): void {
+function collectAffordances(node: SlopNode, path: string, ancestors: string[], out: AffordanceEntry[]): void {
   for (const aff of node.affordances ?? []) {
     out.push({
       nodeId: node.id,
@@ -243,7 +236,6 @@ function buildGroupDescription(group: AffordanceEntry[], isDangerous: boolean): 
   return desc;
 }
 
-
 /** Format the state tree as readable string for LLM context */
 export function formatTree(node: SlopNode, indent = 0): string {
   const pad = "  ".repeat(indent);
@@ -251,23 +243,23 @@ export function formatTree(node: SlopNode, indent = 0): string {
   const meta = node.meta ?? {};
   const displayName = (props.label ?? props.title) as string | undefined;
   // Always show the node ID. If there's a human-readable label/title, show both.
-  const header = displayName && displayName !== node.id
-    ? `${node.id}: ${displayName}`
-    : node.id;
+  const header = displayName && displayName !== node.id ? `${node.id}: ${displayName}` : node.id;
   const extra = Object.entries(props)
     .filter(([k]) => k !== "label" && k !== "title")
     .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
     .join(", ");
   const affordances = (node.affordances ?? [])
-    .map(a => {
+    .map((a) => {
       let s = a.action;
       if (a.params?.properties) {
         const params = Object.entries(a.params.properties as Record<string, any>)
-          .map(([k, v]) => `${k}: ${v.type}`).join(", ");
+          .map(([k, v]) => `${k}: ${v.type}`)
+          .join(", ");
         s += `(${params})`;
       }
       return s;
-    }).join(", ");
+    })
+    .join(", ");
 
   let line = `${pad}[${node.type}] ${header}`;
   if (extra) line += ` (${extra})`;

--- a/packages/typescript/sdk/consumer/src/transport-node-socket.ts
+++ b/packages/typescript/sdk/consumer/src/transport-node-socket.ts
@@ -53,7 +53,7 @@ export class NodeSocketClientTransport implements ClientTransport {
       const socket = createConnection(this.socketPath);
       socket.once("connect", () => resolve(socket));
       socket.once("error", (err) =>
-        reject(new Error(`Unix socket connection failed: ${this.socketPath}: ${err.message}`))
+        reject(new Error(`Unix socket connection failed: ${this.socketPath}: ${err.message}`)),
       );
     });
   }

--- a/packages/typescript/sdk/consumer/src/transport-pm.ts
+++ b/packages/typescript/sdk/consumer/src/transport-pm.ts
@@ -39,8 +39,12 @@ export class PostMessageClientTransport implements ClientTransport {
       send: (m: SlopMessage) => {
         this.port.postMessage({ type: "slop-to-provider", message: m });
       },
-      onMessage: (h: MessageHandler) => { messageHandlers.push(h); },
-      onClose: (h: () => void) => { closeHandlers.push(h); },
+      onMessage: (h: MessageHandler) => {
+        messageHandlers.push(h);
+      },
+      onClose: (h: () => void) => {
+        closeHandlers.push(h);
+      },
       close: () => {
         messageHandlers.length = 0;
         closeHandlers.length = 0;

--- a/packages/typescript/sdk/consumer/src/transport-ws.ts
+++ b/packages/typescript/sdk/consumer/src/transport-ws.ts
@@ -26,10 +26,18 @@ export class WebSocketClientTransport implements ClientTransport {
     };
 
     return {
-      send(msg) { ws.send(JSON.stringify(msg)); },
-      onMessage(h) { messageHandlers.push(h); },
-      onClose(h) { closeHandlers.push(h); },
-      close() { ws.close(); },
+      send(msg) {
+        ws.send(JSON.stringify(msg));
+      },
+      onMessage(h) {
+        messageHandlers.push(h);
+      },
+      onClose(h) {
+        closeHandlers.push(h);
+      },
+      close() {
+        ws.close();
+      },
     };
   }
 }

--- a/packages/typescript/sdk/consumer/src/types.ts
+++ b/packages/typescript/sdk/consumer/src/types.ts
@@ -56,23 +56,83 @@ export type JsonSchema = {
 
 // Messages
 
-export interface SubscribeMessage { type: "subscribe"; id: string; path?: string; depth?: number; }
-export interface UnsubscribeMessage { type: "unsubscribe"; id: string; }
-export interface QueryMessage { type: "query"; id: string; path?: string; depth?: number; }
-export interface InvokeMessage { type: "invoke"; id: string; path: string; action: string; params?: Record<string, unknown>; }
+export interface SubscribeMessage {
+  type: "subscribe";
+  id: string;
+  path?: string;
+  depth?: number;
+}
+export interface UnsubscribeMessage {
+  type: "unsubscribe";
+  id: string;
+}
+export interface QueryMessage {
+  type: "query";
+  id: string;
+  path?: string;
+  depth?: number;
+}
+export interface InvokeMessage {
+  type: "invoke";
+  id: string;
+  path: string;
+  action: string;
+  params?: Record<string, unknown>;
+}
 
 export type ConsumerMessage = SubscribeMessage | UnsubscribeMessage | QueryMessage | InvokeMessage;
 
-export interface HelloMessage { type: "hello"; provider: { id: string; name: string; slop_version: string; capabilities: string[]; }; }
-export interface SnapshotMessage { type: "snapshot"; id: string; version: number; tree: SlopNode; }
-export interface PatchOp { op: "add" | "remove" | "replace"; path: string; value?: unknown; }
-export interface PatchMessage { type: "patch"; subscription: string; version: number; ops: PatchOp[]; }
-export interface ResultMessage { type: "result"; id: string; status: "ok" | "error" | "accepted"; data?: unknown; error?: { code: string; message: string }; }
-export interface ErrorMessage { type: "error"; id?: string; error: { code: string; message: string }; }
-export interface EventMessage { type: "event"; name: string; data?: unknown; }
-export interface BatchMessage { type: "batch"; messages: ProviderMessage[]; }
+export interface HelloMessage {
+  type: "hello";
+  provider: { id: string; name: string; slop_version: string; capabilities: string[] };
+}
+export interface SnapshotMessage {
+  type: "snapshot";
+  id: string;
+  version: number;
+  tree: SlopNode;
+}
+export interface PatchOp {
+  op: "add" | "remove" | "replace";
+  path: string;
+  value?: unknown;
+}
+export interface PatchMessage {
+  type: "patch";
+  subscription: string;
+  version: number;
+  ops: PatchOp[];
+}
+export interface ResultMessage {
+  type: "result";
+  id: string;
+  status: "ok" | "error" | "accepted";
+  data?: unknown;
+  error?: { code: string; message: string };
+}
+export interface ErrorMessage {
+  type: "error";
+  id?: string;
+  error: { code: string; message: string };
+}
+export interface EventMessage {
+  type: "event";
+  name: string;
+  data?: unknown;
+}
+export interface BatchMessage {
+  type: "batch";
+  messages: ProviderMessage[];
+}
 
-export type ProviderMessage = HelloMessage | SnapshotMessage | PatchMessage | ResultMessage | ErrorMessage | EventMessage | BatchMessage;
+export type ProviderMessage =
+  | HelloMessage
+  | SnapshotMessage
+  | PatchMessage
+  | ResultMessage
+  | ErrorMessage
+  | EventMessage
+  | BatchMessage;
 export type SlopMessage = ConsumerMessage | ProviderMessage;
 
 // Transport

--- a/packages/typescript/sdk/core/__tests__/descriptor.test.ts
+++ b/packages/typescript/sdk/core/__tests__/descriptor.test.ts
@@ -33,16 +33,18 @@ describe("normalizeDescriptor", () => {
         },
       },
     });
-    expect(node.affordances).toEqual([{
-      action: "delete",
-      label: "Delete All",
-      dangerous: true,
-      params: {
-        type: "object",
-        properties: { confirm: { type: "boolean" } },
-        required: ["confirm"],
+    expect(node.affordances).toEqual([
+      {
+        action: "delete",
+        label: "Delete All",
+        dangerous: true,
+        params: {
+          type: "object",
+          properties: { confirm: { type: "boolean" } },
+          required: ["confirm"],
+        },
       },
-    }]);
+    ]);
     expect(handlers.get("notes/delete")).toBe(fn);
   });
 
@@ -115,11 +117,13 @@ describe("normalizeDescriptor", () => {
     const editFn = () => {};
     const { handlers } = normalizeDescriptor("inbox/messages", "messages", {
       type: "collection",
-      items: [{
-        id: "msg-1",
-        props: { subject: "Hi" },
-        actions: { edit: editFn },
-      }],
+      items: [
+        {
+          id: "msg-1",
+          props: { subject: "Hi" },
+          actions: { edit: editFn },
+        },
+      ],
     });
     expect(handlers.get("inbox/messages/msg-1/edit")).toBe(editFn);
   });
@@ -197,15 +201,17 @@ describe("normalizeDescriptor", () => {
   test("item contentRef maps to content_ref field", () => {
     const { node } = normalizeDescriptor("docs", "docs", {
       type: "collection",
-      items: [{
-        id: "readme",
-        props: { title: "README.md" },
-        contentRef: {
-          type: "text",
-          mime: "text/markdown",
-          summary: "Project readme",
+      items: [
+        {
+          id: "readme",
+          props: { title: "README.md" },
+          contentRef: {
+            type: "text",
+            mime: "text/markdown",
+            summary: "Project readme",
+          },
         },
-      }],
+      ],
     });
     const item = node.children![0];
     expect(item.content_ref).toBeDefined();
@@ -236,11 +242,13 @@ describe("normalizeDescriptor", () => {
   test("item summary maps to meta.summary", () => {
     const { node } = normalizeDescriptor("notes", "notes", {
       type: "collection",
-      items: [{
-        id: "n1",
-        props: { title: "Note" },
-        summary: "A short note about testing",
-      }],
+      items: [
+        {
+          id: "n1",
+          props: { title: "Note" },
+          summary: "A short note about testing",
+        },
+      ],
     });
     expect(node.children![0].meta?.summary).toBe("A short note about testing");
   });

--- a/packages/typescript/sdk/core/__tests__/helpers.test.ts
+++ b/packages/typescript/sdk/core/__tests__/helpers.test.ts
@@ -47,33 +47,23 @@ describe("omit", () => {
 
 describe("action", () => {
   test("creates action with typed params and handler", () => {
-    const a = action(
-      { title: "string", count: "number" },
-      ({ title, count }) => {
-        // TypeScript should infer: title: string, count: number
-        return { title, count };
-      }
-    );
+    const a = action({ title: "string", count: "number" }, ({ title, count }) => {
+      // TypeScript should infer: title: string, count: number
+      return { title, count };
+    });
     expect(typeof a).toBe("object");
     expect((a as any).params).toEqual({ title: "string", count: "number" });
     expect(typeof (a as any).handler).toBe("function");
   });
 
   test("handler receives params and can use them", () => {
-    const a = action(
-      { name: "string" },
-      ({ name }) => `Hello ${name}`
-    );
+    const a = action({ name: "string" }, ({ name }) => `Hello ${name}`);
     const result = (a as any).handler({ name: "World" });
     expect(result).toBe("Hello World");
   });
 
   test("supports options", () => {
-    const a = action(
-      { id: "string" },
-      () => {},
-      { label: "Delete", dangerous: true }
-    );
+    const a = action({ id: "string" }, () => {}, { label: "Delete", dangerous: true });
     expect((a as any).label).toBe("Delete");
     expect((a as any).dangerous).toBe(true);
   });
@@ -87,11 +77,7 @@ describe("action", () => {
   });
 
   test("action with estimate", () => {
-    const a = action(
-      { env: "string" },
-      () => {},
-      { estimate: "async" }
-    );
+    const a = action({ env: "string" }, () => {}, { estimate: "async" });
     expect((a as any).estimate).toBe("async");
   });
 });

--- a/packages/typescript/sdk/core/__tests__/scaling.test.ts
+++ b/packages/typescript/sdk/core/__tests__/scaling.test.ts
@@ -1,12 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import {
-  truncateTree,
-  autoCompact,
-  filterTree,
-  prepareTree,
-  getSubtree,
-  countNodes,
-} from "../src/scaling";
+import { truncateTree, autoCompact, filterTree, prepareTree, getSubtree, countNodes } from "../src/scaling";
 import { normalizeDescriptor } from "../src/descriptor";
 import { assembleTree } from "../src/tree-assembler";
 import { diffNodes } from "../src/diff";
@@ -29,14 +22,29 @@ function buildTree(entries: [string, NodeDescriptor][]): SlopNode {
 
 function makeDeepTree(): SlopNode {
   return {
-    id: "root", type: "root", children: [
-      { id: "a", type: "view", properties: { label: "A" }, children: [
-        { id: "b", type: "collection", meta: { summary: "B summary" }, children: [
-          { id: "c", type: "item", properties: { x: 1 }, children: [
-            { id: "d", type: "item", properties: { x: 2 } },
-          ]},
-        ]},
-      ]},
+    id: "root",
+    type: "root",
+    children: [
+      {
+        id: "a",
+        type: "view",
+        properties: { label: "A" },
+        children: [
+          {
+            id: "b",
+            type: "collection",
+            meta: { summary: "B summary" },
+            children: [
+              {
+                id: "c",
+                type: "item",
+                properties: { x: 1 },
+                children: [{ id: "d", type: "item", properties: { x: 2 } }],
+              },
+            ],
+          },
+        ],
+      },
       { id: "e", type: "view", properties: { label: "E" } },
     ],
   };
@@ -104,7 +112,14 @@ describe("Windowed collections", () => {
   test("window creates children from window.items", () => {
     const { node } = normalizeDescriptor("msgs", "msgs", {
       type: "collection",
-      window: { items: [{ id: "m1", props: { text: "Hello" } }, { id: "m2", props: { text: "World" } }], total: 500, offset: 10 },
+      window: {
+        items: [
+          { id: "m1", props: { text: "Hello" } },
+          { id: "m2", props: { text: "World" } },
+        ],
+        total: 500,
+        offset: 10,
+      },
     });
     expect(node.children).toHaveLength(2);
     expect(node.children![0].id).toBe("m1");
@@ -251,7 +266,8 @@ describe("truncateTree", () => {
 
   test("leaf nodes unaffected", () => {
     const tree: SlopNode = {
-      id: "root", type: "root",
+      id: "root",
+      type: "root",
       children: [{ id: "leaf", type: "item", properties: { x: 1 } }],
     };
     const truncated = truncateTree(tree, 0);
@@ -266,8 +282,12 @@ describe("truncateTree", () => {
 describe("autoCompact", () => {
   test("tree under budget is unchanged", () => {
     const tree: SlopNode = {
-      id: "root", type: "root",
-      children: [{ id: "a", type: "group" }, { id: "b", type: "group" }],
+      id: "root",
+      type: "root",
+      children: [
+        { id: "a", type: "group" },
+        { id: "b", type: "group" },
+      ],
     };
     const compacted = autoCompact(tree, 100);
     expect(countNodes(compacted)).toBe(3);
@@ -276,14 +296,21 @@ describe("autoCompact", () => {
   test("tree over budget gets compacted", () => {
     // Collapsible nodes must NOT be root direct children (those are protected)
     const tree: SlopNode = {
-      id: "root", type: "root",
-      children: [{
-        id: "app", type: "view",
-        children: [{
-          id: "section", type: "collection",
-          children: Array.from({ length: 10 }, (_, i) => ({ id: `item-${i}`, type: "item" })),
-        }],
-      }],
+      id: "root",
+      type: "root",
+      children: [
+        {
+          id: "app",
+          type: "view",
+          children: [
+            {
+              id: "section",
+              type: "collection",
+              children: Array.from({ length: 10 }, (_, i) => ({ id: `item-${i}`, type: "item" })),
+            },
+          ],
+        },
+      ],
     };
     // 13 nodes, budget 5
     const compacted = autoCompact(tree, 5);
@@ -292,35 +319,64 @@ describe("autoCompact", () => {
 
   test("low salience nodes collapsed before high salience", () => {
     const tree: SlopNode = {
-      id: "root", type: "root",
-      children: [{
-        id: "app", type: "view",
-        children: [
-          { id: "important", type: "collection", meta: { salience: 1.0 }, children: [{ id: "i1", type: "item" }, { id: "i2", type: "item" }] },
-          { id: "unimportant", type: "collection", meta: { salience: 0.1 }, summary: "Low priority", children: [{ id: "u1", type: "item" }, { id: "u2", type: "item" }, { id: "u3", type: "item" }] },
-        ],
-      }],
+      id: "root",
+      type: "root",
+      children: [
+        {
+          id: "app",
+          type: "view",
+          children: [
+            {
+              id: "important",
+              type: "collection",
+              meta: { salience: 1.0 },
+              children: [
+                { id: "i1", type: "item" },
+                { id: "i2", type: "item" },
+              ],
+            },
+            {
+              id: "unimportant",
+              type: "collection",
+              meta: { salience: 0.1 },
+              summary: "Low priority",
+              children: [
+                { id: "u1", type: "item" },
+                { id: "u2", type: "item" },
+                { id: "u3", type: "item" },
+              ],
+            },
+          ],
+        },
+      ],
     };
     // 9 nodes, budget 6 — unimportant should collapse first
     const compacted = autoCompact(tree, 6);
     const app = compacted.children![0];
-    const important = app.children?.find(c => c.id === "important");
-    const unimportant = app.children?.find(c => c.id === "unimportant");
+    const important = app.children?.find((c) => c.id === "important");
+    const unimportant = app.children?.find((c) => c.id === "unimportant");
     expect(important?.children?.length).toBeGreaterThan(0);
     expect(unimportant?.children).toBeUndefined();
   });
 
   test("summaries preserved on collapsed nodes", () => {
     const tree: SlopNode = {
-      id: "root", type: "root",
-      children: [{
-        id: "section", type: "group",
-        children: [{
-          id: "subsection", type: "collection",
-          meta: { summary: "Important subsection with 10 items" },
-          children: Array.from({ length: 10 }, (_, i) => ({ id: `item-${i}`, type: "item" })),
-        }],
-      }],
+      id: "root",
+      type: "root",
+      children: [
+        {
+          id: "section",
+          type: "group",
+          children: [
+            {
+              id: "subsection",
+              type: "collection",
+              meta: { summary: "Important subsection with 10 items" },
+              children: Array.from({ length: 10 }, (_, i) => ({ id: `item-${i}`, type: "item" })),
+            },
+          ],
+        },
+      ],
     };
     const compacted = autoCompact(tree, 4);
     const subsection = compacted.children![0].children![0];
@@ -331,11 +387,21 @@ describe("autoCompact", () => {
 
   test("nodes without summary get auto-generated summary", () => {
     const tree: SlopNode = {
-      id: "root", type: "root",
-      children: [{
-        id: "section", type: "group",
-        children: [{ id: "list", type: "collection", children: Array.from({ length: 5 }, (_, i) => ({ id: `item-${i}`, type: "item" })) }],
-      }],
+      id: "root",
+      type: "root",
+      children: [
+        {
+          id: "section",
+          type: "group",
+          children: [
+            {
+              id: "list",
+              type: "collection",
+              children: Array.from({ length: 5 }, (_, i) => ({ id: `item-${i}`, type: "item" })),
+            },
+          ],
+        },
+      ],
     };
     const compacted = autoCompact(tree, 3);
     const list = compacted.children![0].children![0];
@@ -345,7 +411,8 @@ describe("autoCompact", () => {
 
   test("root direct children are never collapsed", () => {
     const tree: SlopNode = {
-      id: "root", type: "root",
+      id: "root",
+      type: "root",
       children: [
         { id: "nav-1", type: "view", children: [{ id: "x", type: "item" }] },
         { id: "nav-2", type: "view", children: [{ id: "y", type: "item" }] },
@@ -364,7 +431,8 @@ describe("autoCompact", () => {
 describe("filterTree", () => {
   test("filters by min_salience", () => {
     const tree: SlopNode = {
-      id: "root", type: "root",
+      id: "root",
+      type: "root",
       children: [
         { id: "high", type: "item", meta: { salience: 0.9 } },
         { id: "low", type: "item", meta: { salience: 0.1 } },
@@ -373,7 +441,7 @@ describe("filterTree", () => {
     };
     const filtered = filterTree(tree, 0.5);
     expect(filtered.children).toHaveLength(2);
-    const ids = filtered.children!.map(c => c.id);
+    const ids = filtered.children!.map((c) => c.id);
     expect(ids).toContain("high");
     expect(ids).toContain("mid");
     expect(ids).not.toContain("low");
@@ -381,7 +449,8 @@ describe("filterTree", () => {
 
   test("filters by types", () => {
     const tree: SlopNode = {
-      id: "root", type: "root",
+      id: "root",
+      type: "root",
       children: [
         { id: "a", type: "item" },
         { id: "b", type: "notification" },
@@ -390,14 +459,15 @@ describe("filterTree", () => {
     };
     const filtered = filterTree(tree, undefined, ["item", "notification"]);
     expect(filtered.children).toHaveLength(2);
-    const ids = filtered.children!.map(c => c.id);
+    const ids = filtered.children!.map((c) => c.id);
     expect(ids).toContain("a");
     expect(ids).toContain("b");
   });
 
   test("default salience is 0.5 for unset nodes", () => {
     const tree: SlopNode = {
-      id: "root", type: "root",
+      id: "root",
+      type: "root",
       children: [
         { id: "no-meta", type: "item" },
         { id: "has-meta", type: "item", meta: { salience: 0.3 } },
@@ -410,14 +480,19 @@ describe("filterTree", () => {
 
   test("filters recursively", () => {
     const tree: SlopNode = {
-      id: "root", type: "root",
-      children: [{
-        id: "parent", type: "group", meta: { salience: 0.9 },
-        children: [
-          { id: "keep", type: "item", meta: { salience: 0.8 } },
-          { id: "drop", type: "item", meta: { salience: 0.1 } },
-        ],
-      }],
+      id: "root",
+      type: "root",
+      children: [
+        {
+          id: "parent",
+          type: "group",
+          meta: { salience: 0.9 },
+          children: [
+            { id: "keep", type: "item", meta: { salience: 0.8 } },
+            { id: "drop", type: "item", meta: { salience: 0.1 } },
+          ],
+        },
+      ],
     };
     const filtered = filterTree(tree, 0.5);
     expect(filtered.children![0].children).toHaveLength(1);
@@ -426,7 +501,8 @@ describe("filterTree", () => {
 
   test("combined salience + types filter", () => {
     const tree: SlopNode = {
-      id: "root", type: "root",
+      id: "root",
+      type: "root",
       children: [
         { id: "a", type: "notification", meta: { salience: 0.9 } },
         { id: "b", type: "notification", meta: { salience: 0.1 } },
@@ -445,11 +521,10 @@ describe("filterTree", () => {
 
 describe("getSubtree", () => {
   const tree: SlopNode = {
-    id: "root", type: "root",
+    id: "root",
+    type: "root",
     children: [
-      { id: "inbox", type: "view", children: [
-        { id: "msg-1", type: "item", properties: { subject: "Hello" } },
-      ]},
+      { id: "inbox", type: "view", children: [{ id: "msg-1", type: "item", properties: { subject: "Hello" } }] },
       { id: "settings", type: "view" },
     ],
   };
@@ -483,19 +558,23 @@ describe("getSubtree", () => {
 describe("prepareTree", () => {
   test("applies maxDepth + minSalience + maxNodes together", () => {
     const tree: SlopNode = {
-      id: "root", type: "root",
+      id: "root",
+      type: "root",
       children: [
-        { id: "important", type: "view", meta: { salience: 0.9 }, children: [
-          { id: "deep", type: "group", children: [{ id: "leaf", type: "item" }] },
-        ]},
+        {
+          id: "important",
+          type: "view",
+          meta: { salience: 0.9 },
+          children: [{ id: "deep", type: "group", children: [{ id: "leaf", type: "item" }] }],
+        },
         { id: "noise", type: "item", meta: { salience: 0.1 } },
       ],
     };
     const result = prepareTree(tree, { maxDepth: 1, minSalience: 0.5, maxNodes: 10 });
     // noise filtered by salience
-    expect(result.children?.find(c => c.id === "noise")).toBeUndefined();
+    expect(result.children?.find((c) => c.id === "noise")).toBeUndefined();
     // important present but truncated at depth 1
-    const imp = result.children?.find(c => c.id === "important");
+    const imp = result.children?.find((c) => c.id === "important");
     expect(imp).toBeDefined();
     expect(imp!.children).toBeUndefined();
     expect(imp!.meta?.total_children).toBe(1);
@@ -515,59 +594,118 @@ describe("prepareTree", () => {
 describe("Pinned nodes", () => {
   test("pinned node is never collapsed by auto-compaction", () => {
     const tree: SlopNode = {
-      id: "root", type: "root",
+      id: "root",
+      type: "root",
       children: [
-        { id: "data", type: "group", meta: { salience: 0.3 }, children: Array.from({ length: 10 }, (_, i) => ({ id: `item-${i}`, type: "item" })) },
-        { id: "ui", type: "view", meta: { pinned: true, salience: 0.5 }, children: [
-          { id: "filters", type: "status" },
-          { id: "compose", type: "view" },
-        ]},
+        {
+          id: "data",
+          type: "group",
+          meta: { salience: 0.3 },
+          children: Array.from({ length: 10 }, (_, i) => ({ id: `item-${i}`, type: "item" })),
+        },
+        {
+          id: "ui",
+          type: "view",
+          meta: { pinned: true, salience: 0.5 },
+          children: [
+            { id: "filters", type: "status" },
+            { id: "compose", type: "view" },
+          ],
+        },
       ],
     };
     const compacted = autoCompact(tree, 5);
-    const ui = compacted.children?.find(c => c.id === "ui");
+    const ui = compacted.children?.find((c) => c.id === "ui");
     expect(ui!.children).toBeDefined();
     expect(ui!.children!.length).toBe(2);
   });
 
   test("pinned node with low salience still survives compaction", () => {
     const tree: SlopNode = {
-      id: "root", type: "root",
+      id: "root",
+      type: "root",
       children: [
-        { id: "high-salience", type: "group", meta: { salience: 1.0 }, children: [{ id: "h1", type: "item" }, { id: "h2", type: "item" }] },
-        { id: "pinned-low", type: "group", meta: { pinned: true, salience: 0.1 }, children: [{ id: "p1", type: "item" }, { id: "p2", type: "item" }] },
+        {
+          id: "high-salience",
+          type: "group",
+          meta: { salience: 1.0 },
+          children: [
+            { id: "h1", type: "item" },
+            { id: "h2", type: "item" },
+          ],
+        },
+        {
+          id: "pinned-low",
+          type: "group",
+          meta: { pinned: true, salience: 0.1 },
+          children: [
+            { id: "p1", type: "item" },
+            { id: "p2", type: "item" },
+          ],
+        },
       ],
     };
     const compacted = autoCompact(tree, 4);
-    const pinnedNode = compacted.children?.find(c => c.id === "pinned-low");
+    const pinnedNode = compacted.children?.find((c) => c.id === "pinned-low");
     expect(pinnedNode!.children).toBeDefined();
     expect(pinnedNode!.children!.length).toBe(2);
   });
 
   test("non-pinned sibling is collapsed while pinned sibling survives", () => {
     const tree: SlopNode = {
-      id: "root", type: "root",
-      children: [{
-        id: "app", type: "view",
-        children: [
-          { id: "collapsible", type: "collection", children: Array.from({ length: 8 }, (_, i) => ({ id: `c-${i}`, type: "item" })) },
-          { id: "protected", type: "view", meta: { pinned: true }, children: [{ id: "route", type: "status" }, { id: "filter", type: "status" }] },
-        ],
-      }],
+      id: "root",
+      type: "root",
+      children: [
+        {
+          id: "app",
+          type: "view",
+          children: [
+            {
+              id: "collapsible",
+              type: "collection",
+              children: Array.from({ length: 8 }, (_, i) => ({ id: `c-${i}`, type: "item" })),
+            },
+            {
+              id: "protected",
+              type: "view",
+              meta: { pinned: true },
+              children: [
+                { id: "route", type: "status" },
+                { id: "filter", type: "status" },
+              ],
+            },
+          ],
+        },
+      ],
     };
     const compacted = autoCompact(tree, 6);
     const app = compacted.children![0];
-    expect(app.children?.find(c => c.id === "protected")!.children!.length).toBe(2);
-    expect(app.children?.find(c => c.id === "collapsible")!.children).toBeUndefined();
+    expect(app.children?.find((c) => c.id === "protected")!.children!.length).toBe(2);
+    expect(app.children?.find((c) => c.id === "collapsible")!.children).toBeUndefined();
   });
 
   test("all nodes pinned means nothing can be collapsed", () => {
     const tree: SlopNode = {
-      id: "root", type: "root",
-      children: [{
-        id: "a", type: "group", meta: { pinned: true },
-        children: [{ id: "b", type: "collection", meta: { pinned: true }, children: [{ id: "c1", type: "item" }, { id: "c2", type: "item" }] }],
-      }],
+      id: "root",
+      type: "root",
+      children: [
+        {
+          id: "a",
+          type: "group",
+          meta: { pinned: true },
+          children: [
+            {
+              id: "b",
+              type: "collection",
+              meta: { pinned: true },
+              children: [
+                { id: "c1", type: "item" },
+                { id: "c2", type: "item" },
+              ],
+            },
+          ],
+        },
+      ],
     };
     const compacted = autoCompact(tree, 2);
     expect(countNodes(compacted)).toBe(5);
@@ -580,43 +718,91 @@ describe("Pinned nodes", () => {
 
 describe("Patching with scaling features", () => {
   test("changing summary produces a patch", () => {
-    const old: SlopNode = { id: "root", type: "root", children: [{ id: "inbox", type: "view", meta: { summary: "10 messages" } }] };
-    const nw: SlopNode = { id: "root", type: "root", children: [{ id: "inbox", type: "view", meta: { summary: "11 messages" } }] };
+    const old: SlopNode = {
+      id: "root",
+      type: "root",
+      children: [{ id: "inbox", type: "view", meta: { summary: "10 messages" } }],
+    };
+    const nw: SlopNode = {
+      id: "root",
+      type: "root",
+      children: [{ id: "inbox", type: "view", meta: { summary: "11 messages" } }],
+    };
     const ops = diffNodes(old, nw);
-    expect(ops.some(op => op.path.includes("meta") && op.op === "replace")).toBe(true);
+    expect(ops.some((op) => op.path.includes("meta") && op.op === "replace")).toBe(true);
   });
 
   test("changing window items produces patches", () => {
     const old: SlopNode = {
-      id: "root", type: "root",
-      children: [{ id: "list", type: "collection", meta: { total_children: 100, window: [0, 2] as [number, number] }, children: [
-        { id: "item-0", type: "item", properties: { text: "A" } },
-        { id: "item-1", type: "item", properties: { text: "B" } },
-      ]}],
+      id: "root",
+      type: "root",
+      children: [
+        {
+          id: "list",
+          type: "collection",
+          meta: { total_children: 100, window: [0, 2] as [number, number] },
+          children: [
+            { id: "item-0", type: "item", properties: { text: "A" } },
+            { id: "item-1", type: "item", properties: { text: "B" } },
+          ],
+        },
+      ],
     };
     const nw: SlopNode = {
-      id: "root", type: "root",
-      children: [{ id: "list", type: "collection", meta: { total_children: 100, window: [2, 2] as [number, number] }, children: [
-        { id: "item-2", type: "item", properties: { text: "C" } },
-        { id: "item-3", type: "item", properties: { text: "D" } },
-      ]}],
+      id: "root",
+      type: "root",
+      children: [
+        {
+          id: "list",
+          type: "collection",
+          meta: { total_children: 100, window: [2, 2] as [number, number] },
+          children: [
+            { id: "item-2", type: "item", properties: { text: "C" } },
+            { id: "item-3", type: "item", properties: { text: "D" } },
+          ],
+        },
+      ],
     };
     const ops = diffNodes(old, nw);
-    expect(ops.filter(op => op.op === "remove")).toHaveLength(2);
-    expect(ops.filter(op => op.op === "add")).toHaveLength(2);
+    expect(ops.filter((op) => op.op === "remove")).toHaveLength(2);
+    expect(ops.filter((op) => op.op === "add")).toHaveLength(2);
   });
 
   test("adding content_ref produces a patch", () => {
-    const old: SlopNode = { id: "root", type: "root", children: [{ id: "doc", type: "document", properties: { title: "test" } }] };
-    const nw: SlopNode = { id: "root", type: "root", children: [{ id: "doc", type: "document", properties: { title: "test" }, content_ref: { type: "text", mime: "text/plain", summary: "Doc" } }] };
+    const old: SlopNode = {
+      id: "root",
+      type: "root",
+      children: [{ id: "doc", type: "document", properties: { title: "test" } }],
+    };
+    const nw: SlopNode = {
+      id: "root",
+      type: "root",
+      children: [
+        {
+          id: "doc",
+          type: "document",
+          properties: { title: "test" },
+          content_ref: { type: "text", mime: "text/plain", summary: "Doc" },
+        },
+      ],
+    };
     const ops = diffNodes(old, nw);
-    expect(ops.some(op => op.path.includes("content_ref"))).toBe(true);
+    expect(ops.some((op) => op.path.includes("content_ref"))).toBe(true);
   });
 
   test("no diff when tree is identical", () => {
     const tree: SlopNode = {
-      id: "root", type: "root", meta: { summary: "test" },
-      children: [{ id: "list", type: "collection", meta: { total_children: 100, window: [0, 5] as [number, number] }, children: Array.from({ length: 5 }, (_, i) => ({ id: `item-${i}`, type: "item" })) }],
+      id: "root",
+      type: "root",
+      meta: { summary: "test" },
+      children: [
+        {
+          id: "list",
+          type: "collection",
+          meta: { total_children: 100, window: [0, 5] as [number, number] },
+          children: Array.from({ length: 5 }, (_, i) => ({ id: `item-${i}`, type: "item" })),
+        },
+      ],
     };
     expect(diffNodes(tree, structuredClone(tree))).toHaveLength(0);
   });
@@ -628,7 +814,12 @@ describe("Patching with scaling features", () => {
 
 describe("Edge cases", () => {
   test("huge flat tree (1000 children)", () => {
-    const tree = buildTree(Array.from({ length: 1000 }, (_, i) => [`item-${i}`, { type: "item", props: { index: i } }] as [string, NodeDescriptor]));
+    const tree = buildTree(
+      Array.from(
+        { length: 1000 },
+        (_, i) => [`item-${i}`, { type: "item", props: { index: i } }] as [string, NodeDescriptor],
+      ),
+    );
     expect(countNodes(tree)).toBe(1001);
   });
 
@@ -677,8 +868,22 @@ describe("Edge cases", () => {
   test("tree with mixed features", () => {
     const tree = buildTree([
       ["profile", { type: "view", summary: "User profile" }],
-      ["messages", { type: "collection", summary: "500 messages", window: { items: [{ id: "m1", props: { text: "Hi" } }], total: 500, offset: 0 } }],
-      ["editor", { type: "document", props: { title: "main.ts" }, contentRef: { type: "text", mime: "text/typescript", summary: "TS file" } }],
+      [
+        "messages",
+        {
+          type: "collection",
+          summary: "500 messages",
+          window: { items: [{ id: "m1", props: { text: "Hi" } }], total: 500, offset: 0 },
+        },
+      ],
+      [
+        "editor",
+        {
+          type: "document",
+          props: { title: "main.ts" },
+          contentRef: { type: "text", mime: "text/typescript", summary: "TS file" },
+        },
+      ],
     ]);
     expect(countNodes(tree)).toBe(5);
     expect(findNode(tree, "profile")?.meta?.summary).toBe("User profile");
@@ -688,10 +893,21 @@ describe("Edge cases", () => {
 
   test("maxNodes on tree where all nodes have same salience", () => {
     const tree: SlopNode = {
-      id: "root", type: "root",
+      id: "root",
+      type: "root",
       children: [
         { id: "shallow", type: "group", children: [{ id: "s1", type: "item" }] },
-        { id: "deep", type: "group", children: [{ id: "d1", type: "group", children: [{ id: "d2", type: "group", children: [{ id: "d3", type: "item" }] }] }] },
+        {
+          id: "deep",
+          type: "group",
+          children: [
+            {
+              id: "d1",
+              type: "group",
+              children: [{ id: "d2", type: "group", children: [{ id: "d3", type: "item" }] }],
+            },
+          ],
+        },
       ],
     };
     const compacted = autoCompact(tree, 5);

--- a/packages/typescript/sdk/core/__tests__/tree-assembler.test.ts
+++ b/packages/typescript/sdk/core/__tests__/tree-assembler.test.ts
@@ -8,9 +8,7 @@ function makeRegs(entries: [string, NodeDescriptor][]): Map<string, NodeDescript
 
 describe("assembleTree", () => {
   test("single node at root level", () => {
-    const regs = makeRegs([
-      ["notes", { type: "collection", props: { count: 3 } }],
-    ]);
+    const regs = makeRegs([["notes", { type: "collection", props: { count: 3 } }]]);
     const { tree } = assembleTree(regs, "app", "My App");
     expect(tree.id).toBe("app");
     expect(tree.type).toBe("root");
@@ -103,12 +101,13 @@ describe("assembleTree", () => {
   test("items inside registered nodes produce handler entries", () => {
     const deleteFn = () => {};
     const regs = makeRegs([
-      ["todos", {
-        type: "collection",
-        items: [
-          { id: "t1", props: { title: "A" }, actions: { delete: deleteFn } },
-        ],
-      }],
+      [
+        "todos",
+        {
+          type: "collection",
+          items: [{ id: "t1", props: { title: "A" }, actions: { delete: deleteFn } }],
+        },
+      ],
     ]);
     const { tree, handlers } = assembleTree(regs, "app", "App");
     expect(tree.children![0].children![0].id).toBe("t1");
@@ -117,12 +116,15 @@ describe("assembleTree", () => {
 
   test("inline children and path-registered children coexist", () => {
     const regs = makeRegs([
-      ["settings", {
-        type: "view",
-        children: {
-          account: { type: "group", props: { email: "a@b.com" } },
+      [
+        "settings",
+        {
+          type: "view",
+          children: {
+            account: { type: "group", props: { email: "a@b.com" } },
+          },
         },
-      }],
+      ],
       ["settings/notifications", { type: "group", props: { enabled: true } }],
     ]);
     const { tree } = assembleTree(regs, "app", "App");

--- a/packages/typescript/sdk/core/src/descriptor.ts
+++ b/packages/typescript/sdk/core/src/descriptor.ts
@@ -1,6 +1,14 @@
 import type {
-  SlopNode, Affordance, JsonSchema, ActionHandler, NodeMeta, ContentRef,
-  NodeDescriptor, ItemDescriptor, Action, ParamDef,
+  SlopNode,
+  Affordance,
+  JsonSchema,
+  ActionHandler,
+  NodeMeta,
+  ContentRef,
+  NodeDescriptor,
+  ItemDescriptor,
+  Action,
+  ParamDef,
 } from "./types";
 
 export interface NormalizationResult {
@@ -12,11 +20,7 @@ export interface NormalizationResult {
  * Convert a developer-friendly NodeDescriptor into a wire-format SlopNode
  * and extract action handlers into a flat map keyed by "{path}/{action}".
  */
-export function normalizeDescriptor(
-  path: string,
-  id: string,
-  descriptor: NodeDescriptor
-): NormalizationResult {
+export function normalizeDescriptor(path: string, id: string, descriptor: NodeDescriptor): NormalizationResult {
   const handlers = new Map<string, ActionHandler>();
   const children: SlopNode[] = [];
 
@@ -48,9 +52,7 @@ export function normalizeDescriptor(
   if (descriptor.children) {
     for (const [childId, childDesc] of Object.entries(descriptor.children)) {
       const childPath = path ? `${path}/${childId}` : childId;
-      const { node: childNode, handlers: childHandlers } = normalizeDescriptor(
-        childPath, childId, childDesc
-      );
+      const { node: childNode, handlers: childHandlers } = normalizeDescriptor(childPath, childId, childDesc);
       children.push(childNode);
       for (const [k, v] of childHandlers) handlers.set(k, v);
     }
@@ -83,10 +85,7 @@ export function normalizeDescriptor(
   return { node, handlers };
 }
 
-function normalizeItem(
-  path: string,
-  item: ItemDescriptor
-): NormalizationResult {
+function normalizeItem(path: string, item: ItemDescriptor): NormalizationResult {
   const handlers = new Map<string, ActionHandler>();
   const children: SlopNode[] = [];
 
@@ -130,7 +129,7 @@ function normalizeItem(
 function normalizeActions(
   path: string,
   actions: Record<string, Action> | undefined,
-  handlers: Map<string, ActionHandler>
+  handlers: Map<string, ActionHandler>,
 ): Affordance[] {
   if (!actions) return [];
   const affordances: Affordance[] = [];

--- a/packages/typescript/sdk/core/src/diff.ts
+++ b/packages/typescript/sdk/core/src/diff.ts
@@ -4,20 +4,13 @@ import type { SlopNode, PatchOp } from "./types";
  * Recursively diff two SLOP trees and produce JSON Patch ops.
  * Paths use node IDs in children segments (not array indices).
  */
-export function diffNodes(
-  oldNode: SlopNode,
-  newNode: SlopNode,
-  basePath: string = ""
-): PatchOp[] {
+export function diffNodes(oldNode: SlopNode, newNode: SlopNode, basePath: string = ""): PatchOp[] {
   const ops: PatchOp[] = [];
 
   // Diff properties key-by-key
   const oldProps = oldNode.properties ?? {};
   const newProps = newNode.properties ?? {};
-  const allKeys = new Set([
-    ...Object.keys(oldProps),
-    ...Object.keys(newProps),
-  ]);
+  const allKeys = new Set([...Object.keys(oldProps), ...Object.keys(newProps)]);
   for (const key of allKeys) {
     const oldVal = oldProps[key];
     const newVal = newProps[key];

--- a/packages/typescript/sdk/core/src/helpers.ts
+++ b/packages/typescript/sdk/core/src/helpers.ts
@@ -1,10 +1,7 @@
 import type { Action, ActionHandler, ParamDef, InferParams } from "./types";
 
 /** Pick specific fields from an object for use in props */
-export function pick<T extends Record<string, unknown>, K extends keyof T>(
-  obj: T,
-  keys: K[]
-): Pick<T, K> {
+export function pick<T extends Record<string, unknown>, K extends keyof T>(obj: T, keys: K[]): Pick<T, K> {
   const result = {} as Pick<T, K>;
   for (const key of keys) {
     if (key in obj) result[key] = obj[key];
@@ -13,10 +10,7 @@ export function pick<T extends Record<string, unknown>, K extends keyof T>(
 }
 
 /** Exclude specific fields from an object for use in props */
-export function omit<T extends Record<string, unknown>, K extends keyof T>(
-  obj: T,
-  keys: K[]
-): Omit<T, K> {
+export function omit<T extends Record<string, unknown>, K extends keyof T>(obj: T, keys: K[]): Omit<T, K> {
   const result: Partial<T> = { ...obj };
   for (const key of keys) delete result[key];
   return result as Omit<T, K>;
@@ -26,13 +20,25 @@ export function omit<T extends Record<string, unknown>, K extends keyof T>(
 export function action<const P extends Record<string, ParamDef>>(
   params: P,
   handler: (params: InferParams<P>) => unknown | Promise<unknown>,
-  options?: { label?: string; description?: string; dangerous?: boolean; idempotent?: boolean; estimate?: "instant" | "fast" | "slow" | "async" }
+  options?: {
+    label?: string;
+    description?: string;
+    dangerous?: boolean;
+    idempotent?: boolean;
+    estimate?: "instant" | "fast" | "slow" | "async";
+  },
 ): Action;
 
 /** Create an action with options (no params) */
 export function action(
   handler: ActionHandler,
-  options?: { label?: string; description?: string; dangerous?: boolean; idempotent?: boolean; estimate?: "instant" | "fast" | "slow" | "async" }
+  options?: {
+    label?: string;
+    description?: string;
+    dangerous?: boolean;
+    idempotent?: boolean;
+    estimate?: "instant" | "fast" | "slow" | "async";
+  },
 ): Action;
 
 export function action(...args: unknown[]): Action {

--- a/packages/typescript/sdk/core/src/index.ts
+++ b/packages/typescript/sdk/core/src/index.ts
@@ -3,14 +3,7 @@ import { AsyncActionResult } from "./types";
 import { pick, omit, action } from "./helpers";
 import { assembleTree } from "./tree-assembler";
 import { diffNodes } from "./diff";
-import {
-  prepareTree,
-  getSubtree,
-  truncateTree,
-  autoCompact,
-  filterTree,
-  countNodes,
-} from "./scaling";
+import { prepareTree, getSubtree, truncateTree, autoCompact, filterTree, countNodes } from "./scaling";
 
 // Provider base (shared between client and server)
 export { ProviderBase };

--- a/packages/typescript/sdk/core/src/provider.ts
+++ b/packages/typescript/sdk/core/src/provider.ts
@@ -7,10 +7,7 @@
  * `broadcast()` to push updates to consumers.
  */
 
-import type {
-  SlopNode, PatchOp, ActionHandler, NodeDescriptor,
-  SlopClientOptions,
-} from "./types";
+import type { SlopNode, PatchOp, ActionHandler, NodeDescriptor, SlopClientOptions } from "./types";
 import { AsyncActionResult } from "./types";
 import { assembleTree } from "./tree-assembler";
 import { diffNodes } from "./diff";
@@ -73,11 +70,7 @@ export abstract class ProviderBase<S = unknown> {
   /** Rebuild the tree from registrations, diff, and broadcast if changed. */
   protected rebuild(): void {
     const registrations = this.getRegistrations();
-    const { tree, handlers } = assembleTree(
-      registrations,
-      this.options.id,
-      this.options.name,
-    );
+    const { tree, handlers } = assembleTree(registrations, this.options.id, this.options.name);
     const ops = diffNodes(this.currentTree, tree);
     this.currentHandlers = handlers;
 
@@ -133,7 +126,9 @@ export abstract class ProviderBase<S = unknown> {
       const isAsync = data instanceof AsyncActionResult;
       const resultData = isAsync
         ? (data.data ?? {})
-        : (data && typeof data === "object" ? data as Record<string, unknown> : {});
+        : data && typeof data === "object"
+          ? (data as Record<string, unknown>)
+          : {};
       const result: Record<string, unknown> = {
         type: "result",
         id: msg.id,
@@ -175,17 +170,14 @@ export abstract class ProviderBase<S = unknown> {
 
   /** Prepare the tree for output, applying path, depth, filter, window, and global options. */
   getOutputTree(request?: OutputRequest): SlopNode {
-    let tree = request?.path
-      ? getSubtree(this.currentTree, request.path) ?? this.currentTree
-      : this.currentTree;
+    let tree = request?.path ? (getSubtree(this.currentTree, request.path) ?? this.currentTree) : this.currentTree;
 
     tree = prepareTree(tree, {
-      maxDepth: request?.depth != null && request.depth >= 0
-        ? request.depth
-        : this.options.maxDepth,
-      maxNodes: request?.max_nodes != null && this.options.maxNodes != null
-        ? Math.min(request.max_nodes, this.options.maxNodes)
-        : request?.max_nodes ?? this.options.maxNodes,
+      maxDepth: request?.depth != null && request.depth >= 0 ? request.depth : this.options.maxDepth,
+      maxNodes:
+        request?.max_nodes != null && this.options.maxNodes != null
+          ? Math.min(request.max_nodes, this.options.maxNodes)
+          : (request?.max_nodes ?? this.options.maxNodes),
       minSalience: request?.filter?.min_salience,
       types: request?.filter?.types,
     });

--- a/packages/typescript/sdk/core/src/scaling.ts
+++ b/packages/typescript/sdk/core/src/scaling.ts
@@ -116,11 +116,7 @@ export function autoCompact(root: SlopNode, maxNodes: number): SlopNode {
  * Nodes below minSalience or not matching types are removed.
  * The root node is never filtered.
  */
-export function filterTree(
-  node: SlopNode,
-  minSalience?: number,
-  types?: string[]
-): SlopNode {
+export function filterTree(node: SlopNode, minSalience?: number, types?: string[]): SlopNode {
   if (!node.children) return node;
 
   const filtered = node.children
@@ -142,9 +138,7 @@ export function filterTree(
 
 /** Count total nodes in a tree. */
 export function countNodes(node: SlopNode): number {
-  return (
-    1 + (node.children?.reduce((sum, c) => sum + countNodes(c), 0) ?? 0)
-  );
+  return 1 + (node.children?.reduce((sum, c) => sum + countNodes(c), 0) ?? 0);
 }
 
 // --- Internal helpers ---
@@ -159,7 +153,7 @@ function collectCandidates(
   node: SlopNode,
   path: number[],
   candidates: CompactCandidate[],
-  isRootChild: boolean = false
+  isRootChild: boolean = false,
 ): void {
   if (!node.children) return;
   for (let i = 0; i < node.children.length; i++) {
@@ -199,8 +193,7 @@ function collapseAtPath(tree: SlopNode, path: number[]): number {
     meta: {
       ...target.meta,
       total_children: target.children?.length ?? 0,
-      summary:
-        target.meta?.summary ?? `${target.children?.length ?? 0} children`,
+      summary: target.meta?.summary ?? `${target.children?.length ?? 0} children`,
     },
   };
 

--- a/packages/typescript/sdk/core/src/schema-types.ts
+++ b/packages/typescript/sdk/core/src/schema-types.ts
@@ -17,11 +17,10 @@ export type ExtractPaths<S> = S extends string
     : string; // fallback: no schema = any string
 
 /** Extract the sub-schema at a given path */
-export type ExtractSubSchema<S, P extends string> =
-  P extends `${infer Head}/${infer Rest}`
-    ? Head extends keyof S
-      ? ExtractSubSchema<S[Head], Rest>
-      : unknown
-    : P extends keyof S
-      ? S[P]
-      : unknown;
+export type ExtractSubSchema<S, P extends string> = P extends `${infer Head}/${infer Rest}`
+  ? Head extends keyof S
+    ? ExtractSubSchema<S[Head], Rest>
+    : unknown
+  : P extends keyof S
+    ? S[P]
+    : unknown;

--- a/packages/typescript/sdk/core/src/tree-assembler.ts
+++ b/packages/typescript/sdk/core/src/tree-assembler.ts
@@ -13,7 +13,7 @@ export interface AssemblyResult {
 export function assembleTree(
   registrations: Map<string, NodeDescriptor>,
   rootId: string,
-  rootName: string
+  rootName: string,
 ): AssemblyResult {
   const allHandlers = new Map<string, ActionHandler>();
   const nodesByPath = new Map<string, SlopNode>();
@@ -70,11 +70,7 @@ function getParentPath(path: string): string {
  * Ensure a node exists at the given path, creating synthetic placeholders
  * as needed for missing ancestors.
  */
-function ensureNode(
-  path: string,
-  nodesByPath: Map<string, SlopNode>,
-  root: SlopNode
-): SlopNode {
+function ensureNode(path: string, nodesByPath: Map<string, SlopNode>, root: SlopNode): SlopNode {
   // Already exists
   const existing = nodesByPath.get(path);
   if (existing) return existing;

--- a/packages/typescript/sdk/core/src/types.ts
+++ b/packages/typescript/sdk/core/src/types.ts
@@ -56,15 +56,17 @@ export type ActionHandler = (params: Record<string, unknown>) => unknown | Promi
 
 export type ParamDef = string | { type: string; description?: string; enum?: readonly unknown[]; items?: JsonSchema };
 
-export type Action = ActionHandler | {
-  handler: ActionHandler;
-  params?: Record<string, ParamDef>;
-  label?: string;
-  description?: string;
-  dangerous?: boolean;
-  idempotent?: boolean;
-  estimate?: "instant" | "fast" | "slow" | "async";
-};
+export type Action =
+  | ActionHandler
+  | {
+      handler: ActionHandler;
+      params?: Record<string, ParamDef>;
+      label?: string;
+      description?: string;
+      dangerous?: boolean;
+      idempotent?: boolean;
+      estimate?: "instant" | "fast" | "slow" | "async";
+    };
 
 export interface ContentRef {
   type: "text" | "binary" | "stream";
@@ -106,13 +108,19 @@ export interface NodeDescriptor {
 
 // --- Type inference for action params ---
 
-type InferParam<T> = T extends "string" ? string
-  : T extends "number" ? number
-  : T extends "boolean" ? boolean
-  : T extends { type: "string" } ? string
-  : T extends { type: "number" } ? number
-  : T extends { type: "boolean" } ? boolean
-  : unknown;
+type InferParam<T> = T extends "string"
+  ? string
+  : T extends "number"
+    ? number
+    : T extends "boolean"
+      ? boolean
+      : T extends { type: "string" }
+        ? string
+        : T extends { type: "number" }
+          ? number
+          : T extends { type: "boolean" }
+            ? boolean
+            : unknown;
 
 export type InferParams<T> = { [K in keyof T]: InferParam<T[K]> };
 
@@ -151,7 +159,7 @@ export interface SlopClient<S = unknown> {
   asyncAction<P extends Record<string, ParamDef>>(
     params: P,
     fn: (params: InferParams<P>, task: TaskHandle) => Promise<unknown>,
-    options?: { label?: string; description?: string; cancelable?: boolean }
+    options?: { label?: string; description?: string; cancelable?: boolean },
   ): Action;
   flush(): void;
   stop(): void;

--- a/packages/typescript/sdk/server/__tests__/patch-flow.test.ts
+++ b/packages/typescript/sdk/server/__tests__/patch-flow.test.ts
@@ -6,8 +6,12 @@ import { StateMirror } from "../../consumer/src/state-mirror";
 class MockConnection implements Connection {
   messages: any[] = [];
   closed = false;
-  send(message: unknown): void { this.messages.push(message); }
-  close(): void { this.closed = true; }
+  send(message: unknown): void {
+    this.messages.push(message);
+  }
+  close(): void {
+    this.closed = true;
+  }
 }
 
 function setup() {
@@ -18,12 +22,18 @@ function setup() {
 }
 
 function subscribe(slop: SlopServer, conn: MockConnection, opts: any = {}) {
-  slop.handleMessage(conn, { type: "subscribe", id: opts.id ?? "sub-1", path: opts.path ?? "/", depth: opts.depth, filter: opts.filter });
-  return conn.messages.find(m => m.type === "snapshot" && m.id === (opts.id ?? "sub-1"));
+  slop.handleMessage(conn, {
+    type: "subscribe",
+    id: opts.id ?? "sub-1",
+    path: opts.path ?? "/",
+    depth: opts.depth,
+    filter: opts.filter,
+  });
+  return conn.messages.find((m) => m.type === "snapshot" && m.id === (opts.id ?? "sub-1"));
 }
 
 function lastPatch(conn: MockConnection, subId = "sub-1") {
-  return [...conn.messages].reverse().find(m => m.type === "patch" && m.subscription === subId);
+  return [...conn.messages].reverse().find((m) => m.type === "patch" && m.subscription === subId);
 }
 
 function replayState(conn: MockConnection): StateMirror | null {
@@ -41,8 +51,8 @@ describe("Patch message flow", () => {
     slop.register("counter", { type: "status", props: { count: 0 } });
     subscribe(slop, conn);
 
-    const snapshots = conn.messages.filter(m => m.type === "snapshot");
-    const patches = conn.messages.filter(m => m.type === "patch");
+    const snapshots = conn.messages.filter((m) => m.type === "snapshot");
+    const patches = conn.messages.filter((m) => m.type === "patch");
     expect(snapshots.length).toBe(1);
     expect(patches.length).toBe(0);
   });
@@ -124,13 +134,13 @@ describe("Patch message flow", () => {
     expect(mirror).not.toBeNull();
 
     const tree = mirror.getTree();
-    const counter = tree.children?.find(c => c.id === "counter");
+    const counter = tree.children?.find((c) => c.id === "counter");
     expect(counter?.properties?.count).toBe(2);
     expect(counter?.properties?.label).toBe("Counter");
 
-    const tasks = tree.children?.find(c => c.id === "tasks");
+    const tasks = tree.children?.find((c) => c.id === "tasks");
     expect(tasks).toBeDefined();
-    const t1 = tasks?.children?.find(c => c.id === "t1");
+    const t1 = tasks?.children?.find((c) => c.id === "t1");
     expect(t1?.properties?.title).toBe("Do stuff");
   });
 
@@ -139,7 +149,7 @@ describe("Patch message flow", () => {
     slop.register("x", { type: "status", props: { v: 0 } });
     subscribe(slop, conn);
 
-    const snapshot = conn.messages.find(m => m.type === "snapshot");
+    const snapshot = conn.messages.find((m) => m.type === "snapshot");
     expect(snapshot.version).toBe(1);
 
     slop.register("x", { type: "status", props: { v: 1 } });
@@ -187,7 +197,7 @@ describe("Patch message flow", () => {
     const { slop, conn } = setup();
     await slop.handleMessage(conn, { type: "bogus", id: "req-1" });
 
-    const error = conn.messages.find(m => m.type === "error");
+    const error = conn.messages.find((m) => m.type === "error");
     expect(error).toBeDefined();
     expect(error.id).toBe("req-1");
     expect(error.error.code).toBe("bad_request");
@@ -199,11 +209,11 @@ describe("Patch message flow", () => {
     slop.register("inbox", { type: "collection", props: {} });
     await slop.handleMessage(conn, { type: "subscribe", id: "sub-bad", path: "/nonexistent" });
 
-    const error = conn.messages.find(m => m.type === "error" && m.id === "sub-bad");
+    const error = conn.messages.find((m) => m.type === "error" && m.id === "sub-bad");
     expect(error).toBeDefined();
     expect(error.error.code).toBe("not_found");
     // Should not have created a subscription (no snapshot sent)
-    const snapshot = conn.messages.find(m => m.type === "snapshot" && m.id === "sub-bad");
+    const snapshot = conn.messages.find((m) => m.type === "snapshot" && m.id === "sub-bad");
     expect(snapshot).toBeUndefined();
   });
 
@@ -217,7 +227,7 @@ describe("Patch message flow", () => {
     slop.emitEvent("user-navigation", { from: "/a", to: "/b" });
 
     for (const conn of [conn1, conn2]) {
-      const evt = conn.messages.find(m => m.type === "event");
+      const evt = conn.messages.find((m) => m.type === "event");
       expect(evt).toBeDefined();
       expect(evt.name).toBe("user-navigation");
       expect(evt.data).toEqual({ from: "/a", to: "/b" });
@@ -234,7 +244,7 @@ describe("Patch message flow", () => {
 
     slop.handleMessage(conn, { type: "query", id: "q-1", path: "/items", depth: 1, window: [1, 2] });
 
-    const snapshot = conn.messages.find(m => m.type === "snapshot" && m.id === "q-1");
+    const snapshot = conn.messages.find((m) => m.type === "snapshot" && m.id === "q-1");
     expect(snapshot).toBeDefined();
     expect(snapshot.tree.children).toHaveLength(2);
     expect(snapshot.tree.children[0].id).toBe("i1");

--- a/packages/typescript/sdk/server/__tests__/scaling.test.ts
+++ b/packages/typescript/sdk/server/__tests__/scaling.test.ts
@@ -231,8 +231,6 @@ describe("SlopServer scaling", () => {
     const current = conn.currentTree();
     ids = current.tree.children?.map((c: any) => c.id) ?? [];
     expect(ids).toContain("counter");
-    expect(current.tree.children.find((c: any) => c.id === "counter").meta.summary).toBe(
-      "Count is 1"
-    );
+    expect(current.tree.children.find((c: any) => c.id === "counter").meta.summary).toBe("Count is 1");
   });
 });

--- a/packages/typescript/sdk/server/src/adapters/vite.ts
+++ b/packages/typescript/sdk/server/src/adapters/vite.ts
@@ -9,10 +9,7 @@ import type { SlopServer } from "../server";
  * export default { plugins: [sveltekit(), slopPlugin(slop)] };
  * ```
  */
-export function slopPlugin(
-  slop: SlopServer,
-  options: { path?: string } = {}
-) {
+export function slopPlugin(slop: SlopServer, options: { path?: string } = {}) {
   const path = options.path ?? "/slop";
 
   return {

--- a/packages/typescript/sdk/server/src/index.ts
+++ b/packages/typescript/sdk/server/src/index.ts
@@ -27,9 +27,7 @@ import type { SlopServerOptions } from "./server";
  * attachSlop(slop, httpServer);
  * ```
  */
-export function createSlopServer<S = unknown>(
-  options: SlopServerOptions<S>
-): SlopServer<S> {
+export function createSlopServer<S = unknown>(options: SlopServerOptions<S>): SlopServer<S> {
   return new SlopServer<S>(options);
 }
 

--- a/packages/typescript/sdk/server/src/server.ts
+++ b/packages/typescript/sdk/server/src/server.ts
@@ -1,7 +1,11 @@
 import { ProviderBase, diffNodes, getSubtree } from "@slop-ai/core";
 import type {
-  SlopNode, PatchOp, ActionHandler, NodeDescriptor,
-  SlopClientOptions, SubscriptionFilter,
+  SlopNode,
+  PatchOp,
+  ActionHandler,
+  NodeDescriptor,
+  SlopClientOptions,
+  SubscriptionFilter,
 } from "@slop-ai/core";
 
 /** A descriptor function that returns a NodeDescriptor when called. */
@@ -157,21 +161,21 @@ export class SlopServer<S = unknown> extends ProviderBase<S> {
       }
 
       case "unsubscribe": {
-        const idx = this.subscriptions.findIndex(
-          (s) => s.id === msg.id && s.connection === conn
-        );
+        const idx = this.subscriptions.findIndex((s) => s.id === msg.id && s.connection === conn);
         if (idx >= 0) this.subscriptions.splice(idx, 1);
         break;
       }
 
       case "query": {
-        conn.send(this.snapshotMessage(msg.id, {
-          path: msg.path,
-          depth: msg.depth,
-          max_nodes: msg.max_nodes,
-          filter: msg.filter,
-          window: msg.window,
-        }));
+        conn.send(
+          this.snapshotMessage(msg.id, {
+            path: msg.path,
+            depth: msg.depth,
+            max_nodes: msg.max_nodes,
+            filter: msg.filter,
+            window: msg.window,
+          }),
+        );
         break;
       }
 
@@ -201,7 +205,9 @@ export class SlopServer<S = unknown> extends ProviderBase<S> {
   /** Register a listener that fires after every tree rebuild. */
   onChange(fn: () => void): () => void {
     this.changeListeners.add(fn);
-    return () => { this.changeListeners.delete(fn); };
+    return () => {
+      this.changeListeners.delete(fn);
+    };
   }
 
   /** Graceful shutdown. */

--- a/packages/typescript/sdk/server/src/transports/bun.ts
+++ b/packages/typescript/sdk/server/src/transports/bun.ts
@@ -18,10 +18,7 @@ import type { SlopServer, Connection } from "../server";
  * });
  * ```
  */
-export function bunHandler(
-  slop: SlopServer,
-  options: { path?: string; discovery?: boolean } = {}
-) {
+export function bunHandler(slop: SlopServer, options: { path?: string; discovery?: boolean } = {}) {
   const path = options.path ?? "/slop";
   const discovery = options.discovery !== false;
 

--- a/packages/typescript/sdk/server/src/transports/node.ts
+++ b/packages/typescript/sdk/server/src/transports/node.ts
@@ -21,11 +21,7 @@ export interface AttachSlopOptions {
  * server.listen(3000);
  * ```
  */
-export function attachSlop(
-  slop: SlopServer,
-  httpServer: HttpServer,
-  options: AttachSlopOptions = {}
-): void {
+export function attachSlop(slop: SlopServer, httpServer: HttpServer, options: AttachSlopOptions = {}): void {
   const path = options.path ?? "/slop";
   const discovery = options.discovery !== false;
 
@@ -72,7 +68,10 @@ export function attachSlop(
 
   // Intercept /.well-known/slop requests
   if (discovery) {
-    const originalListeners = httpServer.listeners("request") as ((req: IncomingMessage, res: ServerResponse) => void)[];
+    const originalListeners = httpServer.listeners("request") as ((
+      req: IncomingMessage,
+      res: ServerResponse,
+    ) => void)[];
     httpServer.removeAllListeners("request");
 
     httpServer.on("request", (req: IncomingMessage, res: ServerResponse) => {
@@ -80,13 +79,15 @@ export function attachSlop(
         const host = req.headers.host ?? "localhost";
         const protocol = "ws";
         res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({
-          id: slop.id,
-          name: slop.name,
-          slop_version: "0.1",
-          transport: { type: "ws", url: `${protocol}://${host}${path}` },
-          capabilities: ["state", "patches", "affordances", "attention", "windowing", "async", "content_refs"],
-        }));
+        res.end(
+          JSON.stringify({
+            id: slop.id,
+            name: slop.name,
+            slop_version: "0.1",
+            transport: { type: "ws", url: `${protocol}://${host}${path}` },
+            capabilities: ["state", "patches", "affordances", "attention", "windowing", "async", "content_refs"],
+          }),
+        );
         return;
       }
 

--- a/packages/typescript/sdk/server/src/transports/unix.ts
+++ b/packages/typescript/sdk/server/src/transports/unix.ts
@@ -21,7 +21,7 @@ export interface ListenUnixOptions {
 export function listenUnix(
   slop: SlopServer,
   socketPath: string,
-  options: ListenUnixOptions = {}
+  options: ListenUnixOptions = {},
 ): { close: () => void } {
   // Clean up stale socket
   removeSocketIfPresent(socketPath);

--- a/scripts/preflight.ts
+++ b/scripts/preflight.ts
@@ -1,12 +1,7 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
-import {
-  getTypeScriptPackages,
-  readJson,
-  repoRoot,
-  type PackageManifest,
-} from "./release/shared";
+import { getTypeScriptPackages, readJson, repoRoot, type PackageManifest } from "./release/shared";
 
 type Check = {
   label: string;
@@ -36,9 +31,7 @@ type RawPackageComponent = {
   excludedRoots?: string[];
 };
 
-type Cause =
-  | { kind: "changed"; files: string[] }
-  | { kind: "dependency"; dependencyId: string };
+type Cause = { kind: "changed"; files: string[] } | { kind: "dependency"; dependencyId: string };
 
 type Args = {
   all: boolean;
@@ -271,10 +264,7 @@ function collectPackageComponents(): Component[] {
         manifestPath,
         relativeDir,
         absoluteRoot,
-        roots:
-          relativeDir === "website/docs"
-            ? [relativeDir, "docs", "spec"]
-            : [relativeDir],
+        roots: relativeDir === "website/docs" ? [relativeDir, "docs", "spec"] : [relativeDir],
         excludedRoots: relativeDir === "apps/desktop" ? ["apps/desktop/src-tauri"] : undefined,
       });
     }
@@ -355,11 +345,7 @@ function parseUvSourcePaths(filePath: string): string[] {
   return deps;
 }
 
-function resolveDependencyIds(
-  baseDir: string,
-  rawPaths: string[],
-  componentByRoot: Map<string, string>,
-): string[] {
+function resolveDependencyIds(baseDir: string, rawPaths: string[], componentByRoot: Map<string, string>): string[] {
   const dependencies = new Set<string>();
   for (const rawPath of rawPaths) {
     const absolute = resolve(baseDir, rawPath);
@@ -518,11 +504,7 @@ function fileMatchesComponent(filePath: string, component: Component): boolean {
 }
 
 function isRepoWideTrigger(filePath: string): boolean {
-  return (
-    filePath === "package.json" ||
-    filePath === "bun.lock" ||
-    filePath.startsWith("scripts/")
-  );
+  return filePath === "package.json" || filePath === "bun.lock" || filePath.startsWith("scripts/");
 }
 
 function topologicalSort(components: Component[], affectedIds: Set<string>): Component[] {
@@ -549,9 +531,7 @@ function topologicalSort(components: Component[], affectedIds: Set<string>): Com
     }
   }
 
-  const queue = [...affectedIds]
-    .filter((id) => (inDegree.get(id) ?? 0) === 0)
-    .sort((a, b) => a.localeCompare(b));
+  const queue = [...affectedIds].filter((id) => (inDegree.get(id) ?? 0) === 0).sort((a, b) => a.localeCompare(b));
   const ordered: Component[] = [];
 
   while (queue.length > 0) {
@@ -605,9 +585,7 @@ function computeAffected(
     }
   } else {
     for (const component of components) {
-      const matchedFiles = changedFiles.filter((filePath) =>
-        fileMatchesComponent(filePath, component),
-      );
+      const matchedFiles = changedFiles.filter((filePath) => fileMatchesComponent(filePath, component));
 
       if (matchedFiles.length === 0) {
         continue;
@@ -656,7 +634,9 @@ function printPlan(ordered: Component[], causes: Map<string, Cause>, repoWide: b
     if (cause?.kind === "changed") {
       console.log(`  reason: changed ${cause.files.join(", ")}`);
     } else if (cause?.kind === "dependency") {
-      console.log(`  reason: depends on ${ordered.find((item) => item.id === cause.dependencyId)?.label ?? cause.dependencyId}`);
+      console.log(
+        `  reason: depends on ${ordered.find((item) => item.id === cause.dependencyId)?.label ?? cause.dependencyId}`,
+      );
     }
 
     if (component.checks.length === 0) {

--- a/scripts/release/publish-chrome-web-store.ts
+++ b/scripts/release/publish-chrome-web-store.ts
@@ -11,9 +11,7 @@ if (!zipPath) {
 }
 
 if (!publisherId || !extensionId || !serviceAccountJson) {
-  throw new Error(
-    "CHROME_PUBLISHER_ID, CHROME_EXTENSION_ID, and CHROME_SERVICE_ACCOUNT_JSON are required.",
-  );
+  throw new Error("CHROME_PUBLISHER_ID, CHROME_EXTENSION_ID, and CHROME_SERVICE_ACCOUNT_JSON are required.");
 }
 
 type ServiceAccountCredentials = {
@@ -24,11 +22,7 @@ type ServiceAccountCredentials = {
 const credentials = JSON.parse(serviceAccountJson) as ServiceAccountCredentials;
 
 function base64Url(input: string | Buffer): string {
-  return Buffer.from(input)
-    .toString("base64")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/g, "");
+  return Buffer.from(input).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
 }
 
 function createJwt(): string {
@@ -90,17 +84,14 @@ const accessToken = await getAccessToken();
 const itemName = `publishers/${publisherId}/items/${extensionId}`;
 const zipBuffer = readFileSync(zipPath);
 
-const uploadResponse = await fetch(
-  `https://chromewebstore.googleapis.com/upload/v2/${itemName}:upload`,
-  {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      "Content-Type": "application/octet-stream",
-    },
-    body: zipBuffer,
+const uploadResponse = await fetch(`https://chromewebstore.googleapis.com/upload/v2/${itemName}:upload`, {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${accessToken}`,
+    "Content-Type": "application/octet-stream",
   },
-);
+  body: zipBuffer,
+});
 
 const uploadBody = await expectOk(uploadResponse, "Chrome Web Store upload");
 console.log("Uploaded extension package:", JSON.stringify(uploadBody));

--- a/scripts/release/publish-packages.ts
+++ b/scripts/release/publish-packages.ts
@@ -5,9 +5,7 @@ const registry = process.env.NPM_REGISTRY_URL ?? "https://registry.npmjs.org";
 const packages = sortPackagesForPublish(getTypeScriptPackages());
 
 async function isAlreadyPublished(name: string, publishedVersion: string): Promise<boolean> {
-  const packagePath = name.startsWith("@")
-    ? name.replace("/", "%2f")
-    : encodeURIComponent(name);
+  const packagePath = name.startsWith("@") ? name.replace("/", "%2f") : encodeURIComponent(name);
   const response = await fetch(`${registry.replace(/\/$/, "")}/${packagePath}/${publishedVersion}`);
 
   if (response.status === 404) {

--- a/scripts/release/publish-python.ts
+++ b/scripts/release/publish-python.ts
@@ -43,7 +43,10 @@ const distFiles = existsSync(distDir)
   ? readdirSync(distDir).filter((fileName) => fileName.endsWith(".whl") || fileName.endsWith(".tar.gz"))
   : [];
 
-if (!distFiles.some((fileName) => fileName.endsWith(".whl")) || !distFiles.some((fileName) => fileName.endsWith(".tar.gz"))) {
+if (
+  !distFiles.some((fileName) => fileName.endsWith(".whl")) ||
+  !distFiles.some((fileName) => fileName.endsWith(".tar.gz"))
+) {
   throw new Error(`Expected both sdist and wheel artifacts in ${distDir}.`);
 }
 

--- a/scripts/release/shared.ts
+++ b/scripts/release/shared.ts
@@ -34,9 +34,7 @@ export function getReleaseVersion(input: string | undefined): string {
 
   const version = raw.startsWith("v") ? raw.slice(1) : raw;
   if (!/^\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$/.test(version)) {
-    throw new Error(
-      `Invalid release version "${raw}". Expected a SemVer tag like v1.2.3 or v1.2.3-rc.1.`,
-    );
+    throw new Error(`Invalid release version "${raw}". Expected a SemVer tag like v1.2.3 or v1.2.3-rc.1.`);
   }
 
   return version;
@@ -71,10 +69,10 @@ export function toPep440(version: string): string {
 
   // Map common semver pre-release labels to PEP 440 equivalents
   const pep440 = pre
-    .replace(/^alpha\.?/,  "a")
-    .replace(/^beta\.?/,   "b")
-    .replace(/^rc\.?/,     "rc")
-    .replace(/\./g,        "");
+    .replace(/^alpha\.?/, "a")
+    .replace(/^beta\.?/, "b")
+    .replace(/^rc\.?/, "rc")
+    .replace(/\./g, "");
 
   return `${base}${pep440}`;
 }
@@ -96,11 +94,7 @@ export function writeJson(filePath: string, value: unknown): void {
   writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
 }
 
-export function replaceVersionInToml(
-  fileContents: string,
-  version: string,
-  sectionHeader?: string,
-): string {
+export function replaceVersionInToml(fileContents: string, version: string, sectionHeader?: string): string {
   const pattern = sectionHeader
     ? new RegExp(`(\\[${escapeRegExp(sectionHeader)}\\][\\s\\S]*?^version = ")[^"]+(")`, "m")
     : /(^version = ")[^"]+(")/m;
@@ -174,9 +168,7 @@ export function sortPackagesForPublish(packages: WorkspacePackage[]): WorkspaceP
     );
 
     if (ready.length === 0) {
-      throw new Error(
-        `Unable to resolve package publish order for: ${[...pending.keys()].join(", ")}`,
-      );
+      throw new Error(`Unable to resolve package publish order for: ${[...pending.keys()].join(", ")}`);
     }
 
     ready.sort((a, b) => a.manifest.name.localeCompare(b.manifest.name));
@@ -196,12 +188,7 @@ export function updateInternalDependencyVersions(
   version: string,
   workspaceNames: Set<string>,
 ): void {
-  for (const sectionName of [
-    "dependencies",
-    "devDependencies",
-    "peerDependencies",
-    "optionalDependencies",
-  ] as const) {
+  for (const sectionName of ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"] as const) {
     const section = manifest[sectionName];
     if (!section) {
       continue;
@@ -215,12 +202,7 @@ export function updateInternalDependencyVersions(
   }
 }
 
-export function runCommand(
-  command: string,
-  args: string[],
-  cwd: string,
-  env: NodeJS.ProcessEnv = process.env,
-): void {
+export function runCommand(command: string, args: string[], cwd: string, env: NodeJS.ProcessEnv = process.env): void {
   const result = spawnSync(command, args, {
     cwd,
     env,
@@ -228,8 +210,6 @@ export function runCommand(
   });
 
   if (result.status !== 0) {
-    throw new Error(
-      `Command failed (${result.status ?? "unknown"}): ${command} ${args.join(" ")}`,
-    );
+    throw new Error(`Command failed (${result.status ?? "unknown"}): ${command} ${args.join(" ")}`);
   }
 }

--- a/scripts/release/sync-version.ts
+++ b/scripts/release/sync-version.ts
@@ -82,9 +82,7 @@ syncToml(join(repoRoot, "apps", "desktop", "src-tauri", "Cargo.toml"), appVersio
 syncToml(join(repoRoot, "packages", "rust", "slop-ai", "Cargo.toml"), version, "package");
 syncToml(join(repoRoot, "packages", "python", "slop-ai", "pyproject.toml"), pythonVersion, "project");
 
-console.log(
-  `${dryRun ? "Would update" : "Updated"} ${writeOps.length} files for release ${version}.`,
-);
+console.log(`${dryRun ? "Would update" : "Updated"} ${writeOps.length} files for release ${version}.`);
 for (const filePath of writeOps) {
   console.log(`- ${filePath}`);
 }

--- a/website/demo/src/ai/agent.ts
+++ b/website/demo/src/ai/agent.ts
@@ -152,9 +152,10 @@ export async function runAgentTurn(
       // Server-side providers rebuild synchronously; this delay is React-specific.
       await new Promise((r) => setTimeout(r, 150));
 
-      const resultStr = result.status === "ok"
-        ? `OK${result.data ? ": " + JSON.stringify(result.data) : ""}`
-        : `Error [${result.error?.code}]: ${result.error?.message}`;
+      const resultStr =
+        result.status === "ok"
+          ? `OK${result.data ? ": " + JSON.stringify(result.data) : ""}`
+          : `Error [${result.error?.code}]: ${result.error?.message}`;
 
       conversation.push({
         role: "tool",

--- a/website/demo/src/ai/provider.ts
+++ b/website/demo/src/ai/provider.ts
@@ -53,9 +53,7 @@ async function openaiChatCompletion(
   tools: LlmTool[],
 ): Promise<ChatMessage> {
   const model = config.model ?? DEFAULT_MODELS[config.provider];
-  const baseUrl = config.provider === "openrouter"
-    ? "https://openrouter.ai/api"
-    : "https://api.openai.com";
+  const baseUrl = config.provider === "openrouter" ? "https://openrouter.ai/api" : "https://api.openai.com";
   const url = `${baseUrl}/v1/chat/completions`;
 
   const headers: Record<string, string> = {
@@ -123,11 +121,13 @@ async function anthropicChatCompletion(
     } else if (msg.role === "tool") {
       anthropicMessages.push({
         role: "user",
-        content: [{
-          type: "tool_result",
-          tool_use_id: msg.tool_call_id,
-          content: msg.content,
-        }],
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: msg.tool_call_id,
+            content: msg.content,
+          },
+        ],
       });
     }
   }
@@ -195,7 +195,7 @@ async function geminiChatCompletion(
   const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${config.apiKey}`;
 
   // Gemini requires alphanumeric tool names — build index maps
-  const nameMap = new Map<string, string>();    // tool_N → original
+  const nameMap = new Map<string, string>(); // tool_N → original
   const reverseMap = new Map<string, string>(); // original → tool_N
   tools.forEach((t, i) => {
     const geminiName = `tool_${i}`;
@@ -232,15 +232,17 @@ async function geminiChatCompletion(
       contents.push({ role: "model", parts });
     } else if (msg.role === "tool") {
       // Tool results → functionResponse
-      const geminiName = reverseMap.get(msg.tool_call_id ?? "") ?? (msg.tool_call_id ?? "unknown");
+      const geminiName = reverseMap.get(msg.tool_call_id ?? "") ?? msg.tool_call_id ?? "unknown";
       contents.push({
         role: "function",
-        parts: [{
-          functionResponse: {
-            name: geminiName,
-            response: { content: msg.content },
+        parts: [
+          {
+            functionResponse: {
+              name: geminiName,
+              response: { content: msg.content },
+            },
           },
-        }],
+        ],
       });
     }
   }

--- a/website/demo/src/components/CartItem.tsx
+++ b/website/demo/src/components/CartItem.tsx
@@ -1,13 +1,7 @@
 import type { CartItem as CartItemType, Product } from "../state";
 import { useDemo } from "../context";
 
-export function CartItemRow({
-  item,
-  product,
-}: {
-  item: CartItemType;
-  product: Product | undefined;
-}) {
+export function CartItemRow({ item, product }: { item: CartItemType; product: Product | undefined }) {
   const { mode, appState } = useDemo();
   const isInteractive = mode === "interactive";
   const subtotal = (product?.price ?? 0) * item.quantity;
@@ -16,9 +10,7 @@ export function CartItemRow({
     <div className="flex items-center gap-3 py-2">
       <div className="flex-1 min-w-0">
         <p className="text-sm text-on-surface truncate">{product?.name ?? "Unknown"}</p>
-        <p className="text-xs text-on-surface-variant font-mono">
-          ${product?.price.toFixed(2)} each
-        </p>
+        <p className="text-xs text-on-surface-variant font-mono">${product?.price.toFixed(2)} each</p>
       </div>
 
       {/* Quantity controls */}
@@ -30,9 +22,7 @@ export function CartItemRow({
         >
           -
         </button>
-        <span className="font-mono text-xs w-5 text-center text-on-surface">
-          {item.quantity}
-        </span>
+        <span className="font-mono text-xs w-5 text-center text-on-surface">{item.quantity}</span>
         <button
           onClick={() => isInteractive && appState.updateQuantity(item.productId, item.quantity + 1)}
           disabled={!isInteractive}
@@ -43,9 +33,7 @@ export function CartItemRow({
       </div>
 
       {/* Subtotal */}
-      <span className="font-mono text-sm text-primary w-16 text-right">
-        ${subtotal.toFixed(2)}
-      </span>
+      <span className="font-mono text-sm text-primary w-16 text-right">${subtotal.toFixed(2)}</span>
 
       {/* Remove */}
       <button

--- a/website/demo/src/components/ChatMessage.tsx
+++ b/website/demo/src/components/ChatMessage.tsx
@@ -5,9 +5,7 @@ export function ChatMessage({ message }: { message: ChatMessageType }) {
   if (message.role === "system") {
     return (
       <div className="text-center py-2">
-        <span className="text-[11px] text-on-surface-variant font-mono">
-          {message.content}
-        </span>
+        <span className="text-[11px] text-on-surface-variant font-mono">{message.content}</span>
       </div>
     );
   }
@@ -18,9 +16,7 @@ export function ChatMessage({ message }: { message: ChatMessageType }) {
     <div className={`flex ${isUser ? "justify-end" : "justify-start"} mb-3`}>
       <div
         className={`max-w-[85%] rounded px-3 py-2 ${
-          isUser
-            ? "bg-secondary-container/40 text-on-surface"
-            : "bg-surface-container text-on-surface"
+          isUser ? "bg-secondary-container/40 text-on-surface" : "bg-surface-container text-on-surface"
         }`}
       >
         {/* Label */}

--- a/website/demo/src/components/ClickIndicator.tsx
+++ b/website/demo/src/components/ClickIndicator.tsx
@@ -35,10 +35,7 @@ export function ClickIndicator() {
   if (!visible || !pos) return null;
 
   return (
-    <div
-      className="fixed pointer-events-none z-50"
-      style={{ left: pos.x, top: pos.y }}
-    >
+    <div className="fixed pointer-events-none z-50" style={{ left: pos.x, top: pos.y }}>
       {/* Cursor dot */}
       <div className="absolute -translate-x-1/2 -translate-y-1/2 w-4 h-4 rounded-full bg-secondary border-2 border-on-surface shadow-lg shadow-secondary/30" />
       {/* Ripple */}

--- a/website/demo/src/components/ProductCard.tsx
+++ b/website/demo/src/components/ProductCard.tsx
@@ -16,25 +16,21 @@ export function ProductCard({ product }: { product: Product }) {
     <div data-click-target={`product-${product.id}`} className="bg-surface-container rounded p-3 flex flex-col gap-2">
       {/* Category + price */}
       <div className="flex items-center justify-between">
-        <span className={`font-mono text-[10px] uppercase tracking-wider ${CATEGORY_COLORS[product.category] ?? "text-on-surface-variant"}`}>
+        <span
+          className={`font-mono text-[10px] uppercase tracking-wider ${CATEGORY_COLORS[product.category] ?? "text-on-surface-variant"}`}
+        >
           {product.category}
         </span>
-        <span className="font-mono text-sm font-medium text-primary">
-          ${product.price.toFixed(2)}
-        </span>
+        <span className="font-mono text-sm font-medium text-primary">${product.price.toFixed(2)}</span>
       </div>
 
       {/* Name */}
-      <h3 className="text-sm font-medium text-on-surface leading-tight">
-        {product.name}
-      </h3>
+      <h3 className="text-sm font-medium text-on-surface leading-tight">{product.name}</h3>
 
       {/* Rating */}
       <div className="flex items-center gap-1.5">
         <RatingStars rating={product.rating} />
-        <span className="text-[10px] text-on-surface-variant font-mono">
-          ({product.reviewCount})
-        </span>
+        <span className="text-[10px] text-on-surface-variant font-mono">({product.reviewCount})</span>
       </div>
 
       {/* Actions */}

--- a/website/demo/src/components/ReviewItem.tsx
+++ b/website/demo/src/components/ReviewItem.tsx
@@ -7,13 +7,9 @@ export function ReviewItem({ review }: { review: Review }) {
       <div className="flex items-center gap-2">
         <span className="text-xs font-medium text-on-surface">{review.author}</span>
         <RatingStars rating={review.rating} />
-        <span className="text-[10px] text-on-surface-variant font-mono ml-auto">
-          {review.date}
-        </span>
+        <span className="text-[10px] text-on-surface-variant font-mono ml-auto">{review.date}</span>
       </div>
-      <p className="text-xs text-on-surface-variant mt-1 leading-relaxed">
-        {review.text}
-      </p>
+      <p className="text-xs text-on-surface-variant mt-1 leading-relaxed">{review.text}</p>
     </div>
   );
 }

--- a/website/demo/src/components/StatusBar.tsx
+++ b/website/demo/src/components/StatusBar.tsx
@@ -5,7 +5,12 @@ const STATUS_COLORS: Record<StatusState, { dot: string; bg: string; text: string
   acting: { dot: "bg-primary", bg: "bg-primary/20", text: "text-primary", border: "border-l-primary" },
   updating: { dot: "bg-amber", bg: "bg-amber/20", text: "text-amber", border: "border-l-amber" },
   user: { dot: "bg-secondary", bg: "bg-secondary/15", text: "text-secondary", border: "border-l-secondary" },
-  idle: { dot: "bg-on-surface-variant", bg: "bg-surface-container", text: "text-on-surface-variant", border: "border-l-on-surface-variant/30" },
+  idle: {
+    dot: "bg-on-surface-variant",
+    bg: "bg-surface-container",
+    text: "text-on-surface-variant",
+    border: "border-l-on-surface-variant/30",
+  },
 };
 
 const STATUS_LABELS: Record<StatusState, string> = {
@@ -22,17 +27,23 @@ export function StatusBar() {
   const colors = STATUS_COLORS[status.state];
 
   return (
-    <div className={`flex items-center gap-3 px-4 py-2.5 border-l-3 ${colors.border} ${colors.bg} transition-all duration-300`}>
+    <div
+      className={`flex items-center gap-3 px-4 py-2.5 border-l-3 ${colors.border} ${colors.bg} transition-all duration-300`}
+    >
       {/* Status dot + label */}
       <div className="flex items-center gap-2">
-        <span className={`inline-block w-2.5 h-2.5 rounded-full ${colors.dot} ${status.state !== "idle" ? "animate-pulse" : ""}`} />
+        <span
+          className={`inline-block w-2.5 h-2.5 rounded-full ${colors.dot} ${status.state !== "idle" ? "animate-pulse" : ""}`}
+        />
         <span className={`font-mono text-xs font-semibold tracking-wider uppercase ${colors.text}`}>
           {STATUS_LABELS[status.state]}
         </span>
       </div>
 
       {/* Description */}
-      <span className={`text-xs truncate flex-1 ${status.state === "idle" ? "text-on-surface-variant" : colors.text + " opacity-70"}`}>
+      <span
+        className={`text-xs truncate flex-1 ${status.state === "idle" ? "text-on-surface-variant" : colors.text + " opacity-70"}`}
+      >
         {status.label}
       </span>
 
@@ -64,11 +75,11 @@ export function StatusBar() {
       )}
 
       {/* Mode badge */}
-      <span className={`font-mono text-[10px] uppercase tracking-wider px-2 py-0.5 rounded ${
-        mode === "interactive"
-          ? "bg-primary/20 text-primary"
-          : "bg-surface-variant text-on-surface-variant"
-      }`}>
+      <span
+        className={`font-mono text-[10px] uppercase tracking-wider px-2 py-0.5 rounded ${
+          mode === "interactive" ? "bg-primary/20 text-primary" : "bg-surface-variant text-on-surface-variant"
+        }`}
+      >
         {mode === "interactive" ? "● live" : mode === "disconnected" ? "○ disconnected" : ""}
       </span>
     </div>

--- a/website/demo/src/components/ToolCall.tsx
+++ b/website/demo/src/components/ToolCall.tsx
@@ -29,9 +29,11 @@ export function ToolCall({ toolCall }: { toolCall: ToolCallData }) {
 
       {/* Result */}
       {hasResult && (
-        <div className={`mt-1 pt-1 border-t border-outline-variant/15 ${
-          toolCall.result!.status === "ok" ? "text-primary" : "text-error"
-        }`}>
+        <div
+          className={`mt-1 pt-1 border-t border-outline-variant/15 ${
+            toolCall.result!.status === "ok" ? "text-primary" : "text-error"
+          }`}
+        >
           {toolCall.result!.status === "ok" ? "✓ success" : `✗ ${toolCall.result!.status}`}
         </div>
       )}

--- a/website/demo/src/components/TreeNode.tsx
+++ b/website/demo/src/components/TreeNode.tsx
@@ -47,9 +47,7 @@ export function TreeNode({
     <div>
       {/* Main row */}
       <div
-        className={`flex items-center gap-1.5 py-px rounded-sm cursor-default group ${
-          isChanged ? "flash-change" : ""
-        }`}
+        className={`flex items-center gap-1.5 py-px rounded-sm cursor-default group ${isChanged ? "flash-change" : ""}`}
         style={{ paddingLeft: `${depth * 16 + 4}px` }}
         onClick={() => expandable && setCollapsed(!collapsed)}
       >
@@ -65,17 +63,15 @@ export function TreeNode({
         {/* Type dot + label */}
         {!isItem ? (
           <>
-            <span className={`text-[9px] font-mono uppercase tracking-wider flex-shrink-0 opacity-70 ${TYPE_COLORS[node.type] ?? "text-on-surface-variant"}`}>
+            <span
+              className={`text-[9px] font-mono uppercase tracking-wider flex-shrink-0 opacity-70 ${TYPE_COLORS[node.type] ?? "text-on-surface-variant"}`}
+            >
               {node.type}
             </span>
-            <span className="text-xs text-on-surface font-medium truncate">
-              {label}
-            </span>
+            <span className="text-xs text-on-surface font-medium truncate">{label}</span>
           </>
         ) : (
-          <span className="text-xs text-on-surface-variant truncate">
-            {label}
-          </span>
+          <span className="text-xs text-on-surface-variant truncate">{label}</span>
         )}
 
         {/* Key props inline — max 3, short */}
@@ -104,24 +100,21 @@ export function TreeNode({
               style={{ paddingLeft: `${depth * 16 + 26}px` }}
             >
               {visibleProps.slice(3).map(([k, v]) => (
-                <span key={k} className="mr-3">{k}={formatValue(v)}</span>
+                <span key={k} className="mr-3">
+                  {k}={formatValue(v)}
+                </span>
               ))}
             </div>
           )}
 
           {/* Affordances as subtle inline tags */}
           {hasAffordances && (
-            <div
-              className="flex flex-wrap gap-1 py-px"
-              style={{ paddingLeft: `${depth * 16 + 26}px` }}
-            >
+            <div className="flex flex-wrap gap-1 py-px" style={{ paddingLeft: `${depth * 16 + 26}px` }}>
               {node.affordances!.map((a) => (
                 <span
                   key={a.action}
                   className={`font-mono text-[8px] px-1 rounded ${
-                    a.dangerous
-                      ? "bg-error/10 text-error/70"
-                      : "bg-primary/8 text-primary/50"
+                    a.dangerous ? "bg-error/10 text-error/70" : "bg-primary/8 text-primary/50"
                   }`}
                 >
                   {a.action}

--- a/website/demo/src/context.tsx
+++ b/website/demo/src/context.tsx
@@ -48,11 +48,7 @@ interface DemoContextValue {
   messages: ChatMessage[];
   addMessage: (msg: ChatMessage) => void;
   updateMessage: (id: string, update: Partial<ChatMessage>) => void;
-  executeAction: (
-    path: string,
-    action: string,
-    params?: Record<string, unknown>,
-  ) => Promise<any>;
+  executeAction: (path: string, action: string, params?: Record<string, unknown>) => Promise<any>;
   bumpTreeVersion: () => void;
   clickTarget: string | null;
   simulateClick: (target: string) => Promise<void>;
@@ -154,9 +150,7 @@ export function DemoProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const updateMessage = useCallback((id: string, update: Partial<ChatMessage>) => {
-    setMessages((prev) =>
-      prev.map((m) => (m.id === id ? { ...m, ...update } : m)),
-    );
+    setMessages((prev) => prev.map((m) => (m.id === id ? { ...m, ...update } : m)));
   }, []);
 
   const [clickTarget, setClickTarget] = useState<string | null>(null);
@@ -171,24 +165,21 @@ export function DemoProvider({ children }: { children: ReactNode }) {
     slop.flush(); // triggers rebuild → broadcast → tree panel receives patch
   }, []);
 
-  const executeAction = useCallback(
-    async (path: string, action: string, params?: Record<string, unknown>) => {
-      slop.flush();
-      const result = await slop.executeInvoke({
-        id: `demo-inv-${++invokeCounter.current}`,
-        path,
-        action,
-        params,
-      });
-      // React state setters are async — wait for re-render, then flush so the
-      // provider rebuilds the tree and broadcasts patches. Server-side providers
-      // rebuild synchronously; this delay is React-specific (see slop.ts).
-      await new Promise((r) => setTimeout(r, 10));
-      slop.flush();
-      return result;
-    },
-    [],
-  );
+  const executeAction = useCallback(async (path: string, action: string, params?: Record<string, unknown>) => {
+    slop.flush();
+    const result = await slop.executeInvoke({
+      id: `demo-inv-${++invokeCounter.current}`,
+      path,
+      action,
+      params,
+    });
+    // React state setters are async — wait for re-render, then flush so the
+    // provider rebuilds the tree and broadcasts patches. Server-side providers
+    // rebuild synchronously; this delay is React-specific (see slop.ts).
+    await new Promise((r) => setTimeout(r, 10));
+    slop.flush();
+    return result;
+  }, []);
 
   return (
     <DemoContext.Provider

--- a/website/demo/src/panels/AppPanel.tsx
+++ b/website/demo/src/panels/AppPanel.tsx
@@ -35,20 +35,13 @@ export function AppPanel() {
   return (
     <div className="flex flex-col h-full bg-surface-low overflow-hidden relative">
       {/* Click interceptor in replay mode */}
-      {mode !== "interactive" && (
-        <div
-          className="absolute inset-0 z-10 cursor-pointer"
-          onClick={handleReplayClick}
-        />
-      )}
+      {mode !== "interactive" && <div className="absolute inset-0 z-10 cursor-pointer" onClick={handleReplayClick} />}
 
       {/* Prompt toast */}
       {showPrompt && (
         <div className="absolute inset-x-0 top-12 z-20 flex justify-center pointer-events-none">
           <div className="glass rounded px-4 py-3 shadow-lg shadow-black/30 pointer-events-auto max-w-[280px] text-center">
-            <p className="text-xs text-on-surface font-medium">
-              Connect an API key to interact live
-            </p>
+            <p className="text-xs text-on-surface font-medium">Connect an API key to interact live</p>
             <p className="text-[10px] text-on-surface-variant mt-1">
               Click <span className="text-primary font-medium">Connect API</span> in the chat panel
             </p>
@@ -75,16 +68,12 @@ export function AppPanel() {
           onClick={() => isInteractive && appState.navigate("cart")}
           disabled={!isInteractive}
           className={`text-xs font-medium transition-colors disabled:cursor-default flex items-center gap-1 ${
-            currentView === "cart"
-              ? "text-on-surface"
-              : "text-on-surface-variant hover:text-on-surface"
+            currentView === "cart" ? "text-on-surface" : "text-on-surface-variant hover:text-on-surface"
           }`}
         >
           Cart
           {cart.length > 0 && (
-            <span className="font-mono text-[10px] bg-primary/20 text-primary px-1 rounded">
-              {cart.length}
-            </span>
+            <span className="font-mono text-[10px] bg-primary/20 text-primary px-1 rounded">{cart.length}</span>
           )}
         </button>
         <span className="text-[10px] font-mono text-on-surface-variant ml-auto uppercase tracking-wider">
@@ -104,19 +93,10 @@ export function AppPanel() {
           />
         )}
         {currentView === "product" && selectedProduct && (
-          <ProductDetailView
-            product={selectedProduct}
-            reviews={productReviews}
-            isInteractive={isInteractive}
-          />
+          <ProductDetailView product={selectedProduct} reviews={productReviews} isInteractive={isInteractive} />
         )}
         {currentView === "cart" && (
-          <CartView
-            cart={cart}
-            products={products}
-            total={cartTotal}
-            isInteractive={isInteractive}
-          />
+          <CartView cart={cart} products={products} total={cartTotal} isInteractive={isInteractive} />
         )}
       </div>
     </div>
@@ -192,9 +172,7 @@ function CatalogView({
       </div>
 
       {products.length === 0 && (
-        <p className="text-sm text-on-surface-variant text-center py-8">
-          No products match your search.
-        </p>
+        <p className="text-sm text-on-surface-variant text-center py-8">No products match your search.</p>
       )}
     </div>
   );
@@ -231,14 +209,10 @@ function ProductDetailView({
         <h2 className="text-lg font-semibold text-on-surface mt-1">{product.name}</h2>
         <div className="flex items-center gap-2 mt-1">
           <RatingStars rating={product.rating} size="md" />
-          <span className="font-mono text-xs text-on-surface-variant">
-            ({product.reviewCount} reviews)
-          </span>
+          <span className="font-mono text-xs text-on-surface-variant">({product.reviewCount} reviews)</span>
         </div>
         <p className="font-mono text-xl text-primary mt-2">${product.price.toFixed(2)}</p>
-        <p className="text-sm text-on-surface-variant mt-2 leading-relaxed">
-          {product.description}
-        </p>
+        <p className="text-sm text-on-surface-variant mt-2 leading-relaxed">{product.description}</p>
         <div className="flex items-center gap-3 mt-3">
           <span className="text-xs text-on-surface-variant font-mono">
             {product.stock > 0 ? `${product.stock} in stock` : "Out of stock"}
@@ -256,9 +230,7 @@ function ProductDetailView({
 
       {/* Reviews */}
       <div className="bg-surface-container rounded p-3">
-        <h3 className="text-sm font-medium text-on-surface mb-2">
-          Reviews ({reviews.length})
-        </h3>
+        <h3 className="text-sm font-medium text-on-surface mb-2">Reviews ({reviews.length})</h3>
         {reviews.length === 0 ? (
           <p className="text-xs text-on-surface-variant">No reviews yet.</p>
         ) : (
@@ -293,9 +265,7 @@ function CartView({
       </h2>
 
       {cart.length === 0 ? (
-        <p className="text-sm text-on-surface-variant text-center py-8">
-          Your cart is empty.
-        </p>
+        <p className="text-sm text-on-surface-variant text-center py-8">Your cart is empty.</p>
       ) : (
         <>
           <div className="bg-surface-container rounded p-3 divide-y divide-outline-variant/10">
@@ -311,9 +281,7 @@ function CartView({
           {/* Total */}
           <div className="flex items-center justify-between px-3 py-2 bg-surface-container rounded">
             <span className="text-sm text-on-surface-variant">Total</span>
-            <span className="font-mono text-lg text-primary font-medium">
-              ${total.toFixed(2)}
-            </span>
+            <span className="font-mono text-lg text-primary font-medium">${total.toFixed(2)}</span>
           </div>
 
           <button

--- a/website/demo/src/panels/ChatPanel.tsx
+++ b/website/demo/src/panels/ChatPanel.tsx
@@ -35,7 +35,20 @@ const PROVIDER_MODELS: Record<string, { label: string; value: string | null }[]>
 
 export function ChatPanel() {
   const ctx = useDemo();
-  const { messages, mode, setMode, apiKey, setApiKey, apiProvider, setApiProvider, apiModel, setApiModel, addMessage, replayComplete, skipReplay } = ctx;
+  const {
+    messages,
+    mode,
+    setMode,
+    apiKey,
+    setApiKey,
+    apiProvider,
+    setApiProvider,
+    apiModel,
+    setApiModel,
+    addMessage,
+    replayComplete,
+    skipReplay,
+  } = ctx;
   const scrollRef = useRef<HTMLDivElement>(null);
   const [input, setInput] = useState("");
   const [configOpen, setConfigOpen] = useState(false);
@@ -99,9 +112,7 @@ export function ChatPanel() {
       {/* Header */}
       <div className="bg-surface-container">
         <div className="flex items-center justify-between px-3 h-10">
-          <span className="font-mono text-[10px] uppercase tracking-wider text-on-surface-variant">
-            AI Agent
-          </span>
+          <span className="font-mono text-[10px] uppercase tracking-wider text-on-surface-variant">AI Agent</span>
           <div className="flex items-center gap-2">
             {mode === "interactive" && (
               <button
@@ -143,7 +154,10 @@ export function ChatPanel() {
           <div className="px-3 pb-3 flex flex-col gap-2">
             <select
               value={apiProvider}
-              onChange={(e) => { setApiProvider(e.target.value); setApiModel(""); }}
+              onChange={(e) => {
+                setApiProvider(e.target.value);
+                setApiModel("");
+              }}
               className="bg-surface-highest text-xs text-on-surface font-mono px-2 py-1 rounded outline-none"
             >
               <option value="openrouter">OpenRouter</option>
@@ -185,9 +199,7 @@ export function ChatPanel() {
         {messages.length === 0 && (
           <div className="text-center py-8">
             <p className="text-xs text-on-surface-variant">
-              {mode === "replay"
-                ? "Replay will start shortly..."
-                : "Type a message to interact with the store."}
+              {mode === "replay" ? "Replay will start shortly..." : "Type a message to interact with the store."}
             </p>
           </div>
         )}

--- a/website/demo/src/panels/TreePanel.tsx
+++ b/website/demo/src/panels/TreePanel.tsx
@@ -93,12 +93,8 @@ export function TreePanel() {
     <div className="flex flex-col h-full bg-surface-lowest overflow-hidden">
       {/* Header */}
       <div className="px-3 flex items-center h-10 bg-surface-container">
-        <span className="font-mono text-[10px] uppercase tracking-wider text-on-surface-variant">
-          State Tree
-        </span>
-        <span className="font-mono text-[10px] text-on-surface-variant ml-2">
-          v{version}
-        </span>
+        <span className="font-mono text-[10px] uppercase tracking-wider text-on-surface-variant">State Tree</span>
+        <span className="font-mono text-[10px] text-on-surface-variant ml-2">v{version}</span>
       </div>
 
       {/* Tree */}

--- a/website/demo/src/replay/script.ts
+++ b/website/demo/src/replay/script.ts
@@ -38,8 +38,7 @@ export const replayScript: ReplayStep[] = [
   {
     type: "ai_message",
     delay: 1200,
-    content:
-      "Let me search the catalog for headphones and find the best option for you.",
+    content: "Let me search the catalog for headphones and find the best option for you.",
   },
 
   // 4. Search
@@ -56,8 +55,7 @@ export const replayScript: ReplayStep[] = [
   {
     type: "ai_message",
     delay: 1500,
-    content:
-      'I found the "Wireless Headphones Pro" at $79.99 with a 4.7 star rating. Let me pull up the full details.',
+    content: 'I found the "Wireless Headphones Pro" at $79.99 with a 4.7 star rating. Let me pull up the full details.',
   },
 
   // 6. View details
@@ -103,8 +101,7 @@ export const replayScript: ReplayStep[] = [
   {
     type: "ai_message",
     delay: 1200,
-    content:
-      "Done — it's in your cart. Total is $79.99. I can also leave a review if you'd like.",
+    content: "Done — it's in your cart. Total is $79.99. I can also leave a review if you'd like.",
   },
 
   // 11. User asks for review

--- a/website/demo/src/slop.ts
+++ b/website/demo/src/slop.ts
@@ -56,10 +56,7 @@ class InMemoryTransport implements Transport {
 
 export const transport = new InMemoryTransport();
 
-export const slop = new SlopClientImpl(
-  { id: "shop", name: "SLOP Shop" },
-  [transport],
-);
+export const slop = new SlopClientImpl({ id: "shop", name: "SLOP Shop" }, [transport]);
 slop.start();
 
 // Send connect so the provider is ready to accept subscriptions

--- a/website/demo/src/state.ts
+++ b/website/demo/src/state.ts
@@ -44,29 +44,188 @@ export interface AppState {
 // --- Seed data ---
 
 const SEED_PRODUCTS: Product[] = [
-  { id: "wireless-headphones-pro", name: "Wireless Headphones Pro", category: "electronics", price: 79.99, rating: 4.7, reviewCount: 23, stock: 15, description: "Premium wireless headphones with active noise cancellation, 30-hour battery life, and crystal-clear sound. Bluetooth 5.3 with multipoint connection." },
-  { id: "smart-speaker-mini", name: "Smart Speaker Mini", category: "electronics", price: 49.99, rating: 4.3, reviewCount: 89, stock: 42, description: "Compact smart speaker with rich sound, voice assistant built-in, and seamless multi-room audio support." },
-  { id: "usb-c-hub", name: "USB-C Hub 7-in-1", category: "electronics", price: 34.99, rating: 4.5, reviewCount: 156, stock: 78, description: "7-in-1 USB-C hub with HDMI 4K, USB 3.0, SD card reader, and 100W power delivery pass-through." },
-  { id: "mechanical-keyboard", name: "Mechanical Keyboard TKL", category: "electronics", price: 129.99, rating: 4.8, reviewCount: 67, stock: 8, description: "Tenkeyless mechanical keyboard with hot-swappable switches, RGB backlighting, and aluminum frame." },
-  { id: "design-patterns-book", name: "Design Patterns in TypeScript", category: "books", price: 39.99, rating: 4.6, reviewCount: 34, stock: 120, description: "Comprehensive guide to design patterns with modern TypeScript examples. Covers creational, structural, and behavioral patterns." },
-  { id: "clean-architecture-book", name: "Clean Architecture", category: "books", price: 29.99, rating: 4.4, reviewCount: 201, stock: 85, description: "Robert C. Martin's guide to software architecture principles. A must-read for serious developers." },
-  { id: "ceramic-mug-set", name: "Ceramic Mug Set (4-pack)", category: "home", price: 24.99, rating: 4.2, reviewCount: 45, stock: 200, description: "Set of 4 handcrafted ceramic mugs in earthy tones. Microwave and dishwasher safe. 12oz capacity." },
-  { id: "desk-lamp-led", name: "LED Desk Lamp", category: "home", price: 44.99, rating: 4.6, reviewCount: 112, stock: 33, description: "Adjustable LED desk lamp with 5 brightness levels, 3 color temperatures, and USB charging port." },
+  {
+    id: "wireless-headphones-pro",
+    name: "Wireless Headphones Pro",
+    category: "electronics",
+    price: 79.99,
+    rating: 4.7,
+    reviewCount: 23,
+    stock: 15,
+    description:
+      "Premium wireless headphones with active noise cancellation, 30-hour battery life, and crystal-clear sound. Bluetooth 5.3 with multipoint connection.",
+  },
+  {
+    id: "smart-speaker-mini",
+    name: "Smart Speaker Mini",
+    category: "electronics",
+    price: 49.99,
+    rating: 4.3,
+    reviewCount: 89,
+    stock: 42,
+    description:
+      "Compact smart speaker with rich sound, voice assistant built-in, and seamless multi-room audio support.",
+  },
+  {
+    id: "usb-c-hub",
+    name: "USB-C Hub 7-in-1",
+    category: "electronics",
+    price: 34.99,
+    rating: 4.5,
+    reviewCount: 156,
+    stock: 78,
+    description: "7-in-1 USB-C hub with HDMI 4K, USB 3.0, SD card reader, and 100W power delivery pass-through.",
+  },
+  {
+    id: "mechanical-keyboard",
+    name: "Mechanical Keyboard TKL",
+    category: "electronics",
+    price: 129.99,
+    rating: 4.8,
+    reviewCount: 67,
+    stock: 8,
+    description: "Tenkeyless mechanical keyboard with hot-swappable switches, RGB backlighting, and aluminum frame.",
+  },
+  {
+    id: "design-patterns-book",
+    name: "Design Patterns in TypeScript",
+    category: "books",
+    price: 39.99,
+    rating: 4.6,
+    reviewCount: 34,
+    stock: 120,
+    description:
+      "Comprehensive guide to design patterns with modern TypeScript examples. Covers creational, structural, and behavioral patterns.",
+  },
+  {
+    id: "clean-architecture-book",
+    name: "Clean Architecture",
+    category: "books",
+    price: 29.99,
+    rating: 4.4,
+    reviewCount: 201,
+    stock: 85,
+    description: "Robert C. Martin's guide to software architecture principles. A must-read for serious developers.",
+  },
+  {
+    id: "ceramic-mug-set",
+    name: "Ceramic Mug Set (4-pack)",
+    category: "home",
+    price: 24.99,
+    rating: 4.2,
+    reviewCount: 45,
+    stock: 200,
+    description: "Set of 4 handcrafted ceramic mugs in earthy tones. Microwave and dishwasher safe. 12oz capacity.",
+  },
+  {
+    id: "desk-lamp-led",
+    name: "LED Desk Lamp",
+    category: "home",
+    price: 44.99,
+    rating: 4.6,
+    reviewCount: 112,
+    stock: 33,
+    description: "Adjustable LED desk lamp with 5 brightness levels, 3 color temperatures, and USB charging port.",
+  },
 ];
 
 const SEED_REVIEWS: Review[] = [
-  { id: "r1", productId: "wireless-headphones-pro", author: "Alex M.", rating: 5, text: "Best headphones I've owned. The noise cancellation is incredible for the price.", date: "2026-03-15" },
-  { id: "r2", productId: "wireless-headphones-pro", author: "Sam K.", rating: 4, text: "Great sound quality. Battery lasts forever. Wish the ear cups were slightly larger.", date: "2026-03-10" },
-  { id: "r3", productId: "wireless-headphones-pro", author: "Jordan P.", rating: 5, text: "Unbeatable value under $100. Use them daily for work calls and music.", date: "2026-02-28" },
-  { id: "r4", productId: "smart-speaker-mini", author: "Chris L.", rating: 4, text: "Surprisingly powerful sound for its size. Voice assistant works well.", date: "2026-03-20" },
-  { id: "r5", productId: "smart-speaker-mini", author: "Taylor R.", rating: 5, text: "Perfect for the kitchen. Love the multi-room feature.", date: "2026-03-01" },
-  { id: "r6", productId: "mechanical-keyboard", author: "Dev_Mike", rating: 5, text: "The typing feel is sublime. Hot-swap switches are a game changer.", date: "2026-03-18" },
-  { id: "r7", productId: "mechanical-keyboard", author: "KeyboardFan", rating: 5, text: "Best TKL I've used. Build quality is top tier.", date: "2026-02-20" },
-  { id: "r8", productId: "design-patterns-book", author: "TSEnthusiast", rating: 5, text: "Finally a patterns book that uses TypeScript properly. Every example compiles.", date: "2026-03-22" },
-  { id: "r9", productId: "clean-architecture-book", author: "ArchNerd", rating: 4, text: "Uncle Bob delivers again. Some chapters feel repetitive but the core ideas are solid.", date: "2026-01-15" },
-  { id: "r10", productId: "desk-lamp-led", author: "NightOwl", rating: 5, text: "Perfect for late-night coding sessions. The warm light setting is easy on the eyes.", date: "2026-03-25" },
-  { id: "r11", productId: "usb-c-hub", author: "LaptopUser", rating: 4, text: "Works great with my MacBook. All ports detected instantly.", date: "2026-03-12" },
-  { id: "r12", productId: "ceramic-mug-set", author: "CoffeeLover", rating: 4, text: "Beautiful mugs. Good size for morning coffee. One arrived with a tiny chip.", date: "2026-02-14" },
+  {
+    id: "r1",
+    productId: "wireless-headphones-pro",
+    author: "Alex M.",
+    rating: 5,
+    text: "Best headphones I've owned. The noise cancellation is incredible for the price.",
+    date: "2026-03-15",
+  },
+  {
+    id: "r2",
+    productId: "wireless-headphones-pro",
+    author: "Sam K.",
+    rating: 4,
+    text: "Great sound quality. Battery lasts forever. Wish the ear cups were slightly larger.",
+    date: "2026-03-10",
+  },
+  {
+    id: "r3",
+    productId: "wireless-headphones-pro",
+    author: "Jordan P.",
+    rating: 5,
+    text: "Unbeatable value under $100. Use them daily for work calls and music.",
+    date: "2026-02-28",
+  },
+  {
+    id: "r4",
+    productId: "smart-speaker-mini",
+    author: "Chris L.",
+    rating: 4,
+    text: "Surprisingly powerful sound for its size. Voice assistant works well.",
+    date: "2026-03-20",
+  },
+  {
+    id: "r5",
+    productId: "smart-speaker-mini",
+    author: "Taylor R.",
+    rating: 5,
+    text: "Perfect for the kitchen. Love the multi-room feature.",
+    date: "2026-03-01",
+  },
+  {
+    id: "r6",
+    productId: "mechanical-keyboard",
+    author: "Dev_Mike",
+    rating: 5,
+    text: "The typing feel is sublime. Hot-swap switches are a game changer.",
+    date: "2026-03-18",
+  },
+  {
+    id: "r7",
+    productId: "mechanical-keyboard",
+    author: "KeyboardFan",
+    rating: 5,
+    text: "Best TKL I've used. Build quality is top tier.",
+    date: "2026-02-20",
+  },
+  {
+    id: "r8",
+    productId: "design-patterns-book",
+    author: "TSEnthusiast",
+    rating: 5,
+    text: "Finally a patterns book that uses TypeScript properly. Every example compiles.",
+    date: "2026-03-22",
+  },
+  {
+    id: "r9",
+    productId: "clean-architecture-book",
+    author: "ArchNerd",
+    rating: 4,
+    text: "Uncle Bob delivers again. Some chapters feel repetitive but the core ideas are solid.",
+    date: "2026-01-15",
+  },
+  {
+    id: "r10",
+    productId: "desk-lamp-led",
+    author: "NightOwl",
+    rating: 5,
+    text: "Perfect for late-night coding sessions. The warm light setting is easy on the eyes.",
+    date: "2026-03-25",
+  },
+  {
+    id: "r11",
+    productId: "usb-c-hub",
+    author: "LaptopUser",
+    rating: 4,
+    text: "Works great with my MacBook. All ports detected instantly.",
+    date: "2026-03-12",
+  },
+  {
+    id: "r12",
+    productId: "ceramic-mug-set",
+    author: "CoffeeLover",
+    rating: 4,
+    text: "Beautiful mugs. Good size for morning coffee. One arrived with a tiny chip.",
+    date: "2026-02-14",
+  },
 ];
 
 let nextReviewId = 100;
@@ -85,18 +244,19 @@ export function useAppState() {
   // --- Derived ---
 
   const filteredProducts = products.filter((p) => {
-    if (searchQuery && !p.name.toLowerCase().includes(searchQuery.toLowerCase()) && !p.description.toLowerCase().includes(searchQuery.toLowerCase())) return false;
+    if (
+      searchQuery &&
+      !p.name.toLowerCase().includes(searchQuery.toLowerCase()) &&
+      !p.description.toLowerCase().includes(searchQuery.toLowerCase())
+    )
+      return false;
     if (categoryFilter && p.category !== categoryFilter) return false;
     return true;
   });
 
-  const selectedProduct = selectedProductId
-    ? products.find((p) => p.id === selectedProductId) ?? null
-    : null;
+  const selectedProduct = selectedProductId ? (products.find((p) => p.id === selectedProductId) ?? null) : null;
 
-  const productReviews = selectedProductId
-    ? reviews.filter((r) => r.productId === selectedProductId)
-    : [];
+  const productReviews = selectedProductId ? reviews.filter((r) => r.productId === selectedProductId) : [];
 
   const cartTotal = cart.reduce((sum, item) => {
     const product = products.find((p) => p.id === item.productId);
@@ -131,11 +291,7 @@ export function useAppState() {
     setCart((prev) => {
       const existing = prev.find((i) => i.productId === productId);
       if (existing) {
-        return prev.map((i) =>
-          i.productId === productId
-            ? { ...i, quantity: i.quantity + quantity }
-            : i,
-        );
+        return prev.map((i) => (i.productId === productId ? { ...i, quantity: i.quantity + quantity } : i));
       }
       return [...prev, { productId, quantity }];
     });
@@ -149,28 +305,21 @@ export function useAppState() {
     if (quantity <= 0) {
       setCart((prev) => prev.filter((i) => i.productId !== productId));
     } else {
-      setCart((prev) =>
-        prev.map((i) =>
-          i.productId === productId ? { ...i, quantity } : i,
-        ),
-      );
+      setCart((prev) => prev.map((i) => (i.productId === productId ? { ...i, quantity } : i)));
     }
   }, []);
 
-  const addReview = useCallback(
-    (productId: string, author: string, rating: number, text: string) => {
-      const review: Review = {
-        id: `r-${nextReviewId++}`,
-        productId,
-        author,
-        rating,
-        text,
-        date: new Date().toISOString().split("T")[0],
-      };
-      setReviews((prev) => [...prev, review]);
-    },
-    [],
-  );
+  const addReview = useCallback((productId: string, author: string, rating: number, text: string) => {
+    const review: Review = {
+      id: `r-${nextReviewId++}`,
+      productId,
+      author,
+      rating,
+      text,
+      date: new Date().toISOString().split("T")[0],
+    };
+    setReviews((prev) => [...prev, review]);
+  }, []);
 
   const navigate = useCallback((view: ViewType) => {
     setCurrentView(view);
@@ -202,10 +351,7 @@ export function useAppState() {
     },
     actions: {
       search: action({ query: "string" }, ({ query }) => search(query)),
-      filter_category: action(
-        { category: "string" },
-        ({ category }) => filterByCategory(category),
-      ),
+      filter_category: action({ category: "string" }, ({ category }) => filterByCategory(category)),
       clear_filters: action(() => clearFilters()),
     },
     items: filteredProducts.map((p) => ({
@@ -220,21 +366,17 @@ export function useAppState() {
       },
       actions: {
         view_details: action(() => selectProduct(p.id)),
-        add_to_cart: action(
-          { quantity: { type: "number", description: "Quantity to add" } },
-          ({ quantity }) => addToCart(p.id, quantity ?? 1),
+        add_to_cart: action({ quantity: { type: "number", description: "Quantity to add" } }, ({ quantity }) =>
+          addToCart(p.id, quantity ?? 1),
         ),
       },
     })),
   }));
 
   // Product detail node (only when a product is selected)
-  useSlop(
-    slop,
-    "product",
-    () =>
-      selectedProduct
-        ? {
+  useSlop(slop, "product", () =>
+    selectedProduct
+      ? {
           type: "view",
           props: {
             name: selectedProduct.name,
@@ -245,9 +387,8 @@ export function useAppState() {
             category: selectedProduct.category,
           },
           actions: {
-            add_to_cart: action(
-              { quantity: { type: "number", description: "Quantity to add" } },
-              ({ quantity }) => addToCart(selectedProduct.id, quantity ?? 1),
+            add_to_cart: action({ quantity: { type: "number", description: "Quantity to add" } }, ({ quantity }) =>
+              addToCart(selectedProduct.id, quantity ?? 1),
             ),
             back_to_catalog: action(() => navigate("catalog")),
           },
@@ -257,10 +398,7 @@ export function useAppState() {
               props: {
                 count: productReviews.length,
                 averageRating: productReviews.length
-                  ? +(
-                      productReviews.reduce((s, r) => s + r.rating, 0) /
-                      productReviews.length
-                    ).toFixed(1)
+                  ? +(productReviews.reduce((s, r) => s + r.rating, 0) / productReviews.length).toFixed(1)
                   : 0,
               },
               actions: {
@@ -270,8 +408,7 @@ export function useAppState() {
                     rating: { type: "number", description: "Rating 1-5" },
                     text: "string",
                   },
-                  ({ author, rating, text }) =>
-                    addReview(selectedProduct.id, author, rating, text),
+                  ({ author, rating, text }) => addReview(selectedProduct.id, author, rating, text),
                 ),
               },
               items: productReviews.map((r) => ({
@@ -286,7 +423,7 @@ export function useAppState() {
             },
           },
         }
-        : { type: "view", props: { empty: true } },
+      : { type: "view", props: { empty: true } },
   );
 
   // Cart node
@@ -310,9 +447,8 @@ export function useAppState() {
           subtotal: +((product?.price ?? 0) * item.quantity).toFixed(2),
         },
         actions: {
-          update_quantity: action(
-            { quantity: { type: "number", description: "New quantity" } },
-            ({ quantity }) => updateQuantity(item.productId, quantity),
+          update_quantity: action({ quantity: { type: "number", description: "New quantity" } }, ({ quantity }) =>
+            updateQuantity(item.productId, quantity),
           ),
           remove: action(() => removeFromCart(item.productId)),
         },

--- a/website/docs/astro.config.mjs
+++ b/website/docs/astro.config.mjs
@@ -1,23 +1,21 @@
 // @ts-check
-import { defineConfig } from 'astro/config';
-import starlight from '@astrojs/starlight';
-import { docsRedirects, docsSidebar } from './content-manifest.mjs';
+import { defineConfig } from "astro/config";
+import starlight from "@astrojs/starlight";
+import { docsRedirects, docsSidebar } from "./content-manifest.mjs";
 
 export default defineConfig({
-	site: 'https://docs.slopai.dev',
-	redirects: docsRedirects,
-	integrations: [
-		starlight({
-			title: 'SLOP',
-			logo: {
-				src: './src/assets/logo.svg',
-			},
-			favicon: '/favicon.svg',
-			social: [
-				{ icon: 'github', label: 'GitHub', href: 'https://github.com/devteapot/slop' },
-			],
-			customCss: ['./src/styles/custom.css'],
-			sidebar: docsSidebar,
-		}),
-	],
+  site: "https://docs.slopai.dev",
+  redirects: docsRedirects,
+  integrations: [
+    starlight({
+      title: "SLOP",
+      logo: {
+        src: "./src/assets/logo.svg",
+      },
+      favicon: "/favicon.svg",
+      social: [{ icon: "github", label: "GitHub", href: "https://github.com/devteapot/slop" }],
+      customCss: ["./src/styles/custom.css"],
+      sidebar: docsSidebar,
+    }),
+  ],
 });

--- a/website/docs/content-manifest.mjs
+++ b/website/docs/content-manifest.mjs
@@ -1,309 +1,309 @@
 const page = (source, output, options = {}) => ({
-	source,
-	output,
-	slug: output.replace(/\/index\.md$/, '').replace(/\.md$/, ''),
-	redirects: [],
-	...options,
+  source,
+  output,
+  slug: output.replace(/\/index\.md$/, "").replace(/\.md$/, ""),
+  redirects: [],
+  ...options,
 });
 
 export const docsPages = [
-	page('docs/getting-started/index.md', 'getting-started/index.md', {
-		label: 'Quick Start',
-		description: 'Add SLOP to your app in 5 minutes',
-	}),
-	page('docs/getting-started/installation.md', 'getting-started/installation.md', {
-		label: 'Installation',
-		description: 'Install the right SLOP package for your app, agent, or tool',
-	}),
+  page("docs/getting-started/index.md", "getting-started/index.md", {
+    label: "Quick Start",
+    description: "Add SLOP to your app in 5 minutes",
+  }),
+  page("docs/getting-started/installation.md", "getting-started/installation.md", {
+    label: "Installation",
+    description: "Install the right SLOP package for your app, agent, or tool",
+  }),
 
-	page('docs/guides/react.md', 'guides/react.md', {
-		label: 'React',
-		description: 'How to use SLOP with React to expose component state to AI agents.',
-	}),
-	page('docs/guides/vue.md', 'guides/vue.md', {
-		label: 'Vue',
-		description: 'How to use SLOP with Vue to expose component state to AI agents.',
-	}),
-	page('docs/guides/solid.md', 'guides/solid.md', {
-		label: 'SolidJS',
-		description: 'How to use SLOP with SolidJS to expose component state to AI agents.',
-	}),
-	page('docs/guides/angular.md', 'guides/angular.md', {
-		label: 'Angular',
-		description: 'How to use SLOP with Angular to expose component state to AI agents.',
-	}),
-	page('docs/guides/svelte.md', 'guides/svelte.md', {
-		label: 'Svelte',
-		description: 'How to use SLOP with Svelte 5 to expose component state to AI agents',
-	}),
-	page('docs/guides/vanilla.md', 'guides/vanilla.md', {
-		label: 'Vanilla JS',
-		description: 'How to use SLOP with plain JavaScript or TypeScript without a framework.',
-	}),
-	page('docs/guides/server-apps.md', 'guides/server-apps.md', {
-		label: 'Server & Native Apps',
-		description: 'Add SLOP to server-backed apps, desktop helpers, daemons, and CLI tools',
-	}),
-	page('docs/guides/tanstack-start.md', 'guides/tanstack-start.md', {
-		label: 'TanStack Start',
-		description: 'Use SLOP in TanStack Start with server state plus mounted UI state',
-	}),
-	page('docs/guides/python.md', 'guides/python.md', {
-		label: 'Python',
-		description: 'Add SLOP to Python apps with FastAPI, local transports, and consumer tooling',
-	}),
-	page('docs/guides/go.md', 'guides/go.md', {
-		label: 'Go',
-		description: 'Add SLOP to Go services, daemons, CLI tools, and consumer workflows',
-	}),
-	page('docs/guides/rust.md', 'guides/rust.md', {
-		label: 'Rust',
-		description: 'Add SLOP to Rust apps — axum, CLI tools, daemons, WASM-ready',
-	}),
-	page('docs/guides/consumer.md', 'guides/consumer.md', {
-		label: 'Consumer / Testing',
-		description: 'Tools and SDKs for connecting to, inspecting, and testing SLOP providers',
-	}),
+  page("docs/guides/react.md", "guides/react.md", {
+    label: "React",
+    description: "How to use SLOP with React to expose component state to AI agents.",
+  }),
+  page("docs/guides/vue.md", "guides/vue.md", {
+    label: "Vue",
+    description: "How to use SLOP with Vue to expose component state to AI agents.",
+  }),
+  page("docs/guides/solid.md", "guides/solid.md", {
+    label: "SolidJS",
+    description: "How to use SLOP with SolidJS to expose component state to AI agents.",
+  }),
+  page("docs/guides/angular.md", "guides/angular.md", {
+    label: "Angular",
+    description: "How to use SLOP with Angular to expose component state to AI agents.",
+  }),
+  page("docs/guides/svelte.md", "guides/svelte.md", {
+    label: "Svelte",
+    description: "How to use SLOP with Svelte 5 to expose component state to AI agents",
+  }),
+  page("docs/guides/vanilla.md", "guides/vanilla.md", {
+    label: "Vanilla JS",
+    description: "How to use SLOP with plain JavaScript or TypeScript without a framework.",
+  }),
+  page("docs/guides/server-apps.md", "guides/server-apps.md", {
+    label: "Server & Native Apps",
+    description: "Add SLOP to server-backed apps, desktop helpers, daemons, and CLI tools",
+  }),
+  page("docs/guides/tanstack-start.md", "guides/tanstack-start.md", {
+    label: "TanStack Start",
+    description: "Use SLOP in TanStack Start with server state plus mounted UI state",
+  }),
+  page("docs/guides/python.md", "guides/python.md", {
+    label: "Python",
+    description: "Add SLOP to Python apps with FastAPI, local transports, and consumer tooling",
+  }),
+  page("docs/guides/go.md", "guides/go.md", {
+    label: "Go",
+    description: "Add SLOP to Go services, daemons, CLI tools, and consumer workflows",
+  }),
+  page("docs/guides/rust.md", "guides/rust.md", {
+    label: "Rust",
+    description: "Add SLOP to Rust apps — axum, CLI tools, daemons, WASM-ready",
+  }),
+  page("docs/guides/consumer.md", "guides/consumer.md", {
+    label: "Consumer / Testing",
+    description: "Tools and SDKs for connecting to, inspecting, and testing SLOP providers",
+  }),
 
-	page('docs/guides/advanced/agent-scaffolding.md', 'guides/advanced/agent-scaffolding.md', {
-		label: 'Agent-Assisted Integration',
-		redirects: ['/guides-advanced/agent-scaffolding'],
-	}),
-	page('docs/guides/advanced/claude-code.md', 'guides/advanced/claude-code.md', {
-		label: 'Claude Code Integration',
-		description: 'Connect Claude Code to SLOP-enabled applications with dynamic or generic action tools',
-		redirects: ['/guides-advanced/claude-code'],
-	}),
-	page('docs/guides/advanced/codex.md', 'guides/advanced/codex.md', {
-		label: 'Codex Integration',
-		description: 'Connect Codex to SLOP-enabled applications with injected live state and a fixed MCP tool surface',
-		redirects: ['/guides-advanced/codex'],
-	}),
-	page('docs/guides/advanced/openclaw.md', 'guides/advanced/openclaw.md', {
-		label: 'OpenClaw Integration',
-		description: 'Control SLOP-enabled applications through OpenClaw',
-		redirects: ['/guides-advanced/openclaw'],
-	}),
-	page('docs/guides/advanced/benchmarks.md', 'guides/advanced/benchmarks.md', {
-		label: 'Benchmarks: MCP vs SLOP',
-		redirects: ['/guides-advanced/benchmarks'],
-	}),
+  page("docs/guides/advanced/agent-scaffolding.md", "guides/advanced/agent-scaffolding.md", {
+    label: "Agent-Assisted Integration",
+    redirects: ["/guides-advanced/agent-scaffolding"],
+  }),
+  page("docs/guides/advanced/claude-code.md", "guides/advanced/claude-code.md", {
+    label: "Claude Code Integration",
+    description: "Connect Claude Code to SLOP-enabled applications with dynamic or generic action tools",
+    redirects: ["/guides-advanced/claude-code"],
+  }),
+  page("docs/guides/advanced/codex.md", "guides/advanced/codex.md", {
+    label: "Codex Integration",
+    description: "Connect Codex to SLOP-enabled applications with injected live state and a fixed MCP tool surface",
+    redirects: ["/guides-advanced/codex"],
+  }),
+  page("docs/guides/advanced/openclaw.md", "guides/advanced/openclaw.md", {
+    label: "OpenClaw Integration",
+    description: "Control SLOP-enabled applications through OpenClaw",
+    redirects: ["/guides-advanced/openclaw"],
+  }),
+  page("docs/guides/advanced/benchmarks.md", "guides/advanced/benchmarks.md", {
+    label: "Benchmarks: MCP vs SLOP",
+    redirects: ["/guides-advanced/benchmarks"],
+  }),
 
-	page('docs/api/index.md', 'api/index.md', {
-		label: 'Package Overview',
-		description: 'Published SLOP SDKs, adapters, and integration packages',
-	}),
-	page('docs/api/core.md', 'api/core.md', {
-		label: '@slop-ai/core',
-		description: 'Shared SLOP descriptor types, helpers, and tree utilities',
-	}),
-	page('docs/api/client.md', 'api/client.md', {
-		label: '@slop-ai/client',
-		description: 'Browser-side SLOP provider for SPAs and in-page integrations',
-	}),
-	page('docs/api/react.md', 'api/react.md', {
-		label: '@slop-ai/react',
-		description: 'React hook for registering SLOP state from components',
-	}),
-	page('docs/api/vue.md', 'api/vue.md', {
-		label: '@slop-ai/vue',
-		description: 'Vue composable for registering SLOP state from reactive components',
-	}),
-	page('docs/api/solid.md', 'api/solid.md', {
-		label: '@slop-ai/solid',
-		description: 'SolidJS primitive for registering SLOP state from signals',
-	}),
-	page('docs/api/angular.md', 'api/angular.md', {
-		label: '@slop-ai/angular',
-		description: 'Angular integration for exposing signal-based component state through SLOP',
-	}),
-	page('docs/api/svelte.md', 'api/svelte.md', {
-		label: '@slop-ai/svelte',
-		description: 'Svelte 5 composable for publishing rune-based state through SLOP',
-	}),
-	page('docs/api/server.md', 'api/server.md', {
-		label: '@slop-ai/server',
-		description: 'Server-side SLOP provider for Node.js, Bun, local tools, and native apps',
-	}),
-	page('docs/api/consumer.md', 'api/consumer.md', {
-		label: '@slop-ai/consumer',
-		description: 'Consumer SDK for connecting to providers, mirroring state, and invoking actions',
-	}),
-	page('docs/api/tanstack-start.md', 'api/tanstack-start.md', {
-		label: '@slop-ai/tanstack-start',
-		description: 'Full-stack SLOP adapter for TanStack Start applications',
-	}),
-	page('docs/api/openclaw-plugin.md', 'api/openclaw-plugin.md', {
-		label: '@slop-ai/openclaw-plugin',
-		description: 'OpenClaw plugin for discovering and controlling SLOP-enabled applications',
-	}),
-	page('docs/api/python.md', 'api/python.md', {
-		label: 'slop-ai (Python)',
-		description: 'Python package reference for SLOP providers, consumers, and transports',
-	}),
-	page('docs/api/go.md', 'api/go.md', {
-		label: 'slop-ai (Go)',
-		description: 'Go package reference for SLOP providers, consumers, and local transports',
-	}),
-	page('docs/api/rust.md', 'api/rust.md', {
-		label: 'slop-ai (Rust)',
-		description: 'Rust crate reference for SLOP providers, consumers, and transport features',
-	}),
+  page("docs/api/index.md", "api/index.md", {
+    label: "Package Overview",
+    description: "Published SLOP SDKs, adapters, and integration packages",
+  }),
+  page("docs/api/core.md", "api/core.md", {
+    label: "@slop-ai/core",
+    description: "Shared SLOP descriptor types, helpers, and tree utilities",
+  }),
+  page("docs/api/client.md", "api/client.md", {
+    label: "@slop-ai/client",
+    description: "Browser-side SLOP provider for SPAs and in-page integrations",
+  }),
+  page("docs/api/react.md", "api/react.md", {
+    label: "@slop-ai/react",
+    description: "React hook for registering SLOP state from components",
+  }),
+  page("docs/api/vue.md", "api/vue.md", {
+    label: "@slop-ai/vue",
+    description: "Vue composable for registering SLOP state from reactive components",
+  }),
+  page("docs/api/solid.md", "api/solid.md", {
+    label: "@slop-ai/solid",
+    description: "SolidJS primitive for registering SLOP state from signals",
+  }),
+  page("docs/api/angular.md", "api/angular.md", {
+    label: "@slop-ai/angular",
+    description: "Angular integration for exposing signal-based component state through SLOP",
+  }),
+  page("docs/api/svelte.md", "api/svelte.md", {
+    label: "@slop-ai/svelte",
+    description: "Svelte 5 composable for publishing rune-based state through SLOP",
+  }),
+  page("docs/api/server.md", "api/server.md", {
+    label: "@slop-ai/server",
+    description: "Server-side SLOP provider for Node.js, Bun, local tools, and native apps",
+  }),
+  page("docs/api/consumer.md", "api/consumer.md", {
+    label: "@slop-ai/consumer",
+    description: "Consumer SDK for connecting to providers, mirroring state, and invoking actions",
+  }),
+  page("docs/api/tanstack-start.md", "api/tanstack-start.md", {
+    label: "@slop-ai/tanstack-start",
+    description: "Full-stack SLOP adapter for TanStack Start applications",
+  }),
+  page("docs/api/openclaw-plugin.md", "api/openclaw-plugin.md", {
+    label: "@slop-ai/openclaw-plugin",
+    description: "OpenClaw plugin for discovering and controlling SLOP-enabled applications",
+  }),
+  page("docs/api/python.md", "api/python.md", {
+    label: "slop-ai (Python)",
+    description: "Python package reference for SLOP providers, consumers, and transports",
+  }),
+  page("docs/api/go.md", "api/go.md", {
+    label: "slop-ai (Go)",
+    description: "Go package reference for SLOP providers, consumers, and local transports",
+  }),
+  page("docs/api/rust.md", "api/rust.md", {
+    label: "slop-ai (Rust)",
+    description: "Rust crate reference for SLOP providers, consumers, and transport features",
+  }),
 
-	page('spec/core/overview.md', 'spec/core/overview.md'),
-	page('spec/core/state-tree.md', 'spec/core/state-tree.md'),
-	page('spec/core/transport.md', 'spec/core/transport.md'),
-	page('spec/core/messages.md', 'spec/core/messages.md'),
-	page('spec/core/affordances.md', 'spec/core/affordances.md'),
-	page('spec/core/attention.md', 'spec/core/attention.md'),
-	page('spec/extensions/scaling.md', 'spec/extensions/scaling.md'),
-	page('spec/extensions/content-references.md', 'spec/extensions/content-references.md'),
-	page('spec/extensions/async-actions.md', 'spec/extensions/async-actions.md'),
-	page('spec/integrations/adapters.md', 'spec/integrations/adapters.md'),
-	page('spec/integrations/web.md', 'spec/integrations/web.md'),
-	page('spec/integrations/desktop.md', 'spec/integrations/desktop.md'),
-	page('spec/limitations.md', 'spec/limitations.md', {
-		label: 'Known Limitations & Future Work',
-	}),
+  page("spec/core/overview.md", "spec/core/overview.md"),
+  page("spec/core/state-tree.md", "spec/core/state-tree.md"),
+  page("spec/core/transport.md", "spec/core/transport.md"),
+  page("spec/core/messages.md", "spec/core/messages.md"),
+  page("spec/core/affordances.md", "spec/core/affordances.md"),
+  page("spec/core/attention.md", "spec/core/attention.md"),
+  page("spec/extensions/scaling.md", "spec/extensions/scaling.md"),
+  page("spec/extensions/content-references.md", "spec/extensions/content-references.md"),
+  page("spec/extensions/async-actions.md", "spec/extensions/async-actions.md"),
+  page("spec/integrations/adapters.md", "spec/integrations/adapters.md"),
+  page("spec/integrations/web.md", "spec/integrations/web.md"),
+  page("spec/integrations/desktop.md", "spec/integrations/desktop.md"),
+  page("spec/limitations.md", "spec/limitations.md", {
+    label: "Known Limitations & Future Work",
+  }),
 
-	page('docs/sdk/index.md', 'sdk/index.md', {
-		label: 'Overview',
-	}),
-	page('docs/sdk/discovery.md', 'sdk/discovery.md', {
-		label: 'Discovery & Bridge',
-		description: 'Provider scanning, extension bridge, relay transport, auto-connect, state formatting',
-	}),
-	page('docs/sdk/development.md', 'sdk/development.md', {
-		label: 'Development & Debugging',
-	}),
-	page('docs/sdk/sessions.md', 'sdk/sessions.md', {
-		label: 'Sessions & Multi-User',
-	}),
+  page("docs/sdk/index.md", "sdk/index.md", {
+    label: "Overview",
+  }),
+  page("docs/sdk/discovery.md", "sdk/discovery.md", {
+    label: "Discovery & Bridge",
+    description: "Provider scanning, extension bridge, relay transport, auto-connect, state formatting",
+  }),
+  page("docs/sdk/development.md", "sdk/development.md", {
+    label: "Development & Debugging",
+  }),
+  page("docs/sdk/sessions.md", "sdk/sessions.md", {
+    label: "Sessions & Multi-User",
+  }),
 
-	page('docs/desktop/install.md', 'desktop/install.md', {
-		label: 'Desktop App',
-		description: 'Build and use the SLOP desktop app',
-	}),
-	page('docs/extension/install.md', 'extension/install.md', {
-		label: 'Chrome Extension',
-		description: 'Build and use the SLOP browser extension',
-	}),
-	page('docs/extension/privacy.md', 'extension/privacy.md', {
-		label: 'Chrome Extension Privacy Policy',
-		description: 'Privacy policy for the SLOP Chrome extension',
-	}),
+  page("docs/desktop/install.md", "desktop/install.md", {
+    label: "Desktop App",
+    description: "Build and use the SLOP desktop app",
+  }),
+  page("docs/extension/install.md", "extension/install.md", {
+    label: "Chrome Extension",
+    description: "Build and use the SLOP browser extension",
+  }),
+  page("docs/extension/privacy.md", "extension/privacy.md", {
+    label: "Chrome Extension Privacy Policy",
+    description: "Privacy policy for the SLOP Chrome extension",
+  }),
 ];
 
 const docsPageBySlug = new Map(docsPages.map((page) => [page.slug, page]));
 
 const pageItem = (slug, label) => ({
-	label: label ?? docsPageBySlug.get(slug)?.label ?? slug,
-	slug,
+  label: label ?? docsPageBySlug.get(slug)?.label ?? slug,
+  slug,
 });
 
 export const docsSidebar = [
-	{
-		label: 'Getting Started',
-		items: [
-			pageItem('getting-started', 'Quick Start'),
-			{ label: 'Playground', link: 'https://playground.slopai.dev', attrs: { target: '_blank' } },
-			{ label: 'Interactive Demo', link: 'https://demo.slopai.dev', attrs: { target: '_blank' } },
-			pageItem('getting-started/installation', 'Installation'),
-		],
-	},
-	{
-		label: 'Framework Guides',
-		items: [
-			pageItem('guides/react'),
-			pageItem('guides/vue'),
-			pageItem('guides/solid', 'SolidJS'),
-			pageItem('guides/angular'),
-			pageItem('guides/svelte'),
-			pageItem('guides/vanilla', 'Vanilla JS'),
-			pageItem('guides/server-apps', 'Server & Native Apps'),
-			pageItem('guides/tanstack-start', 'TanStack Start'),
-			pageItem('guides/python'),
-			pageItem('guides/go', 'Go'),
-			pageItem('guides/rust', 'Rust'),
-			pageItem('guides/consumer', 'Consumer / Testing'),
-		],
-	},
-	{
-		label: 'API Reference',
-		items: [
-			pageItem('api', 'Package Overview'),
-			pageItem('api/core'),
-			pageItem('api/client'),
-			pageItem('api/react'),
-			pageItem('api/vue'),
-			pageItem('api/solid'),
-			pageItem('api/angular'),
-			pageItem('api/svelte'),
-			pageItem('api/server'),
-			pageItem('api/consumer'),
-			pageItem('api/tanstack-start'),
-			pageItem('api/openclaw-plugin'),
-			pageItem('api/python', 'slop-ai (Python)'),
-			pageItem('api/go', 'slop-ai (Go)'),
-			pageItem('api/rust', 'slop-ai (Rust)'),
-		],
-	},
-	{
-		label: 'Core Protocol',
-		autogenerate: { directory: 'spec/core' },
-	},
-	{
-		label: 'Extensions',
-		autogenerate: { directory: 'spec/extensions' },
-	},
-	{
-		label: 'Integration Guides',
-		autogenerate: { directory: 'spec/integrations' },
-	},
-	{
-		label: 'SDK Architecture',
-		items: [
-			pageItem('sdk', 'Overview'),
-			pageItem('sdk/discovery', 'Discovery & Bridge'),
-			pageItem('sdk/development'),
-			pageItem('sdk/sessions'),
-		],
-	},
-	{
-		label: 'Advanced Guides',
-		items: [
-			pageItem('guides/advanced/agent-scaffolding', 'Agent-Assisted Integration'),
-			pageItem('guides/advanced/claude-code', 'Claude Code Integration'),
-			pageItem('guides/advanced/codex', 'Codex Integration'),
-			pageItem('guides/advanced/openclaw', 'OpenClaw Integration'),
-			pageItem('guides/advanced/benchmarks', 'Benchmarks: MCP vs SLOP'),
-		],
-	},
-	{
-		label: 'Status',
-		items: [pageItem('spec/limitations', 'Known Limitations & Future Work')],
-	},
-	{
-		label: 'Consumers',
-		items: [
-			pageItem('guides/consumer', 'Consumer Guide'),
-			pageItem('desktop/install', 'Desktop App'),
-			pageItem('extension/install', 'Chrome Extension'),
-			pageItem('extension/privacy', 'Extension Privacy Policy'),
-		],
-	},
+  {
+    label: "Getting Started",
+    items: [
+      pageItem("getting-started", "Quick Start"),
+      { label: "Playground", link: "https://playground.slopai.dev", attrs: { target: "_blank" } },
+      { label: "Interactive Demo", link: "https://demo.slopai.dev", attrs: { target: "_blank" } },
+      pageItem("getting-started/installation", "Installation"),
+    ],
+  },
+  {
+    label: "Framework Guides",
+    items: [
+      pageItem("guides/react"),
+      pageItem("guides/vue"),
+      pageItem("guides/solid", "SolidJS"),
+      pageItem("guides/angular"),
+      pageItem("guides/svelte"),
+      pageItem("guides/vanilla", "Vanilla JS"),
+      pageItem("guides/server-apps", "Server & Native Apps"),
+      pageItem("guides/tanstack-start", "TanStack Start"),
+      pageItem("guides/python"),
+      pageItem("guides/go", "Go"),
+      pageItem("guides/rust", "Rust"),
+      pageItem("guides/consumer", "Consumer / Testing"),
+    ],
+  },
+  {
+    label: "API Reference",
+    items: [
+      pageItem("api", "Package Overview"),
+      pageItem("api/core"),
+      pageItem("api/client"),
+      pageItem("api/react"),
+      pageItem("api/vue"),
+      pageItem("api/solid"),
+      pageItem("api/angular"),
+      pageItem("api/svelte"),
+      pageItem("api/server"),
+      pageItem("api/consumer"),
+      pageItem("api/tanstack-start"),
+      pageItem("api/openclaw-plugin"),
+      pageItem("api/python", "slop-ai (Python)"),
+      pageItem("api/go", "slop-ai (Go)"),
+      pageItem("api/rust", "slop-ai (Rust)"),
+    ],
+  },
+  {
+    label: "Core Protocol",
+    autogenerate: { directory: "spec/core" },
+  },
+  {
+    label: "Extensions",
+    autogenerate: { directory: "spec/extensions" },
+  },
+  {
+    label: "Integration Guides",
+    autogenerate: { directory: "spec/integrations" },
+  },
+  {
+    label: "SDK Architecture",
+    items: [
+      pageItem("sdk", "Overview"),
+      pageItem("sdk/discovery", "Discovery & Bridge"),
+      pageItem("sdk/development"),
+      pageItem("sdk/sessions"),
+    ],
+  },
+  {
+    label: "Advanced Guides",
+    items: [
+      pageItem("guides/advanced/agent-scaffolding", "Agent-Assisted Integration"),
+      pageItem("guides/advanced/claude-code", "Claude Code Integration"),
+      pageItem("guides/advanced/codex", "Codex Integration"),
+      pageItem("guides/advanced/openclaw", "OpenClaw Integration"),
+      pageItem("guides/advanced/benchmarks", "Benchmarks: MCP vs SLOP"),
+    ],
+  },
+  {
+    label: "Status",
+    items: [pageItem("spec/limitations", "Known Limitations & Future Work")],
+  },
+  {
+    label: "Consumers",
+    items: [
+      pageItem("guides/consumer", "Consumer Guide"),
+      pageItem("desktop/install", "Desktop App"),
+      pageItem("extension/install", "Chrome Extension"),
+      pageItem("extension/privacy", "Extension Privacy Policy"),
+    ],
+  },
 ];
 
-const withTrailingSlash = (slug) => `/${slug.replace(/^\/+|\/+$/g, '')}/`;
+const withTrailingSlash = (slug) => `/${slug.replace(/^\/+|\/+$/g, "")}/`;
 
 export const docsRedirects = docsPages.reduce(
-	(redirects, page) => {
-		for (const from of page.redirects) {
-			redirects[from.replace(/\/+$/, '') || '/'] = withTrailingSlash(page.slug);
-		}
-		return redirects;
-	},
-	{
-		'/': '/getting-started/',
-	}
+  (redirects, page) => {
+    for (const from of page.redirects) {
+      redirects[from.replace(/\/+$/, "") || "/"] = withTrailingSlash(page.slug);
+    }
+    return redirects;
+  },
+  {
+    "/": "/getting-started/",
+  },
 );

--- a/website/docs/scripts/generate-content.mjs
+++ b/website/docs/scripts/generate-content.mjs
@@ -1,192 +1,192 @@
-import fs from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-import { docsPages } from '../content-manifest.mjs';
+import { docsPages } from "../content-manifest.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const docsRoot = path.resolve(__dirname, '..');
-const repoRoot = path.resolve(docsRoot, '..', '..');
-const outputRoot = path.join(docsRoot, 'src', 'content', 'docs');
+const docsRoot = path.resolve(__dirname, "..");
+const repoRoot = path.resolve(docsRoot, "..", "..");
+const outputRoot = path.join(docsRoot, "src", "content", "docs");
 
-const checkMode = process.argv.includes('--check');
+const checkMode = process.argv.includes("--check");
 
-const normalizePath = (value) => value.split(path.sep).join('/');
+const normalizePath = (value) => value.split(path.sep).join("/");
 
 const quote = (value) => JSON.stringify(value);
 
 const stripLeadingH1 = (markdown) => {
-	const lines = markdown.replace(/^\uFEFF/, '').split('\n');
-	let index = 0;
-	while (index < lines.length && lines[index].trim() === '') index += 1;
-	if (index >= lines.length || !lines[index].startsWith('# ')) {
-		throw new Error('Canonical docs must start with a top-level heading');
-	}
-	const title = lines[index].slice(2).trim();
-	index += 1;
-	if (index < lines.length && lines[index].trim() === '') index += 1;
-	return {
-		title,
-		body: lines.slice(index).join('\n').replace(/\s+$/, '') + '\n',
-	};
+  const lines = markdown.replace(/^\uFEFF/, "").split("\n");
+  let index = 0;
+  while (index < lines.length && lines[index].trim() === "") index += 1;
+  if (index >= lines.length || !lines[index].startsWith("# ")) {
+    throw new Error("Canonical docs must start with a top-level heading");
+  }
+  const title = lines[index].slice(2).trim();
+  index += 1;
+  if (index < lines.length && lines[index].trim() === "") index += 1;
+  return {
+    title,
+    body: lines.slice(index).join("\n").replace(/\s+$/, "") + "\n",
+  };
 };
 
 const buildFrontmatter = (page, title) => {
-	const lines = ['---', `title: ${quote(page.title ?? title)}`];
-	if (page.description) lines.push(`description: ${quote(page.description)}`);
-	if (page.template) lines.push(`template: ${quote(page.template)}`);
-	lines.push('---', '');
-	return `${lines.join('\n')}`;
+  const lines = ["---", `title: ${quote(page.title ?? title)}`];
+  if (page.description) lines.push(`description: ${quote(page.description)}`);
+  if (page.template) lines.push(`template: ${quote(page.template)}`);
+  lines.push("---", "");
+  return `${lines.join("\n")}`;
 };
 
 const sourcePages = new Map();
 const slugRoutes = new Map();
 
 for (const page of docsPages) {
-	const sourcePath = path.resolve(repoRoot, page.source);
-	if (sourcePages.has(sourcePath)) {
-		throw new Error(`Duplicate canonical source in docs manifest: ${page.source}`);
-	}
-	sourcePages.set(sourcePath, page);
-	slugRoutes.set(`/${page.slug}`, `/${page.slug}`);
-	slugRoutes.set(`/${page.slug}/`, `/${page.slug}`);
-	for (const redirect of page.redirects ?? []) {
-		const normalized = redirect.replace(/\/+$/, '') || '/';
-		slugRoutes.set(normalized, `/${page.slug}`);
-		slugRoutes.set(`${normalized}/`, `/${page.slug}`);
-	}
+  const sourcePath = path.resolve(repoRoot, page.source);
+  if (sourcePages.has(sourcePath)) {
+    throw new Error(`Duplicate canonical source in docs manifest: ${page.source}`);
+  }
+  sourcePages.set(sourcePath, page);
+  slugRoutes.set(`/${page.slug}`, `/${page.slug}`);
+  slugRoutes.set(`/${page.slug}/`, `/${page.slug}`);
+  for (const redirect of page.redirects ?? []) {
+    const normalized = redirect.replace(/\/+$/, "") || "/";
+    slugRoutes.set(normalized, `/${page.slug}`);
+    slugRoutes.set(`${normalized}/`, `/${page.slug}`);
+  }
 }
 
 const splitHref = (href) => {
-	const hashIndex = href.indexOf('#');
-	const queryIndex = href.indexOf('?');
-	let cutIndex = href.length;
-	if (hashIndex !== -1) cutIndex = Math.min(cutIndex, hashIndex);
-	if (queryIndex !== -1) cutIndex = Math.min(cutIndex, queryIndex);
-	return {
-		base: href.slice(0, cutIndex),
-		suffix: href.slice(cutIndex),
-	};
+  const hashIndex = href.indexOf("#");
+  const queryIndex = href.indexOf("?");
+  let cutIndex = href.length;
+  if (hashIndex !== -1) cutIndex = Math.min(cutIndex, hashIndex);
+  if (queryIndex !== -1) cutIndex = Math.min(cutIndex, queryIndex);
+  return {
+    base: href.slice(0, cutIndex),
+    suffix: href.slice(cutIndex),
+  };
 };
 
 const resolveCanonicalRoute = (rawHref, sourcePath) => {
-	if (!rawHref || rawHref.startsWith('#')) return rawHref;
-	if (/^(mailto:|tel:|javascript:)/i.test(rawHref)) return rawHref;
+  if (!rawHref || rawHref.startsWith("#")) return rawHref;
+  if (/^(mailto:|tel:|javascript:)/i.test(rawHref)) return rawHref;
 
-	const { base, suffix } = splitHref(rawHref);
+  const { base, suffix } = splitHref(rawHref);
 
-	if (/^https?:\/\//i.test(base)) {
-		try {
-			const url = new URL(base);
-			if (url.hostname === 'docs.slopai.dev') {
-				const normalized = slugRoutes.get(url.pathname.replace(/\/+$/, '') || '/');
-				if (normalized) return `${normalized}${suffix}`;
-			}
-		} catch {
-			return rawHref;
-		}
-		return rawHref;
-	}
+  if (/^https?:\/\//i.test(base)) {
+    try {
+      const url = new URL(base);
+      if (url.hostname === "docs.slopai.dev") {
+        const normalized = slugRoutes.get(url.pathname.replace(/\/+$/, "") || "/");
+        if (normalized) return `${normalized}${suffix}`;
+      }
+    } catch {
+      return rawHref;
+    }
+    return rawHref;
+  }
 
-	if (base.startsWith('/')) {
-		const normalized = slugRoutes.get(base.replace(/\/+$/, '') || '/');
-		if (normalized) return `${normalized}${suffix}`;
+  if (base.startsWith("/")) {
+    const normalized = slugRoutes.get(base.replace(/\/+$/, "") || "/");
+    if (normalized) return `${normalized}${suffix}`;
 
-		if (base.endsWith('.md')) {
-			const targetSource = path.resolve(repoRoot, base.slice(1));
-			const page = sourcePages.get(targetSource);
-			if (page) return `/${page.slug}${suffix}`;
-		}
+    if (base.endsWith(".md")) {
+      const targetSource = path.resolve(repoRoot, base.slice(1));
+      const page = sourcePages.get(targetSource);
+      if (page) return `/${page.slug}${suffix}`;
+    }
 
-		return rawHref;
-	}
+    return rawHref;
+  }
 
-	const candidate = path.resolve(path.dirname(sourcePath), base);
-	const direct = sourcePages.get(candidate);
-	if (direct) return `/${direct.slug}${suffix}`;
+  const candidate = path.resolve(path.dirname(sourcePath), base);
+  const direct = sourcePages.get(candidate);
+  if (direct) return `/${direct.slug}${suffix}`;
 
-	if (!path.extname(candidate)) {
-		const withMd = sourcePages.get(`${candidate}.md`);
-		if (withMd) return `/${withMd.slug}${suffix}`;
-		const withIndex = sourcePages.get(path.join(candidate, 'index.md'));
-		if (withIndex) return `/${withIndex.slug}${suffix}`;
-	}
+  if (!path.extname(candidate)) {
+    const withMd = sourcePages.get(`${candidate}.md`);
+    if (withMd) return `/${withMd.slug}${suffix}`;
+    const withIndex = sourcePages.get(path.join(candidate, "index.md"));
+    if (withIndex) return `/${withIndex.slug}${suffix}`;
+  }
 
-	return rawHref;
+  return rawHref;
 };
 
 const normalizeMarkdown = (markdown, sourcePath) =>
-	markdown.replace(/(!?\[[^\]]*]\()([^)]+)(\))/g, (match, prefix, href, suffix) => {
-		const normalized = resolveCanonicalRoute(href, sourcePath);
-		return `${prefix}${normalized}${suffix}`;
-	});
+  markdown.replace(/(!?\[[^\]]*]\()([^)]+)(\))/g, (match, prefix, href, suffix) => {
+    const normalized = resolveCanonicalRoute(href, sourcePath);
+    return `${prefix}${normalized}${suffix}`;
+  });
 
 const generatedPages = new Map();
 
 for (const page of docsPages) {
-	const sourcePath = path.resolve(repoRoot, page.source);
-	const outputPath = normalizePath(page.output);
-	const source = fs.readFileSync(sourcePath, 'utf8');
-	const { title, body } = stripLeadingH1(source);
-	const normalizedBody = normalizeMarkdown(body, sourcePath);
-	const content = `${buildFrontmatter(page, title)}${normalizedBody}`;
-	generatedPages.set(outputPath, content);
+  const sourcePath = path.resolve(repoRoot, page.source);
+  const outputPath = normalizePath(page.output);
+  const source = fs.readFileSync(sourcePath, "utf8");
+  const { title, body } = stripLeadingH1(source);
+  const normalizedBody = normalizeMarkdown(body, sourcePath);
+  const content = `${buildFrontmatter(page, title)}${normalizedBody}`;
+  generatedPages.set(outputPath, content);
 }
 
 const listGeneratedFiles = (rootDir) => {
-	if (!fs.existsSync(rootDir)) return [];
+  if (!fs.existsSync(rootDir)) return [];
 
-	const files = [];
+  const files = [];
 
-	const walk = (currentDir) => {
-		for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
-			const fullPath = path.join(currentDir, entry.name);
-			if (entry.isDirectory()) {
-				walk(fullPath);
-				continue;
-			}
-			if (entry.isFile() && /\.mdx?$/.test(entry.name)) {
-				files.push(normalizePath(path.relative(rootDir, fullPath)));
-			}
-		}
-	};
+  const walk = (currentDir) => {
+    for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
+      const fullPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+        continue;
+      }
+      if (entry.isFile() && /\.mdx?$/.test(entry.name)) {
+        files.push(normalizePath(path.relative(rootDir, fullPath)));
+      }
+    }
+  };
 
-	walk(rootDir);
-	return files.sort();
+  walk(rootDir);
+  return files.sort();
 };
 
 if (checkMode) {
-	const actualFiles = new Set(listGeneratedFiles(outputRoot));
-	const expectedFiles = new Set(generatedPages.keys());
-	const problems = [];
+  const actualFiles = new Set(listGeneratedFiles(outputRoot));
+  const expectedFiles = new Set(generatedPages.keys());
+  const problems = [];
 
-	for (const file of [...expectedFiles].sort()) {
-		if (!actualFiles.has(file)) {
-			problems.push(`missing generated file: ${file}`);
-			continue;
-		}
-		const actual = fs.readFileSync(path.join(outputRoot, file), 'utf8');
-		const expected = generatedPages.get(file);
-		if (actual !== expected) problems.push(`stale generated file: ${file}`);
-	}
+  for (const file of [...expectedFiles].sort()) {
+    if (!actualFiles.has(file)) {
+      problems.push(`missing generated file: ${file}`);
+      continue;
+    }
+    const actual = fs.readFileSync(path.join(outputRoot, file), "utf8");
+    const expected = generatedPages.get(file);
+    if (actual !== expected) problems.push(`stale generated file: ${file}`);
+  }
 
-	for (const file of [...actualFiles].sort()) {
-		if (!expectedFiles.has(file)) problems.push(`unexpected generated file: ${file}`);
-	}
+  for (const file of [...actualFiles].sort()) {
+    if (!expectedFiles.has(file)) problems.push(`unexpected generated file: ${file}`);
+  }
 
-	if (problems.length > 0) {
-		for (const problem of problems) console.error(problem);
-		process.exit(1);
-	}
+  if (problems.length > 0) {
+    for (const problem of problems) console.error(problem);
+    process.exit(1);
+  }
 
-	process.exit(0);
+  process.exit(0);
 }
 
 fs.rmSync(outputRoot, { recursive: true, force: true });
 fs.mkdirSync(outputRoot, { recursive: true });
 
 for (const [outputPath, content] of [...generatedPages.entries()].sort(([a], [b]) => a.localeCompare(b))) {
-	const fullPath = path.join(outputRoot, outputPath);
-	fs.mkdirSync(path.dirname(fullPath), { recursive: true });
-	fs.writeFileSync(fullPath, content);
+  const fullPath = path.join(outputRoot, outputPath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, content);
 }

--- a/website/docs/src/content.config.ts
+++ b/website/docs/src/content.config.ts
@@ -1,7 +1,7 @@
-import { defineCollection } from 'astro:content';
-import { docsLoader } from '@astrojs/starlight/loaders';
-import { docsSchema } from '@astrojs/starlight/schema';
+import { defineCollection } from "astro:content";
+import { docsLoader } from "@astrojs/starlight/loaders";
+import { docsSchema } from "@astrojs/starlight/schema";
 
 export const collections = {
-	docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
 };

--- a/website/landing/src/scripts/sloppy.ts
+++ b/website/landing/src/scripts/sloppy.ts
@@ -59,12 +59,7 @@ function calcPupilTransform(
 function checkCrossEyed(svg: SVGSVGElement): boolean {
   const leftInner = toScreenCoords(svg, 67, 40);
   const rightInner = toScreenCoords(svg, 86, 80);
-  return (
-    mouseX >= leftInner.x &&
-    mouseX <= rightInner.x &&
-    mouseY >= leftInner.y &&
-    mouseY <= rightInner.y
-  );
+  return mouseX >= leftInner.x && mouseX <= rightInner.x && mouseY >= leftInner.y && mouseY <= rightInner.y;
 }
 
 // ---- Track pupils for a given sloppy container ----
@@ -78,7 +73,10 @@ function updatePupilsFor(container: HTMLElement, svg: SVGSVGElement) {
 
   if (isCrossEyed) {
     leftPupil.setAttribute("transform", calcPupilTransform(svg, LEFT_EYE, LEFT_PUPIL_DEFAULT, CROSS_PUPIL_OFFSET, 0));
-    rightPupil.setAttribute("transform", calcPupilTransform(svg, RIGHT_EYE, RIGHT_PUPIL_DEFAULT, -CROSS_PUPIL_OFFSET, 0));
+    rightPupil.setAttribute(
+      "transform",
+      calcPupilTransform(svg, RIGHT_EYE, RIGHT_PUPIL_DEFAULT, -CROSS_PUPIL_OFFSET, 0),
+    );
     container.classList.add("cross-eyed");
     if (!container.dataset.angryHover) {
       container.classList.remove("angry");

--- a/website/playground/src/App.tsx
+++ b/website/playground/src/App.tsx
@@ -137,9 +137,7 @@ export default function App() {
       <div className="px-3 flex items-center justify-between h-10 bg-surface-container">
         <div className="flex items-center gap-2">
           <img src="/sloppy.svg" alt="SLOP" className="h-5 w-5" />
-          <span className="font-mono text-[11px] uppercase tracking-wider text-primary">
-            SLOP Playground
-          </span>
+          <span className="font-mono text-[11px] uppercase tracking-wider text-primary">SLOP Playground</span>
         </div>
         <div className="flex items-center gap-2">
           <button
@@ -164,9 +162,7 @@ export default function App() {
         {/* Left: Editor */}
         <div className="flex flex-col flex-1 h-full bg-surface-lowest overflow-hidden">
           <div className="px-3 flex items-center h-8 bg-surface-container">
-            <span className="font-mono text-[11px] uppercase tracking-wider text-on-surface-variant">
-              Editor
-            </span>
+            <span className="font-mono text-[11px] uppercase tracking-wider text-on-surface-variant">Editor</span>
           </div>
           <Editor code={code} onChange={handleCodeChange} error={error} />
         </div>
@@ -176,26 +172,19 @@ export default function App() {
           {/* Tree */}
           <div className="flex flex-col flex-1 min-h-0 bg-surface-low overflow-hidden">
             <div className="px-3 flex items-center h-8 bg-surface-container">
-              <span className="font-mono text-[11px] uppercase tracking-wider text-on-surface-variant">
-                State Tree
-              </span>
+              <span className="font-mono text-[11px] uppercase tracking-wider text-on-surface-variant">State Tree</span>
             </div>
             <div className="flex-1 overflow-auto p-2 font-mono">
               {tree ? (
                 <TreePanel tree={tree} changedPaths={changedPaths} onInvoke={handleInvoke} />
               ) : (
-                <p className="text-sm text-on-surface-variant p-2">
-                  Write some register() calls to see the tree
-                </p>
+                <p className="text-sm text-on-surface-variant p-2">Write some register() calls to see the tree</p>
               )}
             </div>
           </div>
 
           {/* Protocol Log */}
-          <div
-            className="flex flex-col bg-surface-lowest overflow-hidden"
-            style={{ height: "35%" }}
-          >
+          <div className="flex flex-col bg-surface-lowest overflow-hidden" style={{ height: "35%" }}>
             <div className="px-3 flex items-center h-8 bg-surface-container">
               <span className="font-mono text-[11px] uppercase tracking-wider text-on-surface-variant">
                 Protocol Messages
@@ -213,8 +202,7 @@ export default function App() {
 }
 
 function summarizeTree(node: SlopNode): string {
-  const label =
-    (node.properties?.label ?? node.properties?.title ?? node.id) as string;
+  const label = (node.properties?.label ?? node.properties?.title ?? node.id) as string;
   const childCount = node.children?.length ?? 0;
   return `[${node.type}] ${label}${childCount > 0 ? ` (${childCount} children)` : ""}`;
 }
@@ -222,10 +210,7 @@ function summarizeTree(node: SlopNode): string {
 function flashChanged(ops: PatchOp[], setChangedPaths: (s: Set<string>) => void) {
   const paths = new Set(
     ops.map((op) => {
-      const nodePath = op.path.replace(
-        /\/(properties|affordances|meta|children|content_ref)\/.*/,
-        "",
-      );
+      const nodePath = op.path.replace(/\/(properties|affordances|meta|children|content_ref)\/.*/, "");
       return nodePath;
     }),
   );

--- a/website/playground/src/Editor.tsx
+++ b/website/playground/src/Editor.tsx
@@ -136,11 +136,7 @@ export function Editor({ code, onChange, error }: EditorProps) {
           />
         </div>
       </div>
-      {error && (
-        <div className="px-3 py-2 font-mono text-xs text-error bg-error/8 shrink-0">
-          {error}
-        </div>
-      )}
+      {error && <div className="px-3 py-2 font-mono text-xs text-error bg-error/8 shrink-0">{error}</div>}
     </div>
   );
 }

--- a/website/playground/src/InfoPanel.tsx
+++ b/website/playground/src/InfoPanel.tsx
@@ -49,35 +49,31 @@ export function InfoPanel({ open, onToggle }: InfoPanelProps) {
         className="px-3 flex items-center justify-between h-8 bg-surface-container cursor-pointer"
         onClick={onToggle}
       >
-        <span className="font-mono text-[11px] uppercase tracking-wider text-on-surface-variant">
-          Guide
-        </span>
+        <span className="font-mono text-[11px] uppercase tracking-wider text-on-surface-variant">Guide</span>
         <span className="text-on-surface-variant/40 text-xs">✕</span>
       </div>
       <div className="flex-1 overflow-y-auto px-4 py-3 text-sm text-on-surface-variant leading-relaxed space-y-4">
         <p>
-          Write{" "}
-          <code className="font-mono text-primary/70 text-[13px]">register(path, descriptor)</code>{" "}
-          calls to build a SLOP state tree. Click actions in the tree to invoke them.
+          Write <code className="font-mono text-primary/70 text-[13px]">register(path, descriptor)</code> calls to build
+          a SLOP state tree. Click actions in the tree to invoke them.
         </p>
 
         <div>
           <p className="text-on-surface font-medium mb-1.5">Sandbox vs real SDK</p>
           <ul className="list-disc list-inside space-y-1.5 text-[13px]">
             <li>
-              <code className="font-mono text-primary/70">register()</code> is a global here
-              — in your app it's{" "}
+              <code className="font-mono text-primary/70">register()</code> is a global here — in your app it's{" "}
               <code className="font-mono text-primary/70">slop.register()</code>
             </li>
             <li>
-              State is plain mutable variables — in React you'd
-              use <code className="font-mono text-primary/70">useState</code> +{" "}
+              State is plain mutable variables — in React you'd use{" "}
+              <code className="font-mono text-primary/70">useState</code> +{" "}
               <code className="font-mono text-primary/70">useSlop</code> hook
             </li>
             <li>
-              <code className="font-mono text-primary/70">const</code>/<code className="font-mono text-primary/70">let</code> are
-              converted to <code className="font-mono text-primary/70">var</code> so
-              handler mutations persist
+              <code className="font-mono text-primary/70">const</code>/
+              <code className="font-mono text-primary/70">let</code> are converted to{" "}
+              <code className="font-mono text-primary/70">var</code> so handler mutations persist
             </li>
           </ul>
         </div>
@@ -93,39 +89,32 @@ export function InfoPanel({ open, onToggle }: InfoPanelProps) {
         <div>
           <p className="text-on-surface font-medium mb-1.5">What's the same</p>
           <p className="text-[13px]">
-            The descriptor format is identical —{" "}
-            <code className="font-mono text-primary/70">type</code>,{" "}
+            The descriptor format is identical — <code className="font-mono text-primary/70">type</code>,{" "}
             <code className="font-mono text-primary/70">props</code>,{" "}
             <code className="font-mono text-primary/70">items</code>,{" "}
             <code className="font-mono text-primary/70">actions</code>,{" "}
-            <code className="font-mono text-primary/70">children</code>{" "}
-            work the same way here and in production. The tree output and
-            protocol messages are real.
+            <code className="font-mono text-primary/70">children</code> work the same way here and in production. The
+            tree output and protocol messages are real.
           </p>
         </div>
 
         <div>
           <p className="text-on-surface font-medium mb-2">Try it — step by step</p>
           <div className="space-y-4 text-[13px]">
-
             <div>
               <p className="text-on-surface font-medium mb-1">1. State tree</p>
               <p className="mb-1">
-                The tree panel shows what AI sees. Edit a todo's title in the
-                editor and watch the tree update live. The protocol log shows
-                a <code className="font-mono text-primary/70">patch</code> with
-                the exact diff.
+                The tree panel shows what AI sees. Edit a todo's title in the editor and watch the tree update live. The
+                protocol log shows a <code className="font-mono text-primary/70">patch</code> with the exact diff.
               </p>
             </div>
 
             <div>
               <p className="text-on-surface font-medium mb-1">2. Contextual affordances</p>
               <p className="mb-1">
-                Actions live on the nodes they affect — not in a global list.
-                Click <code className="font-mono text-primary/70">toggle</code> on
-                a todo item. The handler runs, the tree updates,
-                and the log shows{" "}
-                <code className="font-mono text-primary/70">invoke</code> →{" "}
+                Actions live on the nodes they affect — not in a global list. Click{" "}
+                <code className="font-mono text-primary/70">toggle</code> on a todo item. The handler runs, the tree
+                updates, and the log shows <code className="font-mono text-primary/70">invoke</code> →{" "}
                 <code className="font-mono text-primary/70">result</code> →{" "}
                 <code className="font-mono text-primary/70">patch</code>.
               </p>
@@ -134,32 +123,31 @@ export function InfoPanel({ open, onToggle }: InfoPanelProps) {
             <div>
               <p className="text-on-surface font-medium mb-1">3. Typed parameters</p>
               <p className="mb-1">
-                Click <code className="font-mono text-primary/70">create</code> on
-                the collection or <code className="font-mono text-primary/70">rename</code> on
-                an item. A param form appears — actions can require typed
-                inputs. The AI fills these from context.
+                Click <code className="font-mono text-primary/70">create</code> on the collection or{" "}
+                <code className="font-mono text-primary/70">rename</code> on an item. A param form appears — actions can
+                require typed inputs. The AI fills these from context.
               </p>
             </div>
 
             <div>
               <p className="text-on-surface font-medium mb-1">4. Dangerous actions</p>
               <p className="mb-1">
-                Click <code className="font-mono text-error/70">delete</code> (red).
-                It prompts for confirmation. The{" "}
-                <code className="font-mono text-primary/70">dangerous: true</code> flag
-                tells AI to confirm before executing.
+                Click <code className="font-mono text-error/70">delete</code> (red). It prompts for confirmation. The{" "}
+                <code className="font-mono text-primary/70">dangerous: true</code> flag tells AI to confirm before
+                executing.
               </p>
             </div>
 
             <div>
               <p className="text-on-surface font-medium mb-1">5. Hierarchical registration</p>
               <p className="mb-1">
-                Add a second <code className="font-mono text-primary/70">register()</code> call
-                at a different path. Try:
+                Add a second <code className="font-mono text-primary/70">register()</code> call at a different path.
+                Try:
               </p>
               <pre
                 className="font-mono text-[12px] bg-surface-lowest rounded-sm p-2 leading-relaxed whitespace-pre overflow-x-auto mt-1"
-                dangerouslySetInnerHTML={{ __html: highlight(`register("settings", {
+                dangerouslySetInnerHTML={{
+                  __html: highlight(`register("settings", {
   type: "group",
   props: { theme: "dark" },
   actions: {
@@ -168,23 +156,25 @@ export function InfoPanel({ open, onToggle }: InfoPanelProps) {
       handler: () => {},
     },
   },
-});`) }}
+});`),
+                }}
               />
               <p className="mt-1">
-                The tree now has two top-level nodes. Each component
-                registers its own slice — the engine assembles the full tree.
+                The tree now has two top-level nodes. Each component registers its own slice — the engine assembles the
+                full tree.
               </p>
             </div>
 
             <div>
               <p className="text-on-surface font-medium mb-1">6. Nested children</p>
               <p className="mb-1">
-                Use <code className="font-mono text-primary/70">children</code> for
-                inline subtrees or path-based nesting:
+                Use <code className="font-mono text-primary/70">children</code> for inline subtrees or path-based
+                nesting:
               </p>
               <pre
                 className="font-mono text-[12px] bg-surface-lowest rounded-sm p-2 leading-relaxed whitespace-pre overflow-x-auto mt-1"
-                dangerouslySetInnerHTML={{ __html: highlight(`register("inbox", {
+                dangerouslySetInnerHTML={{
+                  __html: highlight(`register("inbox", {
   type: "view",
   children: {
     unread: {
@@ -202,34 +192,33 @@ export function InfoPanel({ open, onToggle }: InfoPanelProps) {
       },
     },
   },
-});`) }}
+});`),
+                }}
               />
             </div>
 
             <div>
               <p className="text-on-surface font-medium mb-1">7. Attention hints</p>
               <p className="mb-1">
-                Add <code className="font-mono text-primary/70">meta</code> to
-                signal importance to the AI:
+                Add <code className="font-mono text-primary/70">meta</code> to signal importance to the AI:
               </p>
               <pre
                 className="font-mono text-[12px] bg-surface-lowest rounded-sm p-2 leading-relaxed whitespace-pre overflow-x-auto mt-1"
-                dangerouslySetInnerHTML={{ __html: highlight(`// On an item:
+                dangerouslySetInnerHTML={{
+                  __html: highlight(`// On an item:
 meta: {
   salience: 1.0,  // high priority
   pinned: true,    // keep in view
   changed: true,   // recently modified
-}`) }}
+}`),
+                }}
               />
             </div>
-
           </div>
         </div>
 
         <div className="mt-4">
-          <p className="text-[13px] text-on-surface-variant mb-3">
-            Done exploring? Add SLOP to your own app.
-          </p>
+          <p className="text-[13px] text-on-surface-variant mb-3">Done exploring? Add SLOP to your own app.</p>
           <a
             href="https://docs.slopai.dev/getting-started"
             target="_blank"

--- a/website/playground/src/ProtocolLog.tsx
+++ b/website/playground/src/ProtocolLog.tsx
@@ -41,12 +41,8 @@ export function ProtocolLog({ entries }: ProtocolLogProps) {
         return (
           <div key={entry.id} className="flex items-start gap-2 py-px">
             <span className="text-[11px] text-on-surface-variant/30 shrink-0">{time}</span>
-            <span className={`text-[11px] px-1 rounded-sm shrink-0 ${style}`}>
-              {entry.type}
-            </span>
-            <span className="text-on-surface-variant/60 break-all">
-              {formatPayload(entry)}
-            </span>
+            <span className={`text-[11px] px-1 rounded-sm shrink-0 ${style}`}>{entry.type}</span>
+            <span className="text-on-surface-variant/60 break-all">{formatPayload(entry)}</span>
           </div>
         );
       })}

--- a/website/playground/src/TreePanel.tsx
+++ b/website/playground/src/TreePanel.tsx
@@ -27,9 +27,7 @@ interface TreePanelProps {
 }
 
 export function TreePanel({ tree, changedPaths, onInvoke }: TreePanelProps) {
-  return (
-    <TreeNode node={tree} depth={0} changedPaths={changedPaths} currentPath="" onInvoke={onInvoke} />
-  );
+  return <TreeNode node={tree} depth={0} changedPaths={changedPaths} currentPath="" onInvoke={onInvoke} />;
 }
 
 function TreeNode({
@@ -63,9 +61,7 @@ function TreeNode({
     <div>
       {/* Main row */}
       <div
-        className={`flex items-center gap-1.5 py-px rounded-sm cursor-default group ${
-          isChanged ? "flash-change" : ""
-        }`}
+        className={`flex items-center gap-1.5 py-px rounded-sm cursor-default group ${isChanged ? "flash-change" : ""}`}
         style={{ paddingLeft: `${depth * 16 + 4}px` }}
         onClick={() => expandable && setCollapsed(!collapsed)}
       >
@@ -128,10 +124,7 @@ function TreeNode({
 
           {/* Affordance buttons */}
           {hasAffordances && (
-            <div
-              className="flex flex-wrap gap-1 py-px"
-              style={{ paddingLeft: `${depth * 16 + 26}px` }}
-            >
+            <div className="flex flex-wrap gap-1 py-px" style={{ paddingLeft: `${depth * 16 + 26}px` }}>
               {node.affordances!.map((a) => (
                 <ActionButton
                   key={a.action}

--- a/website/playground/src/highlight.ts
+++ b/website/playground/src/highlight.ts
@@ -11,7 +11,10 @@ const RULES: Array<[RegExp, string]> = [
   // Numbers
   [/\b\d+(\.\d+)?\b/g, "hl-number"],
   // Keywords
-  [/\b(const|let|var|function|return|if|else|for|while|do|switch|case|break|continue|new|typeof|instanceof|in|of|true|false|null|undefined|this|class|export|import|from|default|try|catch|throw|finally|async|await|yield)\b/g, "hl-keyword"],
+  [
+    /\b(const|let|var|function|return|if|else|for|while|do|switch|case|break|continue|new|typeof|instanceof|in|of|true|false|null|undefined|this|class|export|import|from|default|try|catch|throw|finally|async|await|yield)\b/g,
+    "hl-keyword",
+  ],
   // Arrow functions
   [/=>/g, "hl-keyword"],
   // Property keys (before colon in objects)
@@ -66,8 +69,5 @@ export function highlight(code: string): string {
 }
 
 function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }


### PR DESCRIPTION
## Summary
- add a root Biome formatter setup for JS/TS files, including workspace scripts and generated-file exclusions
- apply a one-time Biome formatting pass across the existing TypeScript and JavaScript codebase
- enforce formatting in the main preflight workflow with `bun run format:check`