### PR TITLE
Build(deps): Bump the js-workspace group with 23 updates

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,8 +20,8 @@
     "@tauri-apps/cli": "^2.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "@vitejs/plugin-react": "^4.0.0",
-    "typescript": "^5.0.0",
-    "vite": "^6.0.0"
+    "@vitejs/plugin-react": "^6.0.1",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.9"
   }
 }

--- a/examples/desktop/typescript/package.json
+++ b/examples/desktop/typescript/package.json
@@ -11,6 +11,6 @@
     "@slop-ai/server": "workspace:*"
   },
   "devDependencies": {
-    "electron": "^33.0.0"
+    "electron": "^41.2.1"
   }
 }

--- a/examples/full-stack/python-react/frontend/package.json
+++ b/examples/full-stack/python-react/frontend/package.json
@@ -17,8 +17,8 @@
   "devDependencies": {
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "@vitejs/plugin-react": "^4.3.0",
-    "typescript": "^5.7.0",
-    "vite": "^6.0.0"
+    "@vitejs/plugin-react": "^6.0.1",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.9"
   }
 }

--- a/examples/full-stack/tanstack-start/package.json
+++ b/examples/full-stack/tanstack-start/package.json
@@ -22,7 +22,7 @@
     "@tanstack/react-router-ssr-query": "latest",
     "@tanstack/react-start": "latest",
     "@tanstack/router-plugin": "^1.132.0",
-    "lucide-react": "^0.545.0",
+    "lucide-react": "^1.8.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "tailwindcss": "^4.1.18"
@@ -32,15 +32,15 @@
     "@tanstack/devtools-vite": "latest",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.0",
-    "@types/node": "^22.10.2",
+    "@types/node": "^25.6.0",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
-    "@vitejs/plugin-react": "^5.1.4",
-    "jsdom": "^28.1.0",
-    "typescript": "^5.7.2",
-    "vite": "^7.3.1",
-    "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^3.0.5"
+    "@vitejs/plugin-react": "^6.0.1",
+    "jsdom": "^29.0.2",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.9",
+    "vite-tsconfig-paths": "^6.1.1",
+    "vitest": "^4.1.4"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/examples/spa/angular/package.json
+++ b/examples/spa/angular/package.json
@@ -9,22 +9,22 @@
     "preview": "ng serve --port 4200 --configuration production"
   },
   "dependencies": {
-    "@angular/common": "^19.0.0",
-    "@angular/compiler": "^19.0.0",
-    "@angular/core": "^19.0.0",
-    "@angular/forms": "^19.0.0",
-    "@angular/platform-browser": "^19.0.0",
+    "@angular/common": "^21.2.9",
+    "@angular/compiler": "^21.2.9",
+    "@angular/core": "^21.2.9",
+    "@angular/forms": "^21.2.9",
+    "@angular/platform-browser": "^21.2.9",
     "@slop-ai/angular": "workspace:*",
     "@slop-ai/client": "workspace:*",
     "@slop-ai/core": "workspace:*",
     "rxjs": "^7.8.0",
     "tslib": "^2.6.0",
-    "zone.js": "^0.15.0"
+    "zone.js": "^0.16.1"
   },
   "devDependencies": {
-    "@angular/build": "^19.0.0",
-    "@angular/cli": "^19.0.0",
-    "@angular/compiler-cli": "^19.0.0",
-    "typescript": "~5.6.0"
+    "@angular/build": "^21.2.7",
+    "@angular/cli": "^21.2.7",
+    "@angular/compiler-cli": "^21.2.9",
+    "typescript": "~6.0.3"
   }
 }

--- a/examples/spa/react/package.json
+++ b/examples/spa/react/package.json
@@ -17,8 +17,8 @@
   "devDependencies": {
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "@vitejs/plugin-react": "^4.3.0",
-    "typescript": "^5.7.0",
-    "vite": "^6.0.0"
+    "@vitejs/plugin-react": "^6.0.1",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.9"
   }
 }

--- a/examples/spa/solid/package.json
+++ b/examples/spa/solid/package.json
@@ -14,8 +14,8 @@
     "solid-js": "^1.9.0"
   },
   "devDependencies": {
-    "typescript": "^5.7.0",
-    "vite": "^6.0.0",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.9",
     "vite-plugin-solid": "^2.10.0"
   }
 }

