### PR TITLE
Reserve node-field keywords in patch paths (spec + SDK conformance)

### DIFF
--- a/packages/go/slop-ai/state_mirror.go
+++ b/packages/go/slop-ai/state_mirror.go
@@ -101,6 +101,13 @@ func (sm *StateMirror) applyFieldAdd(node *WireNode, fieldPath []string, value a
 		node.Meta = &meta
 		return
 	}
+	if len(fieldPath) == 1 && fieldPath[0] == "content_ref" {
+		var cr WireContentRef
+		data, _ := json.Marshal(value)
+		_ = json.Unmarshal(data, &cr)
+		node.ContentRef = &cr
+		return
+	}
 }
 
 func (sm *StateMirror) applyRemove(segments []string) {
@@ -150,6 +157,10 @@ func (sm *StateMirror) applyFieldRemove(node *WireNode, fieldPath []string) {
 		node.Meta = nil
 		return
 	}
+	if len(fieldPath) == 1 && fieldPath[0] == "content_ref" {
+		node.ContentRef = nil
+		return
+	}
 }
 
 func (sm *StateMirror) applyReplace(segments []string, value any) {
@@ -189,6 +200,13 @@ func (sm *StateMirror) applyFieldReplace(node *WireNode, fieldPath []string, val
 		data, _ := json.Marshal(value)
 		_ = json.Unmarshal(data, &meta)
 		node.Meta = &meta
+		return
+	}
+	if len(fieldPath) == 1 && fieldPath[0] == "content_ref" {
+		var cr WireContentRef
+		data, _ := json.Marshal(value)
+		_ = json.Unmarshal(data, &cr)
+		node.ContentRef = &cr
 		return
 	}
 }

--- a/packages/go/slop-ai/state_mirror_test.go
+++ b/packages/go/slop-ai/state_mirror_test.go
@@ -1,0 +1,108 @@
+package slop
+
+import "testing"
+
+// Conformance: reserved field keywords (properties, meta, affordances,
+// content_ref) take precedence over child-id resolution in patch paths.
+// See spec/core/messages.md §patch-path-syntax.
+
+func makeMirror() *StateMirror {
+	tree := WireNode{
+		ID:   "root",
+		Type: "root",
+		Children: []WireNode{
+			{
+				ID:   "todos",
+				Type: "collection",
+				Children: []WireNode{
+					{ID: "t1", Type: "item", Properties: Props{"done": false}},
+				},
+			},
+		},
+	}
+	return NewStateMirror(tree, 1)
+}
+
+func TestAddAffordancesFieldRoutesToFieldNotChildren(t *testing.T) {
+	m := makeMirror()
+	m.ApplyPatch([]PatchOp{{
+		Op:    "add",
+		Path:  "/todos/t1/affordances",
+		Value: []any{map[string]any{"action": "cancel"}},
+	}}, 2)
+
+	t1 := m.Tree().Children[0].Children[0]
+	if len(t1.Affordances) != 1 || t1.Affordances[0].Action != "cancel" {
+		t.Fatalf("expected one affordance on t1, got %+v", t1.Affordances)
+	}
+	if len(t1.Children) != 0 {
+		t.Fatalf("field add must not create a child, got %d children", len(t1.Children))
+	}
+}
+
+func TestAddMetaFieldRoutesToFieldNotChildren(t *testing.T) {
+	m := makeMirror()
+	m.ApplyPatch([]PatchOp{{
+		Op:    "add",
+		Path:  "/todos/t1/meta",
+		Value: map[string]any{"summary": "done"},
+	}}, 2)
+
+	t1 := m.Tree().Children[0].Children[0]
+	if t1.Meta == nil || t1.Meta.Summary != "done" {
+		t.Fatalf("expected meta.summary=done on t1, got %+v", t1.Meta)
+	}
+	if len(t1.Children) != 0 {
+		t.Fatalf("field add must not create a child, got %d children", len(t1.Children))
+	}
+}
+
+func TestAddContentRefField(t *testing.T) {
+	m := makeMirror()
+	m.ApplyPatch([]PatchOp{{
+		Op:   "add",
+		Path: "/todos/t1/content_ref",
+		Value: map[string]any{
+			"type":    "text",
+			"mime":    "text/plain",
+			"summary": "42 bytes",
+		},
+	}}, 2)
+
+	t1 := m.Tree().Children[0].Children[0]
+	if t1.ContentRef == nil || t1.ContentRef.MIME != "text/plain" {
+		t.Fatalf("expected content_ref on t1, got %+v", t1.ContentRef)
+	}
+	if len(t1.Children) != 0 {
+		t.Fatalf("field add must not create a child, got %d children", len(t1.Children))
+	}
+}
+
+func TestRemoveContentRefField(t *testing.T) {
+	m := makeMirror()
+	m.tree.Children[0].Children[0].ContentRef = &WireContentRef{Type: "text", MIME: "text/plain", Summary: "x"}
+	m.ApplyPatch([]PatchOp{{
+		Op:   "remove",
+		Path: "/todos/t1/content_ref",
+	}}, 2)
+
+	t1 := m.Tree().Children[0].Children[0]
+	if t1.ContentRef != nil {
+		t.Fatalf("expected content_ref to be removed, got %+v", t1.ContentRef)
+	}
+}
+
+func TestNestedPropertyPathRoutesIntoProperties(t *testing.T) {
+	// Regression: isFieldPath scans all segments, not just the last.
+	m := makeMirror()
+	m.ApplyPatch([]PatchOp{{
+		Op:    "replace",
+		Path:  "/todos/t1/properties/done",
+		Value: true,
+	}}, 2)
+
+	t1 := m.Tree().Children[0].Children[0]
+	if v, _ := t1.Properties["done"].(bool); !v {
+		t.Fatalf("expected properties.done=true on t1, got %v", t1.Properties["done"])
+	}
+}

