### PR TITLE
docs(spec): clarify affordance security model

### DIFF
--- a/spec/core/affordances.md
+++ b/spec/core/affordances.md
@@ -13,7 +13,7 @@ Key differences:
 | | Tools (MCP, etc.) | Affordances (SLOP) |
 |---|---|---|
 | Scope | Global flat list | Per-node, contextual |
-| Availability | Always listed (may fail at runtime) | Only present when valid |
+| Availability | Always listed (may fail at runtime) | Only present when expected to be valid in the current projected state |
 | Discovery | Read tool descriptions | See them alongside state |
 | Parameters | Must be inferred from docs | Defined with JSON Schema, contextualized |
 
@@ -124,9 +124,25 @@ Affordances are invoked via the `invoke` message (see [Messages](./messages.md))
 The provider:
 1. Validates the action exists on the target node
 2. Validates parameters against the affordance's `params` schema
-3. Executes the action
-4. Returns a `result` message
-5. Emits state `patch` messages reflecting any state changes caused by the action
+3. Re-validates that the action is still allowed under the provider's current state, session permissions, and app policy
+4. Executes the action
+5. Returns a `result` message
+6. Emits state `patch` messages reflecting any state changes caused by the action
+
+## Applicability is not authorization
+
+The presence of an affordance means the action is **structurally applicable in the provider's current projected state**. It is not an authorization grant, and it is not a promise that the action will still succeed by the time the consumer invokes it.
+
+Consumers, LLMs, browser extensions, desktop daemons, service workers, and relay processes are all **untrusted** from the provider's perspective. They may be stale, buggy, compromised, or influenced by prompt injection. A provider MUST therefore treat every `invoke` as untrusted input and MUST re-check:
+
+1. The target node and affordance still exist in the live state
+2. The supplied parameters are valid
+3. The current caller/session is allowed to perform the action
+4. Any resource-specific policy guards still pass
+
+If the action is no longer valid because state changed, return `conflict`. If the caller is not allowed to perform it, return `unauthorized`.
+
+Contextual affordances are still valuable: they reduce invalid action attempts, help the model choose correctly, and make the safe path obvious. But they are **defense in depth**, not the primary security boundary.
 
 ## Confirmation pattern
 
@@ -136,7 +152,7 @@ When `dangerous: true`, the protocol itself doesn't enforce confirmation — it'
 2. Present the action to the user for confirmation before invoking
 3. Only invoke after explicit approval
 
-This keeps policy in the consumer, not the provider.
+This keeps confirmation UX in the consumer, while execution authorization remains in the provider.
 
 ## Compound actions
 
@@ -154,7 +170,9 @@ This keeps each affordance atomic and lets the AI make decisions between steps.
 
 Affordances must be **declared in the node's descriptor** to appear in the state tree. The descriptor is the source of truth for what the consumer sees.
 
-A handler registered separately (e.g., for routing or middleware) does not automatically create an affordance in the tree. If a developer registers a handler for `"delete"` on a node but doesn't include `"delete"` in the node's affordances, the action is callable but invisible to the consumer. This is intentional — it allows providers to have internal actions that aren't exposed to AI consumers.
+A handler registered separately (e.g., for routing or middleware) does not automatically create an affordance in the tree. If a developer registers a handler for `"delete"` on a node but doesn't include `"delete"` in the node's affordances, the action may still be callable while remaining invisible to the consumer.
+
+This can be useful for adapter plumbing, but providers MUST NOT rely on invisibility for safety. If an operation must not be invocable by an untrusted SLOP consumer, do not expose it on the SLOP transport at all, or enforce the same authorization and policy checks at runtime.
 
 ## Affordance placement
 

--- a/spec/core/messages.md
+++ b/spec/core/messages.md
@@ -188,8 +188,8 @@ On error:
 |---|---|
 | `not_found` | Target node or action doesn't exist |
 | `invalid_params` | Parameters failed validation |
-| `unauthorized` | Consumer lacks permission for this action |
-| `conflict` | Action can't be performed in current state |
+| `unauthorized` | Consumer/session lacks permission, or policy forbids this action |
+| `conflict` | Action can't be performed in the current live state, even if it appeared valid in an earlier snapshot |
 | `internal` | Provider-side error |
 
 ### Extended result statuses

--- a/spec/core/transport.md
+++ b/spec/core/transport.md
@@ -248,4 +248,6 @@ Capabilities declare which features a provider supports. Consumers must not rely
 - **WebSocket transports** must require authentication for non-localhost connections. A bearer token in the initial HTTP upgrade request is the simplest approach.
 - **Providers should not expose secrets** in the state tree. The state tree is a projection, not an internal dump — treat it like a public API surface.
 - **Affordance invocations are untrusted input.** Providers must validate all parameters, just as they would for any API endpoint.
