### PR TITLE
docs(discovery): clarify shared package boundary

### DIFF
--- a/docs/sdk/discovery.md
+++ b/docs/sdk/discovery.md
@@ -40,6 +40,8 @@ Integrations (Claude Code plugin, OpenClaw plugin, VS Code extension, custom age
 
 Integrations compose these entrypoints: `@slop-ai/discovery/service` for provider scanning and connection orchestration, `@slop-ai/discovery/tools` when they need lifecycle or dynamic-tool helpers, and the root export when they need direct bridge primitives.
 
+These are subpath entrypoints of the same published `@slop-ai/discovery` package, not separately published npm packages. They currently share one install-time dependency set even when a consumer only imports the root, `/service`, or `/tools` entrypoint.
+
 ## Phase 1: Core Discovery Layer
 
 As of `v0.1`, the **core discovery layer** is shipped across TypeScript, Python, Go, and Rust. The TypeScript implementation remains the behavioral reference, but other SDKs do **not** need to copy its package topology.

--- a/packages/typescript/integrations/discovery/src/anthropic-agent-sdk.ts
+++ b/packages/typescript/integrations/discovery/src/anthropic-agent-sdk.ts
@@ -17,7 +17,7 @@ import { createToolHandlers } from "./tools";
  *
  * Returns lifecycle tools only (list_apps, connect_app, disconnect_app).
  * Dynamic affordance tools should be wired via MCP's tools/list_changed
- * using `createDynamicTools()` from the main export.
+ * using `createDynamicTools()` from `@slop-ai/discovery/tools`.
  */
 export function createSlopAgentTools(discovery: ReturnType<typeof createDiscoveryService>) {
   const handlers = createToolHandlers(discovery);

--- a/website/docs/src/content/docs/sdk/discovery.md
+++ b/website/docs/src/content/docs/sdk/discovery.md
@@ -42,6 +42,8 @@ Integrations (Claude Code plugin, OpenClaw plugin, VS Code extension, custom age
 
 Integrations compose these entrypoints: `@slop-ai/discovery/service` for provider scanning and connection orchestration, `@slop-ai/discovery/tools` when they need lifecycle or dynamic-tool helpers, and the root export when they need direct bridge primitives.
 
+These are subpath entrypoints of the same published `@slop-ai/discovery` package, not separately published npm packages. They currently share one install-time dependency set even when a consumer only imports the root, `/service`, or `/tools` entrypoint.
+
 ## Phase 1: Core Discovery Layer
 
 As of `v0.1`, the **core discovery layer** is shipped across TypeScript, Python, Go, and Rust. The TypeScript implementation remains the behavioral reference, but other SDKs do **not** need to copy its package topology.


### PR DESCRIPTION
## Summary
- clarify in the discovery SDK docs that `@slop-ai/discovery`, `/service`, and `/tools` are subpath entrypoints of one published package rather than separate npm artifacts
- make the shared install-time dependency boundary explicit so the import split is not mistaken for dependency isolation
- fix the Anthropic Agent SDK helper comment to point dynamic tools at `@slop-ai/discovery/tools`

## Testing
- `cd website/docs && bun run check:content`