--- a/packages/python/slop-ai/src/slop_ai/state_mirror.py
+++ b/packages/python/slop-ai/src/slop_ai/state_mirror.py
@@ -77,10 +77,13 @@ class StateMirror:
         return (current, segments[-1])
 
     def _is_field_segment(self, segments: list[str]) -> bool:
-        """Check if the path targets a node field (not a child ID)."""
-        if len(segments) == 1:
-            return segments[0] in _NODE_FIELDS
-        for seg in segments[:-1]:
+        """Check if the path targets a node field (not a child ID).
+
+        A path is a field mutation if any segment is a reserved field
+        keyword — including the terminal segment (e.g. /<node>/affordances).
+        See spec/core/messages.md §patch-path-syntax.
+        """
+        for seg in segments:
             if seg in _NODE_FIELDS:
                 return True
         return False

--- a/packages/python/slop-ai/tests/test_state_mirror.py
+++ b/packages/python/slop-ai/tests/test_state_mirror.py
@@ -1,0 +1,85 @@
+"""StateMirror conformance tests — field-vs-child patch-path routing.
+
+Covers the cross-SDK contract from spec/core/messages.md §patch-path-syntax:
+reserved field keywords (`properties`, `meta`, `affordances`, `content_ref`)
+take precedence over child-id resolution.
+"""
+
+from __future__ import annotations
+
+from slop_ai.state_mirror import StateMirror
+
+
+def _snapshot() -> dict:
+    return {
+        "version": 1,
+        "tree": {
+            "id": "root",
+            "type": "root",
+            "properties": {"label": "App"},
+            "children": [
+                {
+                    "id": "todos",
+                    "type": "collection",
+                    "children": [
+                        {"id": "t1", "type": "item", "properties": {"done": False}},
+                    ],
+                }
+            ],
+        },
+    }
+
+
+def test_add_affordances_field_routes_to_field_not_children() -> None:
+    mirror = StateMirror(_snapshot())
+    mirror.apply_patch(
+        {
+            "version": 2,
+            "ops": [
+                {
+                    "op": "add",
+                    "path": "/todos/t1/affordances",
+                    "value": [{"action": "cancel"}],
+                }
+            ],
+        }
+    )
+    t1 = mirror.get_tree().children[0].children[0]
+    assert t1.affordances is not None and len(t1.affordances) == 1
+    # Must not have been pushed into children as a pseudo-child node.
+    assert not (t1.children or [])
+
+
+def test_add_meta_field_routes_to_field_not_children() -> None:
+    mirror = StateMirror(_snapshot())
+    mirror.apply_patch(
+        {
+            "version": 2,
+            "ops": [
+                {"op": "add", "path": "/todos/t1/meta", "value": {"summary": "done"}}
+            ],
+        }
+    )
+    t1 = mirror.get_tree().children[0].children[0]
+    assert t1.meta is not None
+    assert not (t1.children or [])
+
+
+def test_nested_property_path_routes_into_properties() -> None:
+    # Regression: isFieldSegment must scan all segments, not just the last —
+    # otherwise /<node>/properties/<nested>/<key> is mis-routed as a child op.
+    mirror = StateMirror(_snapshot())
+    mirror.apply_patch(
+        {
+            "version": 2,
+            "ops": [
+                {
+                    "op": "replace",
+                    "path": "/todos/t1/properties/done",
+                    "value": True,
+                }
+            ],
+        }
+    )
+    t1 = mirror.get_tree().children[0].children[0]
+    assert t1.properties["done"] is True