+- **Prompt injection is in scope.** A consumer may send fabricated, stale, or policy-violating `invoke` messages regardless of what the tree previously showed. Providers must re-authorize every invoke against live state, caller identity, and resource policy.
+- **Bridges and relays are not the security boundary.** Browser extensions, desktop daemons, MCP proxies, and service workers may discover providers or relay SLOP messages, but the provider (or authoritative backend behind it) must make the final allow/deny decision for every action.
 - **Multi-user servers** must use session-scoped state so that each user's state tree is isolated. Authentication happens at the transport level (WebSocket upgrade), not in SLOP messages. See [Sessions & Multi-User](../../docs/sdk/sessions.md) for SDK implementation patterns.

--- a/spec/limitations.md
+++ b/spec/limitations.md
@@ -16,6 +16,16 @@ This is intentional — session management is an application concern, and the pr
 
 **Path forward:** SDK-level session support — session-scoped descriptor functions, session-aware `refresh()`, and connection authentication helpers. See [Sessions & Multi-User](../docs/sdk/sessions.md) for the full architecture. No protocol changes are needed.
 
+### No standardized authorization metadata
+
+The protocol models **what actions are exposed right now**, but it does not standardize a machine-readable policy layer explaining *why* an action is allowed, what permission it requires, or which constraints are advisory versus hard enforcement.
+
+**Current behavior:** Providers expose contextual affordances, `dangerous` hints, and parameter schemas. At execution time they may reject an invoke with `unauthorized` or `conflict`, but the exact policy logic and denial semantics are implementation-specific.
+
+**Impact:** Consumers can see the safe path more clearly, but they cannot reliably explain permission boundaries, compare security posture across providers, or reason about denial causes beyond the coarse runtime error codes.
+
+**Path forward:** A future extension could define optional affordance policy metadata — for example required capability tags, structured denial reasons, or policy scopes — while keeping runtime enforcement authoritative at the provider.
+
 ### No backpressure signaling
 
 The spec mentions `pause` / `resume` messages for subscriptions but doesn't define them. If a consumer is slow to process patches, the provider may skip intermediate versions and send a fresh snapshot — but there's no formal mechanism for the consumer to signal that it's falling behind.

--- a/website/docs/src/content/docs/spec/core/affordances.md
+++ b/website/docs/src/content/docs/spec/core/affordances.md
@@ -14,7 +14,7 @@ Key differences:
 | | Tools (MCP, etc.) | Affordances (SLOP) |
 |---|---|---|
 | Scope | Global flat list | Per-node, contextual |
-| Availability | Always listed (may fail at runtime) | Only present when valid |
+| Availability | Always listed (may fail at runtime) | Only present when expected to be valid in the current projected state |
 | Discovery | Read tool descriptions | See them alongside state |
 | Parameters | Must be inferred from docs | Defined with JSON Schema, contextualized |
 
