### PR TITLE
fix(rust): restore docs.rs build for slop-ai

### DIFF
--- a/packages/rust/slop-ai/src/lib.rs
+++ b/packages/rust/slop-ai/src/lib.rs
@@ -56,7 +56,7 @@
 //! - Integration guide: <https://docs.slopai.dev/guides/rust>
 //! - crates.io docs: <https://docs.rs/slop-ai>
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod descriptor;
 pub mod diff;


### PR DESCRIPTION
## Summary
- replace the removed `doc_auto_cfg` nightly rustdoc feature with `doc_cfg` in the Rust SDK crate root
- restore `docs.rs` generation for `slop-ai`, which was failing on current nightly toolchains
- keep the crate's existing docs.rs config and feature-gated API docs behavior unchanged

## Testing
- `cargo +nightly rustdoc --lib --all-features -- --cfg docsrs`