--- a/packages/rust/slop-ai/src/state_mirror.rs
+++ b/packages/rust/slop-ai/src/state_mirror.rs
@@ -72,6 +72,7 @@ fn apply_one(node: &mut SlopNode, segments: &[String], op: &PatchOpKind, value: 
         "properties" => apply_in_properties(node, rest, op, value),
         "meta" => apply_in_meta(node, rest, op, value),
         "affordances" => apply_in_affordances(node, rest, op, value),
+        "content_ref" => apply_in_content_ref(node, rest, op, value),
         // Any other segment is a child ID
         child_id => apply_in_children(node, child_id, rest, op, value),
     }
@@ -315,6 +316,33 @@ fn apply_in_affordances(
     }
 }
 
+// -- content_ref --
+
+fn apply_in_content_ref(
+    node: &mut SlopNode,
+    segments: &[String],
+    op: &PatchOpKind,
+    value: Option<&Value>,
+) {
+    // Only whole-field replace/add/remove is supported; deeper paths into
+    // ContentRef fields are uncommon and treated as no-ops.
+    if !segments.is_empty() {
+        return;
+    }
+    match op {
+        PatchOpKind::Replace | PatchOpKind::Add => {
+            if let Some(val) = value {
+                if let Ok(cr) = serde_json::from_value::<crate::types::ContentRef>(val.clone()) {
+                    node.content_ref = Some(cr);
+                }
+            }
+        }
+        PatchOpKind::Remove => {
+            node.content_ref = None;
+        }
+    }
+}
+
 // -- generic JSON value navigation --
 
 fn apply_in_value(
@@ -503,6 +531,98 @@ mod tests {
             2,
         );
         assert!(mirror.tree().meta.as_ref().unwrap().summary.is_none());
+    }
+
+    #[test]
+    fn test_add_content_ref_field() {
+        let mut mirror = StateMirror::new(make_tree(), 1);
+        mirror.apply_patch(
+            &[PatchOp {
+                op: PatchOpKind::Add,
+                path: "/counter/content_ref".into(),
+                value: Some(json!({
+                    "type": "text",
+                    "mime": "text/plain",
+                    "summary": "42 bytes"
+                })),
+            }],
+            2,
+        );
+        let counter = &mirror.tree().children.as_ref().unwrap()[0];
+        let cr = counter
+            .content_ref
+            .as_ref()
+            .expect("content_ref should be set on the node");
+        assert_eq!(cr.mime, "text/plain");
+        // Must not have been pushed into children as a pseudo-child node.
+        let children_len = counter
+            .children
+            .as_ref()
+            .map(|c| c.len())
+            .unwrap_or(0);
+        assert_eq!(children_len, 0);
+    }
+
+    #[test]
+    fn test_remove_content_ref_field() {
+        let mut tree = make_tree();
+        tree.children.as_mut().unwrap()[0].content_ref = Some(crate::types::ContentRef {
+            content_type: crate::types::ContentType::Text,
+            mime: "text/plain".into(),
+            summary: "x".into(),
+            size: None,
+            uri: None,
+            preview: None,
+            encoding: None,
+            hash: None,
+        });
+        let mut mirror = StateMirror::new(tree, 1);
+        mirror.apply_patch(
+            &[PatchOp {
+                op: PatchOpKind::Remove,
+                path: "/counter/content_ref".into(),
+                value: None,
+            }],
+            2,
+        );
+        let counter = &mirror.tree().children.as_ref().unwrap()[0];
+        assert!(counter.content_ref.is_none());
+    }
+
+    #[test]
+    fn test_field_keyword_routes_to_field_not_children() {
+        // Cross-SDK conformance: `/<node>/<field>` writes the field, never a child.
+        // Spec: field keywords (properties, meta, affordances, content_ref) take
+        // precedence over child-id resolution.
+        let mut mirror = StateMirror::new(make_tree(), 1);
+        mirror.apply_patch(
+            &[
+                PatchOp {
+                    op: PatchOpKind::Add,
+                    path: "/counter/affordances".into(),
+                    value: Some(json!([{"action": "cancel"}])),
+                },
+                PatchOp {
+                    op: PatchOpKind::Add,
+                    path: "/counter/meta".into(),
+                    value: Some(json!({"summary": "done"})),
+                },
+            ],
+            2,
+        );
+        let counter = &mirror.tree().children.as_ref().unwrap()[0];
+        assert_eq!(counter.affordances.as_ref().unwrap().len(), 1);
+        assert_eq!(
+            counter.meta.as_ref().and_then(|m| m.summary.as_deref()),
+            Some("done")
+        );
+        // No stray id-less "child" pushed into children.
+        let stray = counter
+            .children
+            .as_ref()
+            .map(|c| c.iter().any(|x| x.id.is_empty()))
+            .unwrap_or(false);
+        assert!(!stray, "field add must not create an id-less child");
     }
 
     #[test]