@@ -125,9 +125,25 @@ Affordances are invoked via the `invoke` message (see [Messages](/spec/core/mess
 The provider:
 1. Validates the action exists on the target node
 2. Validates parameters against the affordance's `params` schema
-3. Executes the action
-4. Returns a `result` message
-5. Emits state `patch` messages reflecting any state changes caused by the action
+3. Re-validates that the action is still allowed under the provider's current state, session permissions, and app policy
+4. Executes the action
+5. Returns a `result` message
+6. Emits state `patch` messages reflecting any state changes caused by the action
+
+## Applicability is not authorization
+
+The presence of an affordance means the action is **structurally applicable in the provider's current projected state**. It is not an authorization grant, and it is not a promise that the action will still succeed by the time the consumer invokes it.
+
+Consumers, LLMs, browser extensions, desktop daemons, service workers, and relay processes are all **untrusted** from the provider's perspective. They may be stale, buggy, compromised, or influenced by prompt injection. A provider MUST therefore treat every `invoke` as untrusted input and MUST re-check:
+
+1. The target node and affordance still exist in the live state
+2. The supplied parameters are valid
+3. The current caller/session is allowed to perform the action
+4. Any resource-specific policy guards still pass
+
+If the action is no longer valid because state changed, return `conflict`. If the caller is not allowed to perform it, return `unauthorized`.
+
+Contextual affordances are still valuable: they reduce invalid action attempts, help the model choose correctly, and make the safe path obvious. But they are **defense in depth**, not the primary security boundary.
 
 ## Confirmation pattern
 
@@ -137,7 +153,7 @@ When `dangerous: true`, the protocol itself doesn't enforce confirmation — it'
 2. Present the action to the user for confirmation before invoking
 3. Only invoke after explicit approval
 
-This keeps policy in the consumer, not the provider.
+This keeps confirmation UX in the consumer, while execution authorization remains in the provider.
 
 ## Compound actions
 
@@ -155,7 +171,9 @@ This keeps each affordance atomic and lets the AI make decisions between steps.
 
 Affordances must be **declared in the node's descriptor** to appear in the state tree. The descriptor is the source of truth for what the consumer sees.
 
-A handler registered separately (e.g., for routing or middleware) does not automatically create an affordance in the tree. If a developer registers a handler for `"delete"` on a node but doesn't include `"delete"` in the node's affordances, the action is callable but invisible to the consumer. This is intentional — it allows providers to have internal actions that aren't exposed to AI consumers.
+A handler registered separately (e.g., for routing or middleware) does not automatically create an affordance in the tree. If a developer registers a handler for `"delete"` on a node but doesn't include `"delete"` in the node's affordances, the action may still be callable while remaining invisible to the consumer.
+
+This can be useful for adapter plumbing, but providers MUST NOT rely on invisibility for safety. If an operation must not be invocable by an untrusted SLOP consumer, do not expose it on the SLOP transport at all, or enforce the same authorization and policy checks at runtime.
 
 ## Affordance placement
 

--- a/website/docs/src/content/docs/spec/core/messages.md
+++ b/website/docs/src/content/docs/spec/core/messages.md
@@ -189,8 +189,8 @@ On error:
 |---|---|
 | `not_found` | Target node or action doesn't exist |
 | `invalid_params` | Parameters failed validation |
-| `unauthorized` | Consumer lacks permission for this action |
-| `conflict` | Action can't be performed in current state |
+| `unauthorized` | Consumer/session lacks permission, or policy forbids this action |
+| `conflict` | Action can't be performed in the current live state, even if it appeared valid in an earlier snapshot |
 | `internal` | Provider-side error |
 
 ### Extended result statuses

--- a/website/docs/src/content/docs/spec/core/transport.md
+++ b/website/docs/src/content/docs/spec/core/transport.md
@@ -249,4 +249,6 @@ Capabilities declare which features a provider supports. Consumers must not rely
 - **WebSocket transports** must require authentication for non-localhost connections. A bearer token in the initial HTTP upgrade request is the simplest approach.
 - **Providers should not expose secrets** in the state tree. The state tree is a projection, not an internal dump — treat it like a public API surface.
 - **Affordance invocations are untrusted input.** Providers must validate all parameters, just as they would for any API endpoint.
+- **Prompt injection is in scope.** A consumer may send fabricated, stale, or policy-violating `invoke` messages regardless of what the tree previously showed. Providers must re-authorize every invoke against live state, caller identity, and resource policy.
+- **Bridges and relays are not the security boundary.** Browser extensions, desktop daemons, MCP proxies, and service workers may discover providers or relay SLOP messages, but the provider (or authoritative backend behind it) must make the final allow/deny decision for every action.
 - **Multi-user servers** must use session-scoped state so that each user's state tree is isolated. Authentication happens at the transport level (WebSocket upgrade), not in SLOP messages. See [Sessions & Multi-User](/sdk/sessions) for SDK implementation patterns.

--- a/website/docs/src/content/docs/spec/limitations.md
+++ b/website/docs/src/content/docs/spec/limitations.md
@@ -17,6 +17,16 @@ This is intentional — session management is an application concern, and the pr
 
 **Path forward:** SDK-level session support — session-scoped descriptor functions, session-aware `refresh()`, and connection authentication helpers. See [Sessions & Multi-User](/sdk/sessions) for the full architecture. No protocol changes are needed.
 
+### No standardized authorization metadata
+
+The protocol models **what actions are exposed right now**, but it does not standardize a machine-readable policy layer explaining *why* an action is allowed, what permission it requires, or which constraints are advisory versus hard enforcement.
+
+**Current behavior:** Providers expose contextual affordances, `dangerous` hints, and parameter schemas. At execution time they may reject an invoke with `unauthorized` or `conflict`, but the exact policy logic and denial semantics are implementation-specific.
+
+**Impact:** Consumers can see the safe path more clearly, but they cannot reliably explain permission boundaries, compare security posture across providers, or reason about denial causes beyond the coarse runtime error codes.
+
+**Path forward:** A future extension could define optional affordance policy metadata — for example required capability tags, structured denial reasons, or policy scopes — while keeping runtime enforcement authoritative at the provider.
+
 ### No backpressure signaling
 
 The spec mentions `pause` / `resume` messages for subscriptions but doesn't define them. If a consumer is slow to process patches, the provider may skip intermediate versions and send a fresh snapshot — but there's no formal mechanism for the consumer to signal that it's falling behind.


### PR DESCRIPTION
## Summary
- clarify that affordance presence means an action is expected to be valid in the current projected state, not that it is authorized
- require providers to revalidate every `invoke` against live state, session permissions, and resource policy
- tighten `unauthorized` and `conflict` semantics, document prompt injection as in scope, and add missing authorization metadata to limitations/future work

## Why
The spec already described contextual affordances and validation, but it left the security boundary too implicit. This makes the runtime enforcement model explicit so prompt injection, stale state, hidden handlers, and bridge/relay hops are all clearly treated as untrusted from the provider's perspective.

## Impact
This is a documentation/spec clarification only. It does not add a new protocol primitive, but it makes the intended trust model and remaining gap around standardized authorization metadata much clearer.

## Validation
- `cd website/docs && bun run generate:content`
- `cd website/docs && bun run check:content`