--- a/examples/spa/svelte/package.json
+++ b/examples/spa/svelte/package.json
@@ -15,9 +15,9 @@
     "svelte": "^5.0.0"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^5.0.0",
+    "@sveltejs/vite-plugin-svelte": "^7.0.0",
     "svelte-check": "^4.0.0",
-    "typescript": "^5.7.0",
-    "vite": "^6.0.0"
+    "typescript": "^6.0.3",
+    "vite": "^8.0.9"
   }
 }

--- a/examples/spa/vue/package.json
+++ b/examples/spa/vue/package.json
@@ -14,9 +14,9 @@
     "vue": "^3.5.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^5.2.0",
-    "typescript": "^5.7.0",
-    "vite": "^6.0.0",
-    "vue-tsc": "^2.2.0"
+    "@vitejs/plugin-vue": "^6.0.6",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.9",
+    "vue-tsc": "^3.2.7"
   }
 }

--- a/packages/typescript/adapters/angular/package.json
+++ b/packages/typescript/adapters/angular/package.json
@@ -23,5 +23,5 @@
   },
   "dependencies": { "@slop-ai/core": "workspace:*" },
   "peerDependencies": { "@angular/core": ">=19.0.0" },
-  "devDependencies": { "@angular/core": "^19.0.0" }
+  "devDependencies": { "@angular/core": "^21.2.9" }
 }

--- a/packages/typescript/adapters/tanstack-start/package.json
+++ b/packages/typescript/adapters/tanstack-start/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@types/react": "^19.0.0",
     "@types/ws": "^8.5.0",
-    "@types/node": "^22.0.0",
+    "@types/node": "^25.6.0",
     "@tanstack/react-router": "^1.0.0"
   },
   "peerDependencies": {

--- a/packages/typescript/integrations/discovery/package.json
+++ b/packages/typescript/integrations/discovery/package.json
@@ -43,13 +43,13 @@
   },
   "dependencies": {
     "@slop-ai/consumer": "workspace:*",
-    "@anthropic-ai/claude-agent-sdk": "^0.1.0",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.114",
     "@modelcontextprotocol/sdk": "^1.12.0",
     "ws": "^8.18.0",
-    "zod": "^3.23.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
+    "@types/node": "^25.6.0",
     "@types/ws": "^8.5.0"
   }
 }

--- a/packages/typescript/integrations/openclaw-plugin/package.json
+++ b/packages/typescript/integrations/openclaw-plugin/package.json
@@ -37,6 +37,6 @@
     "openclaw": ">=2026.0.0"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0"
+    "@types/node": "^25.6.0"
   }
 }

--- a/packages/typescript/sdk/server/package.json
+++ b/packages/typescript/sdk/server/package.json
@@ -53,7 +53,7 @@
     "@slop-ai/core": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
+    "@types/node": "^25.6.0",
     "@types/ws": "^8.5.0",
     "ws": "^8.18.0"
   }

--- a/website/demo/package.json
+++ b/website/demo/package.json
@@ -20,9 +20,9 @@
     "@tailwindcss/vite": "^4.1.18",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "@vitejs/plugin-react": "^4.5.2",
+    "@vitejs/plugin-react": "^6.0.1",
     "tailwindcss": "^4.1.18",
-    "typescript": "^5.8.3",
-    "vite": "^6.3.5"
+    "typescript": "^6.0.3",
+    "vite": "^8.0.9"
   }
 }

--- a/website/playground/package.json
+++ b/website/playground/package.json
@@ -18,9 +18,9 @@
     "@tailwindcss/vite": "^4.1.18",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "@vitejs/plugin-react": "^4.5.2",
+    "@vitejs/plugin-react": "^6.0.1",
     "tailwindcss": "^4.1.18",
-    "typescript": "^5.8.3",
-    "vite": "^6.3.5"
+    "typescript": "^6.0.3",
+    "vite": "^8.0.9"
   }
 }


### PR DESCRIPTION
## What's Updated (23 packages across the workspace)

Bumps the js-workspace dependency group including:
-  3.25.76 → 4.3.6
-  5.6.3 → 6.0.2
-  6.4.1 → 8.0.4
-  19.2.20 → 21.2.7
-  3.2.4 → 4.1.2
-  0.545.0 → 1.7.0
- And 18 more packages

All changes are in package.json version bumps only. No code changes.