--- a/spec/core/messages.md
+++ b/spec/core/messages.md
@@ -148,6 +148,8 @@ Within `properties`, paths follow standard JSON Pointer key-based addressing. Th
 
 This design means patches are **stable across reordering** — moving a message from position 0 to position 5 does not invalidate paths that reference it by ID.
 
+**Reserved field keywords.** The segments `properties`, `children`, `affordances`, `meta`, and `content_ref` are **reserved**: when one appears as a segment while walking a node, the remaining path is interpreted relative to that field of the node rather than as a child-id lookup. A reserved keyword always takes precedence over child-id resolution, and node `id` values MUST NOT equal a reserved keyword (see [State Tree §id](./state-tree.md#id)). Once the path has descended into a non-node field (e.g. inside `properties` or `meta`), subsequent segments are plain JSON Pointer keys and the reservation no longer applies — a property literally named `properties` is addressed normally.
+
 **Version semantics:**
 - Versions are monotonically increasing integers, scoped to a subscription
 - The consumer can detect missed patches via version gaps

--- a/spec/core/state-tree.md
+++ b/spec/core/state-tree.md
@@ -33,6 +33,7 @@ A string that uniquely identifies a node within the tree. Must be stable across 
 - Unique among siblings (no two children of the same parent share an ID)
 - Stable across updates (the same logical entity keeps its ID)
 - Must not change when properties change
+- MUST NOT equal any reserved node-field keyword: `properties`, `children`, `affordances`, `meta`, `content_ref`, `id`, or `type`. These keywords have structural meaning in patch paths (see [Messages](./messages.md#patch-path-syntax)), so an id colliding with one is unaddressable.
 
 ### `type`
 

--- a/website/docs/src/content/docs/spec/core/messages.md
+++ b/website/docs/src/content/docs/spec/core/messages.md
@@ -149,6 +149,8 @@ Within `properties`, paths follow standard JSON Pointer key-based addressing. Th
 
 This design means patches are **stable across reordering** — moving a message from position 0 to position 5 does not invalidate paths that reference it by ID.
 
+**Reserved field keywords.** The segments `properties`, `children`, `affordances`, `meta`, and `content_ref` are **reserved**: when one appears as a segment while walking a node, the remaining path is interpreted relative to that field of the node rather than as a child-id lookup. A reserved keyword always takes precedence over child-id resolution, and node `id` values MUST NOT equal a reserved keyword (see [State Tree §id](/spec/core/state-tree#id)). Once the path has descended into a non-node field (e.g. inside `properties` or `meta`), subsequent segments are plain JSON Pointer keys and the reservation no longer applies — a property literally named `properties` is addressed normally.
+
 **Version semantics:**
 - Versions are monotonically increasing integers, scoped to a subscription
 - The consumer can detect missed patches via version gaps

--- a/website/docs/src/content/docs/spec/core/state-tree.md
+++ b/website/docs/src/content/docs/spec/core/state-tree.md
@@ -34,6 +34,7 @@ A string that uniquely identifies a node within the tree. Must be stable across 
 - Unique among siblings (no two children of the same parent share an ID)
 - Stable across updates (the same logical entity keeps its ID)
 - Must not change when properties change
+- MUST NOT equal any reserved node-field keyword: `properties`, `children`, `affordances`, `meta`, `content_ref`, `id`, or `type`. These keywords have structural meaning in patch paths (see [Messages](/spec/core/messages#patch-path-syntax)), so an id colliding with one is unaddressable.
 
 ### `type`
 


### PR DESCRIPTION
## Summary

- Codify in `spec/core/messages.md` §patch-path-syntax and `spec/core/state-tree.md` §id that `properties`, `children`, `affordances`, `meta`, and `content_ref` are **reserved field keywords** with precedence over child-id resolution, and that node `id` MUST NOT collide with any of them.
- Bring Python, Go, and Rust StateMirrors into line with the spec and with the TypeScript fix from 8a66ced:
  - **Python**: fix `_is_field_segment` so terminal-segment field paths (`/<node>/affordances`) route to the field, not children.
  - **Rust**: add `content_ref` arm to `apply_one` + handler.
  - **Go**: add `content_ref` arms to `applyField{Add,Remove,Replace}` (handlers were silent no-ops; `navigateTo` already recognized the keyword).
- Add cross-SDK conformance tests exercising field-vs-child routing for `affordances`, `meta`, `content_ref`, and nested property paths (Python, Go, Rust).

## Motivation

Spec-compliance audit of commit 8a66ced ("Fix StateMirror: route /<node>/<field> patch ops to the field, not children") found the spec never formally defined the field-vs-child precedence the SDKs rely on, and that Rust/Go silently dropped `content_ref` field ops while Python shared the pre-8a66ced TS bug. This PR closes both gaps.

## Test plan

- [x] `cd packages/rust/slop-ai && cargo test --lib state_mirror` → 11 passed
- [x] `cd packages/go/slop-ai && go test -run 'TestAdd|TestRemoveContentRef|TestNestedProperty'` → PASS
- [x] `cd packages/python/slop-ai && uv run --with pytest pytest tests/test_state_mirror.py` → 3 passed
- [ ] CI green on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)