### PR TITLE
feat: @slop-ai/mcp-apps-bridge — render SLOP inside MCP Apps hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ The full specification is in [`spec/`](./spec/):
 ### Guides
 
 - [Agent-Assisted Integration](./docs/guides/advanced/agent-scaffolding.md) — AI-powered SLOP scaffolding for existing codebases
+- [MCP Apps Bridge](./docs/guides/advanced/mcp-bridge.md) — render a SLOP provider inside VS Code / Claude / Goose with model-callable affordances
 - [OpenClaw Integration](./docs/guides/advanced/openclaw.md) — control SLOP apps from WhatsApp, Telegram, Slack via OpenClaw
 
 ## Benchmarks

--- a/bun.lock
+++ b/bun.lock
@@ -127,6 +127,7 @@
         "@slop-ai/consumer": "workspace:*",
         "@slop-ai/core": "workspace:*",
         "@slop-ai/mcp-apps-bridge": "workspace:*",
+        "@slop-ai/server": "workspace:*",
       },
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -354,13 +355,16 @@
         "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "@types/node": "^25.6.0",
+        "zod": "^3.25.0",
       },
       "peerDependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.12.0",
+        "zod": "^3.25.0",
       },
       "optionalPeers": [
         "@modelcontextprotocol/sdk",
+        "zod",
       ],
     },
     "packages/typescript/integrations/openclaw-plugin": {
@@ -2889,6 +2893,8 @@
     "@parcel/watcher/node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
     "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
+
+    "@slop-ai/mcp-apps-bridge/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -117,6 +117,22 @@
         "vitest": "^4.1.4",
       },
     },
+    "examples/mcp-apps-bridge": {
+      "name": "mcp-apps-bridge-demo",
+      "version": "0.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "@slop-ai/client": "workspace:*",
+        "@slop-ai/consumer": "workspace:*",
+        "@slop-ai/core": "workspace:*",
+        "@slop-ai/mcp-apps-bridge": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "typescript": "^6.0.3",
+      },
+    },
     "examples/spa/angular": {
       "name": "kanban-board-angular",
       "version": "0.1.0",
@@ -327,6 +343,25 @@
         "@types/node": "^25.6.0",
         "@types/ws": "^8.5.0",
       },
+    },
+    "packages/typescript/integrations/mcp-apps-bridge": {
+      "name": "@slop-ai/mcp-apps-bridge",
+      "version": "0.1.0",
+      "dependencies": {
+        "@slop-ai/consumer": "workspace:*",
+      },
+      "devDependencies": {
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "@types/node": "^25.6.0",
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
+        "@modelcontextprotocol/sdk": "^1.12.0",
+      },
+      "optionalPeers": [
+        "@modelcontextprotocol/sdk",
+      ],
     },
     "packages/typescript/integrations/openclaw-plugin": {
       "name": "@slop-ai/openclaw-plugin",
@@ -891,6 +926,8 @@
 
     "@mistralai/mistralai": ["@mistralai/mistralai@1.14.1", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.24.1" } }, "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ=="],
 
+    "@modelcontextprotocol/ext-apps": ["@modelcontextprotocol/ext-apps@1.7.0", "", { "dependencies": { "@standard-schema/spec": "^1.1.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.29.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-gs8rYVx6a8pyCvSpXq7TyVLTERCC94JLrcmJgBs0+3p4jp3iQdJPu1IU+2ovVdFZ1sW8JgmvTkRnxAlIizKINg=="],
+
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@mozilla/readability": ["@mozilla/readability@0.6.0", "", {}, "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ=="],
@@ -1156,6 +1193,8 @@
     "@slop-ai/core": ["@slop-ai/core@workspace:packages/typescript/sdk/core"],
 
     "@slop-ai/discovery": ["@slop-ai/discovery@workspace:packages/typescript/integrations/discovery"],
+
+    "@slop-ai/mcp-apps-bridge": ["@slop-ai/mcp-apps-bridge@workspace:packages/typescript/integrations/mcp-apps-bridge"],
 
     "@slop-ai/openclaw-plugin": ["@slop-ai/openclaw-plugin@workspace:packages/typescript/integrations/openclaw-plugin"],
 
@@ -2200,6 +2239,8 @@
     "matrix-js-sdk": ["matrix-js-sdk@41.2.0", "", { "dependencies": { "@babel/runtime": "^7.12.5", "@matrix-org/matrix-sdk-crypto-wasm": "^18.0.0", "another-json": "^0.2.0", "bs58": "^6.0.0", "content-type": "^1.0.4", "jwt-decode": "^4.0.0", "loglevel": "^1.9.2", "matrix-events-sdk": "0.0.1", "matrix-widget-api": "^1.16.1", "oidc-client-ts": "^3.0.1", "p-retry": "7", "sdp-transform": "^3.0.0", "unhomoglyph": "^1.0.6", "uuid": "13" } }, "sha512-kVLDKm/bUlwlHoDKRemshs27LCnOnNpmsVKtbCOM5F5D/E1SkrKldou+vQ/lk4PyXTvu9/qglkd2m0pBwJ5opg=="],
 
     "matrix-widget-api": ["matrix-widget-api@1.17.0", "", { "dependencies": { "@types/events": "^3.0.0", "events": "^3.2.0" } }, "sha512-5FHoo3iEP3Bdlv5jsYPWOqj+pGdFQNLWnJLiB0V7Ygne7bb+Gsj3ibyFyHWC6BVw+Z+tSW4ljHpO17I9TwStwQ=="],
+
+    "mcp-apps-bridge-demo": ["mcp-apps-bridge-demo@workspace:examples/mcp-apps-bridge"],
 
     "mcp-vs-slop-benchmark": ["mcp-vs-slop-benchmark@workspace:benchmarks/mcp-vs-slop"],
 

--- a/docs/guides/advanced/mcp-bridge.md
+++ b/docs/guides/advanced/mcp-bridge.md
@@ -1,93 +1,173 @@
 # MCP Apps Bridge
 
-Expose a SLOP provider inside an MCP Apps host (Claude, ChatGPT, Goose, VS Code) so an embedded SLOP consumer can subscribe to live state, project selected state into model context, and invoke affordances from the chat surface.
+Expose a SLOP provider inside an MCP Apps host (Claude, ChatGPT, Goose, VS Code Insiders) so the host model can subscribe to live state and call your app's affordances directly from chat.
 
-This guide is the developer-facing complement to the normative [MCP Interoperability](../../../spec/integrations/mcp.md) spec.
+The `@slop-ai/mcp-apps-bridge` package handles three things:
+
+- **Iframe-side bridge** — runs inside the sandboxed `ui://` view, opens a SLOP consumer, projects salience-filtered state into `app.updateModelContext`.
+- **`registerSlopView`** — server-side helper that wires the MCP tool + `ui://` resource + sandbox CSP.
+- **`registerSlopTools`** — server-side helper that mirrors every SLOP affordance as a callable MCP tool, with `tools/listChanged` resync on every patch.
+
+This guide is the developer-facing complement to the normative [MCP Interoperability spec](../../../spec/integrations/mcp.md). For an end-to-end runnable example, see [`examples/mcp-apps-bridge`](https://github.com/devteapot/slop/tree/main/examples/mcp-apps-bridge).
 
 ## When to use this
 
-Use the MCP Apps bridge when:
+- Your users interact with SLOP-aware apps through a chat UI (Claude / VS Code chat / Goose / etc.) and you want the model to both *observe* state and *act* on it inside the same conversation.
+- You already have a SLOP provider — adding the bridge is a server file plus an iframe bundle.
 
-- Your users interact with SLOP-aware apps through Claude or ChatGPT rather than a standalone SLOP consumer.
-- You want a single integration that reaches MCP Apps hosts without implementing each host's UI extension API separately.
-- You already have a SLOP provider and do not want to rewrite it as an MCP tool server.
+If your target host doesn't support MCP Apps yet, use the [Claude Code integration](./claude-code.md) (proxy pattern) instead.
 
-Use the [MCP proxy](./claude-code.md) instead when your target host doesn't support MCP Apps yet, or when you want a flat tool catalog rather than live state.
-
-## How it works
-
-MCP Apps lets an MCP tool return a `ui://` resource. The host fetches it and renders it in a sandboxed iframe, wiring a JSON-RPC channel over `postMessage`. That `postMessage` channel is already a [native SLOP transport](../../../spec/core/transport.md#postmessage-convention), so the bridge is a thin multiplexer.
+## Architecture
 
 ```
-MCP host ──► open_slop_view tool
-                │
-                ▼
-        iframe (ui://slop/...)
-        ├── @slop-ai/spa consumer
-        └── SLOP provider (in-iframe OR WS relay)
+┌─ host (VS Code Insiders / Claude / Goose) ─────────────────────────┐
+│                                                                     │
+│   MCP client ──stdio──▶ MCP server                                  │
+│        │                  │                                          │
+│        │                  ├── SLOP provider (yours)                 │
+│        │                  │                                          │
+│        │                  ├── registerSlopView  ── tool + ui://     │
+│        │                  └── registerSlopTools ── one MCP tool     │
+│        │                                              per affordance │
+│        ▼                                                             │
+│   sandboxed iframe (open_*your_view*)                                │
+│        │                                                             │
+│        └── createMcpAppsBridge ──ws──▶ same SLOP provider           │
+│              ├── consumer mirrors tree                               │
+│              ├── projector → app.updateModelContext (debounced)     │
+│              └── you render UI from consumer.getTree()              │
+└─────────────────────────────────────────────────────────────────────┘
 ```
 
-Inside the iframe, SLOP frames carry `{ slop: true, message }`. MCP Apps frames don't. The adapter routes on that field.
+A single Node process typically hosts the SLOP provider, the MCP server, and the WS endpoint. The iframe is a thin client.
 
-## Minimum integration
+## Server: register the view + the tools
 
-1. **Expose one MCP Apps tool** whose sole job is to open the view:
+```ts
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  registerSlopView,
+  registerSlopTools,
+} from "@slop-ai/mcp-apps-bridge/server";
+import { createSlopServer } from "@slop-ai/server";
+import { bunHandler } from "@slop-ai/server/bun";
+import { readFile } from "node:fs/promises";
 
-   ```ts
-   import {
-     RESOURCE_MIME_TYPE,
-     registerAppResource,
-     registerAppTool,
-   } from "@modelcontextprotocol/ext-apps/server";
-   import { readFile } from "node:fs/promises";
+const PORT = 7411;
+const slop = createSlopServer({ id: "kanban", name: "Kanban" });
+// register your nodes + actions on slop ...
 
-   const resourceUri = "ui://your-app/slop";
+// Expose the SLOP provider over WebSocket (Bun example; use attachSlop for Node).
+const slopHandler = bunHandler(slop, { path: "/slop" });
+Bun.serve({
+  port: PORT,
+  hostname: "127.0.0.1",
+  fetch(req, srv) {
+    return slopHandler.fetch(req, srv) ?? new Response("ok");
+  },
+  websocket: slopHandler.websocket,
+});
 
-   registerAppTool(
-     server,
-     "open_slop_view",
-     {
-       description: "Open a live view of your app state",
-       inputSchema: {},
-       _meta: { ui: { resourceUri } },
-     },
-     async () => ({ content: [] }),
-   );
+const RESOURCE_URI = "ui://my-app/view";
+const mcp = new McpServer(
+  { name: "my-app", version: "0.1.0" },
+  { capabilities: { tools: { listChanged: true }, resources: {} } },
+);
 
-   registerAppResource(
-     server,
-     "SLOP View",
-     resourceUri,
-     {},
-     async () => {
-       const html = await readFile(new URL("./dist/slop.html", import.meta.url), "utf8");
-       return {
-         contents: [{ uri: resourceUri, mimeType: RESOURCE_MIME_TYPE, text: html }],
-       };
-     },
-   );
-   ```
+registerSlopView(mcp, {
+  toolName: "open_kanban",
+  description: "Open a live view of the kanban board",
+  resourceUri: RESOURCE_URI,
+  resourceName: "Kanban View",
+  html: () => readFile(new URL("./dist/iframe.html", import.meta.url), "utf8"),
+  // CRITICAL for sandboxed hosts: whitelist the SLOP provider's WS origin.
+  // Without this, VS Code's webview blocks the iframe's WS connection.
+  connectDomains: [`ws://127.0.0.1:${PORT}`],
+});
 
-   `registerAppResource`'s second argument is a display name for the host. The `RESOURCE_MIME_TYPE` default is supplied by the helper, so the metadata object can be empty; it's still set explicitly on the returned `contents[]` so the host sees the MCP Apps MIME type.
+await registerSlopTools(mcp, {
+  url: `ws://127.0.0.1:${PORT}/slop`,
+  uiResourceUri: RESOURCE_URI, // tags every tool with the iframe surface
+});
 
-2. **Serve the UI resource** as a static HTML bundle that loads `@slop-ai/spa` (for in-iframe providers) or `@slop-ai/consumer` + a WebSocket relay (for remote providers).
+await mcp.connect(new StdioServerTransport());
+```
 
-3. **Project state into the model** by calling `app.updateModelContext()` with a salience-filtered snapshot whenever the SLOP consumer receives a meaningful snapshot or patch. Do not ship raw trees — the model's context window is limited; use `min_salience` on the subscription and debounce updates.
+What `registerSlopTools` does: connects to the SLOP provider as a consumer, walks the affordances via `affordancesToTools`, and registers one MCP tool per `(action, schema)` group (so 1000 cards each with a `delete` affordance produce **one** `delete` MCP tool with a `target` parameter, not 1000). Resyncs on every patch and emits `tools/listChanged`.
 
-4. **Route invocations** from the UI to the SLOP provider. If you want the model itself to call affordances, expose each affordance as an MCP tool on the server and forward the invocation through the iframe.
+## Iframe: render + project
+
+The iframe bundle is plain HTML/JS served by `registerSlopView`. Bundle it however you like (Bun, Vite, esbuild) — the demo uses a single-file HTML wrapper.
+
+```ts
+import { createMcpAppsBridge } from "@slop-ai/mcp-apps-bridge";
+import type { SlopNode } from "@slop-ai/consumer/browser";
+
+const bridge = await createMcpAppsBridge({
+  provider: { mode: "ws", url: "ws://127.0.0.1:7411/slop" },
+  subscribe: { depth: -1, minSalience: 0.3 },
+  projection: { header: "# Kanban — live state from the iframe" },
+});
+
+// Render UI from the consumer's mirrored tree.
+function render(tree: SlopNode | null) { /* your DOM updates */ }
+render(bridge.getTree());
+bridge.consumer.on("patch", () => render(bridge.getTree()));
+```
+
+The bridge's other mode is `{ mode: "postmessage" }` for client-only setups where the SLOP provider runs inside the iframe via `@slop-ai/client`. Use `ws` mode whenever there's a server-side authoritative state.
+
+## Provider modes
+
+| Mode | When to use | Tradeoffs |
+|---|---|---|
+| `ws` | Server-side authoritative state. The MCP server, SLOP provider, and tool-registering consumer all run in one process. | Requires `connectDomains` for sandboxed hosts. The architecture every non-toy app wants. |
+| `postmessage` | Client-only / no backend. SLOP provider lives in the iframe via `@slop-ai/client`. | Model can't act on state via `registerSlopTools` (server has no consumer to discover affordances from). State is iframe-local. |
+
+## How the model sees state
+
+The bridge calls `app.updateModelContext` with a debounced markdown projection of the salience-filtered tree on every snapshot/patch. The projection includes the state tree (via `formatTree`) **and** the affordance list (via `affordancesToTools`). The model receives this in context on the *next* turn after the iframe opens — so the very first response after `open_*` won't see state yet, but every subsequent turn will.
+
+To validate: open the view, then ask a question whose answer depends on tree contents. The model should answer without making another tool call.
+
+## Caveats and known gotchas
+
+- **Sandboxed network.** Hosts like VS Code's webview default to "no network." If you don't pass `connectDomains` to `registerSlopView`, your `ws` iframe will silently fail to connect. The bridge surfaces this as `error: WebSocket connection failed` in the iframe status line if you wrap `createMcpAppsBridge` in a try/catch.
+- **First-turn latency.** `app.updateModelContext` lands asynchronously after the tool returns. The model that just called `open_*` won't see state until its next turn.
+- **Tool descriptions inline param info.** The MCP SDK only accepts Zod schemas for `inputSchema`, not raw JSON Schema. `registerSlopTools` works around this with a permissive passthrough schema and stuffs the SLOP affordance's params + valid `target` paths into the tool *description*. The model handles this fine; future versions will convert SLOP JSON Schema → Zod for proper validation.
+- **`tools/list_changed` is chatty.** Currently fires once per patch resync; in apps with high patch frequency, consider widening the bridge's resync debounce (PRs welcome).
+- **Big trees flood context.** The default projection ships the entire salience-filtered tree as markdown on every patch. For apps with thousands of nodes use a stricter `subscribe.minSalience` and a custom `projection.format` that summarizes rather than emits every node. See the [scaling extension](../../../spec/extensions/scaling.md).
 
 ## Security
 
 The host's iframe sandbox and user-consent prompts are defense in depth. They are **not** the authorization boundary. Your SLOP provider must re-authorize every affordance invocation against live state and caller identity, exactly as it would for a direct WebSocket consumer.
 
-For remote providers, the iframe's WebSocket relay should use a short-lived token minted by your backend for that app session. Do not put provider bearer tokens into MCP tool `content`, `structuredContent`, or any model-visible context. Keep iframe origins and CSP as narrow as the host allows.
+For remote providers (production), use a short-lived token in the WS URL minted per-session by your backend. Don't put bearer tokens in MCP tool `content` or anywhere model-visible — they end up in conversation transcripts.
 
-## Limitations
+## Validating in real hosts
 
-- **No native model-visible SLOP subscription.** MCP resources can support change subscriptions, and Streamable HTTP can carry server-to-client notifications, but MCP Apps still require explicit model-context updates. Debounce `updateModelContext` — every call consumes context tokens.
-- **No cross-tool affordances.** An affordance triggered from the UI runs through the bridge, not as a first-class MCP tool call, so the model doesn't see it in its tool trace. If you want the model to invoke affordances, publish them as MCP tools as well.
-- **Host support is uneven.** MCP Apps shipped in January 2026. Older MCP hosts fall back to rendering the tool's text result; ship a plain-text summary alongside the `ui://` resource for graceful degradation.
+The smoke test we use:
+
+1. Build the demo: `cd examples/mcp-apps-bridge && bun run build`.
+2. Register the server in **VS Code Insiders** (Cmd+Shift+P → `MCP: Open User Configuration`):
+   ```jsonc
+   {
+     "servers": {
+       "slop-kanban": {
+         "type": "stdio",
+         "command": "bun",
+         "args": ["<absolute-path-to>/dist/server.js"]
+       }
+     }
+   }
+   ```
+3. Reload the window, open Copilot Chat, ask: `Use the open_kanban tool`. The iframe should render with status `connected`.
+4. Ask: `What cards are in todo?` — model should answer without another tool call.
+5. Ask: `Add a card called "Ship it" to todo` — the model calls `add_card`, the iframe re-renders, and the next turn's context reflects the new card.
+
+If the iframe shows `error: WebSocket connection failed`, the most common cause is missing `connectDomains` (or VS Code holding a cached MCP server connection — Stop + Start the server in `MCP: List Servers`).
 
 ## Future direction
 
-If MCP standardizes event-driven resource updates or a SLOP-specific extension, the bridge can move from `updateModelContext` projections to a direct `slop/subscribe` stream over MCP. See the [MCP extension future work entry](../../../spec/limitations.md#no-formal-mcp-extension) for the planned SEP.
+When MCP standardizes event-driven resource subscriptions (tracked in the [2026 roadmap](https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/)), the bridge will offer a third `mode: "mcp-tunnel"` that doesn't require the iframe to open a WebSocket — all SLOP traffic flows over MCP's own subscription channel. Until then, `ws` + `connectDomains` is the recommended pattern. See the ["No formal MCP extension" entry](../../../spec/limitations.md#no-formal-mcp-extension) for the planned SEP.

--- a/docs/guides/advanced/mcp-bridge.md
+++ b/docs/guides/advanced/mcp-bridge.md
@@ -8,7 +8,7 @@ The `@slop-ai/mcp-apps-bridge` package handles three things:
 - **`registerSlopView`** — server-side helper that wires the MCP tool + `ui://` resource + sandbox CSP.
 - **`registerSlopTools`** — server-side helper that mirrors every SLOP affordance as a callable MCP tool, with `tools/listChanged` resync on every patch.
 
-For an end-to-end runnable example, see [`examples/mcp-apps-bridge`](https://github.com/devteapot/slop/tree/main/examples/mcp-apps-bridge).
+This guide is the developer-facing complement to the normative [MCP Interoperability spec](../../../spec/integrations/mcp.md). For an end-to-end runnable example, see [`examples/mcp-apps-bridge`](https://github.com/devteapot/slop/tree/main/examples/mcp-apps-bridge).
 
 ## When to use this
 
@@ -170,4 +170,4 @@ If the iframe shows `error: WebSocket connection failed`, the most common cause 
 
 ## Future direction
 
-When MCP standardizes event-driven resource subscriptions (tracked in the [2026 roadmap](https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/)), the bridge will offer a third `mode: "mcp-tunnel"` that doesn't require the iframe to open a WebSocket — all SLOP traffic flows over MCP's own subscription channel. Until then, `ws` + `connectDomains` is the recommended pattern.
+When MCP standardizes event-driven resource subscriptions (tracked in the [2026 roadmap](https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/)), the bridge will offer a third `mode: "mcp-tunnel"` that doesn't require the iframe to open a WebSocket — all SLOP traffic flows over MCP's own subscription channel. Until then, `ws` + `connectDomains` is the recommended pattern. See the ["No formal MCP extension" entry](../../../spec/limitations.md#no-formal-mcp-extension) for the planned SEP.

--- a/docs/guides/advanced/mcp-bridge.md
+++ b/docs/guides/advanced/mcp-bridge.md
@@ -8,7 +8,7 @@ The `@slop-ai/mcp-apps-bridge` package handles three things:
 - **`registerSlopView`** — server-side helper that wires the MCP tool + `ui://` resource + sandbox CSP.
 - **`registerSlopTools`** — server-side helper that mirrors every SLOP affordance as a callable MCP tool, with `tools/listChanged` resync on every patch.
 
-This guide is the developer-facing complement to the normative [MCP Interoperability spec](../../../spec/integrations/mcp.md). For an end-to-end runnable example, see [`examples/mcp-apps-bridge`](https://github.com/devteapot/slop/tree/main/examples/mcp-apps-bridge).
+For an end-to-end runnable example, see [`examples/mcp-apps-bridge`](https://github.com/devteapot/slop/tree/main/examples/mcp-apps-bridge).
 
 ## When to use this
 
@@ -170,4 +170,4 @@ If the iframe shows `error: WebSocket connection failed`, the most common cause 
 
 ## Future direction
 
-When MCP standardizes event-driven resource subscriptions (tracked in the [2026 roadmap](https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/)), the bridge will offer a third `mode: "mcp-tunnel"` that doesn't require the iframe to open a WebSocket — all SLOP traffic flows over MCP's own subscription channel. Until then, `ws` + `connectDomains` is the recommended pattern. See the ["No formal MCP extension" entry](../../../spec/limitations.md#no-formal-mcp-extension) for the planned SEP.
+When MCP standardizes event-driven resource subscriptions (tracked in the [2026 roadmap](https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/)), the bridge will offer a third `mode: "mcp-tunnel"` that doesn't require the iframe to open a WebSocket — all SLOP traffic flows over MCP's own subscription channel. Until then, `ws` + `connectDomains` is the recommended pattern.

--- a/examples/mcp-apps-bridge/README.md
+++ b/examples/mcp-apps-bridge/README.md
@@ -1,0 +1,40 @@
+# mcp-apps-bridge demo
+
+End-to-end example: a stdio MCP server exposing a single `open_kanban` tool. The tool opens a sandboxed iframe (served as a `ui://` resource) that runs an in-iframe SLOP provider + `@slop-ai/mcp-apps-bridge`. Subscribing, snapshots, patches, and affordance invocations all round-trip through the bridge; salience-filtered markdown projections reach the host model via `app.updateModelContext`.
+
+## Build & run
+
+```bash
+bun install
+bun run build
+```
+
+## Connect a host
+
+**MCP Inspector** (quickest smoke test):
+
+```bash
+bunx @modelcontextprotocol/inspector bun dist/server.js
+```
+
+**VS Code Insiders** — in `settings.json`:
+
+```jsonc
+"mcp.servers": {
+  "slop-kanban": {
+    "command": "bun",
+    "args": ["<absolute-path-to-dist>/server.js"]
+  }
+}
+```
+
+**Goose** — add the same command to your Goose MCP config.
+
+Call the `open_kanban` tool from the host's chat. The iframe renders the kanban and the model starts receiving state updates (debounced markdown projections).
+
+## What to look for
+
+- The iframe visibly renders three columns with two initial cards.
+- After the host connects, `app.updateModelContext` fires: the model context now contains `# Kanban — live state from the iframe` followed by a state + actions block.
+- Asking the model "what cards are in doing?" answers correctly without any tool call — state arrives via context.
+- Toggling/deleting a card in the iframe triggers a patch → debounced re-projection → updated context on the next model turn.

--- a/examples/mcp-apps-bridge/README.md
+++ b/examples/mcp-apps-bridge/README.md
@@ -1,40 +1,84 @@
 # mcp-apps-bridge demo
 
-End-to-end example: a stdio MCP server exposing a single `open_kanban` tool. The tool opens a sandboxed iframe (served as a `ui://` resource) that runs an in-iframe SLOP provider + `@slop-ai/mcp-apps-bridge`. Subscribing, snapshots, patches, and affordance invocations all round-trip through the bridge; salience-filtered markdown projections reach the host model via `app.updateModelContext`.
+End-to-end example of a SLOP provider rendered inside an MCP Apps host (Claude / VS Code Insiders / Goose).
+
+A single Node process runs three things:
+
+1. **A SLOP provider** over WebSocket on `:7411/slop` (kanban state in `@slop-ai/server`).
+2. **An MCP server** over stdio that:
+   - Exposes `open_kanban`, an MCP Apps tool returning the iframe.
+   - Mirrors every SLOP affordance as a callable MCP tool via `registerSlopTools`, so the model can act on the board from chat (not just observe it).
+3. **The iframe bundle** (`dist/iframe.html`) — a thin SLOP consumer wired to `@slop-ai/mcp-apps-bridge`. Subscribes to the same WS provider and pushes salience-filtered markdown projections into `app.updateModelContext`.
 
 ## Build & run
 
 ```bash
 bun install
 bun run build
+realpath dist/server.js  # absolute path for host configs below
 ```
+
+Override the WS port with `SLOP_PORT=…` if `7411` is taken; the iframe URL inside `src/app.ts` must match.
 
 ## Connect a host
 
-**MCP Inspector** (quickest smoke test):
+**MCP Inspector** — fastest smoke test:
 
 ```bash
 bunx @modelcontextprotocol/inspector bun dist/server.js
 ```
 
-**VS Code Insiders** — in `settings.json`:
+**VS Code Insiders** — `MCP: Open User Configuration` (Cmd+Shift+P) and add:
 
 ```jsonc
-"mcp.servers": {
-  "slop-kanban": {
-    "command": "bun",
-    "args": ["<absolute-path-to-dist>/server.js"]
+{
+  "servers": {
+    "slop-kanban": {
+      "type": "stdio",
+      "command": "bun",
+      "args": ["<absolute-path-to>/dist/server.js"]
+    }
   }
 }
 ```
 
-**Goose** — add the same command to your Goose MCP config.
+Reload window, then in chat: `Use the open_kanban tool to show me the board.`
 
-Call the `open_kanban` tool from the host's chat. The iframe renders the kanban and the model starts receiving state updates (debounced markdown projections).
+**Goose** — `~/.config/goose/config.yaml`:
+
+```yaml
+extensions:
+  slop-kanban:
+    type: stdio
+    cmd: bun
+    args: ["<absolute-path-to>/dist/server.js"]
+    enabled: true
+```
 
 ## What to look for
 
-- The iframe visibly renders three columns with two initial cards.
-- After the host connects, `app.updateModelContext` fires: the model context now contains `# Kanban — live state from the iframe` followed by a state + actions block.
-- Asking the model "what cards are in doing?" answers correctly without any tool call — state arrives via context.
-- Toggling/deleting a card in the iframe triggers a patch → debounced re-projection → updated context on the next model turn.
+- The iframe renders three columns with two initial cards.
+- The model receives `# Kanban — live state from the iframe` in context the next turn — ask "what cards are in doing?" and it answers without making another tool call.
+- The model can act: ask "add a card called 'Ship it' to todo" — it calls `add_card` with `{ target: "/todo", title: "Ship it" }`, the SLOP provider updates, the iframe re-renders, and the next turn's context reflects the new card.
+- `tools/list_changed` notifications fire as state evolves; the model's available tool list stays in sync with affordances on the live tree.
+
+## Architecture
+
+```
+┌─ host process (VS Code / Goose / etc.) ─────────────────────┐
+│                                                              │
+│   MCP client ──stdio─▶ MCP server (this demo)                │
+│        │                  │                                   │
+│        │                  ├── @slop-ai/server  ◀──ws──┐       │
+│        │                  │   (kanban state)          │       │
+│        │                  └── registerSlopTools  ◀────┘       │
+│        │                      (one MCP tool per affordance)   │
+│        ▼                                                      │
+│   sandboxed iframe (open_kanban)                              │
+│        │                                                      │
+│        └── @slop-ai/mcp-apps-bridge ──ws──▶ same SLOP server  │
+│              ├── consumer mirrors tree                         │
+│              ├── projector → app.updateModelContext           │
+│              └── UI renders from consumer.getTree()           │
+└──────────────────────────────────────────────────────────────┘
+```

--- a/examples/mcp-apps-bridge/package.json
+++ b/examples/mcp-apps-bridge/package.json
@@ -6,7 +6,7 @@
   "description": "Demo MCP Apps server that serves a sandboxed iframe backed by a SLOP provider via @slop-ai/mcp-apps-bridge.",
   "scripts": {
     "build:iframe": "bun run scripts/build-iframe.ts",
-    "build:server": "bun build src/server.ts --outdir dist --format esm --target node --external '@modelcontextprotocol/*'",
+    "build:server": "bun build src/server.ts --outdir dist --format esm --target node --external '@modelcontextprotocol/*' --external '@slop-ai/*' --external 'ws'",
     "build": "bun run build:iframe && bun run build:server",
     "start": "bun dist/server.js",
     "dev": "bun run build && bun dist/server.js"
@@ -17,7 +17,8 @@
     "@slop-ai/client": "workspace:*",
     "@slop-ai/consumer": "workspace:*",
     "@slop-ai/core": "workspace:*",
-    "@slop-ai/mcp-apps-bridge": "workspace:*"
+    "@slop-ai/mcp-apps-bridge": "workspace:*",
+    "@slop-ai/server": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/examples/mcp-apps-bridge/package.json
+++ b/examples/mcp-apps-bridge/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "mcp-apps-bridge-demo",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Demo MCP Apps server that serves a sandboxed iframe backed by a SLOP provider via @slop-ai/mcp-apps-bridge.",
+  "scripts": {
+    "build:iframe": "bun run scripts/build-iframe.ts",
+    "build:server": "bun build src/server.ts --outdir dist --format esm --target node --external '@modelcontextprotocol/*'",
+    "build": "bun run build:iframe && bun run build:server",
+    "start": "bun dist/server.js",
+    "dev": "bun run build && bun dist/server.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "@slop-ai/client": "workspace:*",
+    "@slop-ai/consumer": "workspace:*",
+    "@slop-ai/core": "workspace:*",
+    "@slop-ai/mcp-apps-bridge": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/examples/mcp-apps-bridge/scripts/build-iframe.ts
+++ b/examples/mcp-apps-bridge/scripts/build-iframe.ts
@@ -1,0 +1,51 @@
+// Bundle src/app.ts into a single inlined HTML file under dist/iframe.html.
+// That file is served verbatim as the `ui://` resource by the MCP server.
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const outDir = join(import.meta.dir, "..", "dist");
+const entry = join(import.meta.dir, "..", "src", "app.ts");
+
+const built = await Bun.build({
+  entrypoints: [entry],
+  target: "browser",
+  format: "esm",
+  minify: true,
+});
+
+if (!built.success) {
+  console.error(built.logs);
+  process.exit(1);
+}
+
+const jsArtifact = built.outputs.find((o) => o.kind === "entry-point");
+if (!jsArtifact) throw new Error("bun build produced no entry-point output");
+const js = await jsArtifact.text();
+
+const html = `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>SLOP — Kanban</title>
+    <style>
+      body { font-family: system-ui, sans-serif; margin: 0; padding: 16px; background: #0f172a; color: #f1f5f9; }
+      h1 { font-size: 18px; margin: 0 0 12px; }
+      .cols { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+      .col { background: #1e293b; border-radius: 8px; padding: 12px; }
+      .col h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.08em; color: #94a3b8; margin: 0 0 8px; }
+      .col ul { list-style: none; padding: 0; margin: 0; }
+      .col li { background: #334155; padding: 8px 10px; border-radius: 6px; margin-bottom: 6px; font-size: 13px; }
+      .col li.done { text-decoration: line-through; opacity: 0.6; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module">${js}</script>
+  </body>
+</html>
+`;
+
+await mkdir(outDir, { recursive: true });
+await writeFile(join(outDir, "iframe.html"), html, "utf8");
+console.log(`wrote ${outDir}/iframe.html (${html.length} bytes)`);

--- a/examples/mcp-apps-bridge/scripts/build-iframe.ts
+++ b/examples/mcp-apps-bridge/scripts/build-iframe.ts
@@ -40,7 +40,9 @@ const html = `<!doctype html>
     </style>
   </head>
   <body>
-    <div id="root"></div>
+    <h1>Kanban — SLOP inside MCP Apps</h1>
+    <div id="status" style="font-size: 11px; opacity: 0.6; margin-bottom: 8px;">booting…</div>
+    <div id="board"></div>
     <script type="module">${js}</script>
   </body>
 </html>

--- a/examples/mcp-apps-bridge/src/app.ts
+++ b/examples/mcp-apps-bridge/src/app.ts
@@ -1,99 +1,57 @@
 // Iframe bundle — runs inside the sandboxed MCP Apps view.
 //
-// 1. Boots a tiny in-iframe SLOP provider via @slop-ai/client (postMessage transport).
-// 2. Uses @slop-ai/mcp-apps-bridge to consume it and push salience-filtered
-//    markdown projections into the host model through ext-apps' App.
+// Connects (over WebSocket) to the SLOP provider that the MCP server hosts in
+// the same process. The bridge handles the model-context projection; this file
+// only renders the visible UI from the consumer's mirrored tree.
 
-import { createSlop, action } from "@slop-ai/client";
 import { createMcpAppsBridge } from "@slop-ai/mcp-apps-bridge";
+import type { SlopNode } from "@slop-ai/consumer/browser";
 
-type Card = { id: string; title: string; done: boolean };
-type Column = { id: "todo" | "doing" | "done"; title: string; cards: Card[] };
-
-const state: { columns: Column[] } = {
-  columns: [
-    { id: "todo", title: "Todo", cards: [{ id: "c1", title: "Wire bridge", done: false }] },
-    { id: "doing", title: "Doing", cards: [{ id: "c2", title: "Write demo", done: false }] },
-    { id: "done", title: "Done", cards: [] },
-  ],
-};
-
-const slop = createSlop({ id: "mcp-apps-bridge-demo", name: "MCP Apps Bridge Demo" });
-
-function registerAll() {
-  for (const col of state.columns) {
-    slop.register(col.id, {
-      type: "group",
-      props: { title: col.title, count: col.cards.length },
-      meta: { salience: col.cards.length > 0 ? 0.8 : 0.4 },
-      actions: {
-        add_card: action(
-          { title: "string" } as const,
-          ({ title }) => {
-            col.cards.push({ id: `c${Date.now()}`, title, done: false });
-            registerAll();
-            renderUI();
-          },
-          { label: `Add card to ${col.title}` },
-        ),
-      },
-      items: col.cards.map((c) => ({
-        id: c.id,
-        props: { title: c.title, done: c.done },
-        meta: { salience: c.done ? 0.3 : 0.7 },
-        actions: {
-          toggle: action(
-            () => {
-              c.done = !c.done;
-              registerAll();
-              renderUI();
-            },
-            { idempotent: true, label: "Toggle done" },
-          ),
-          delete: action(
-            () => {
-              col.cards = col.cards.filter((x) => x.id !== c.id);
-              registerAll();
-              renderUI();
-            },
-            { dangerous: true, label: "Delete" },
-          ),
-        },
-      })),
-    });
-  }
-}
-
-function renderUI() {
-  const root = document.getElementById("root");
-  if (!root) return;
-  root.innerHTML = `
-    <h1>Kanban — SLOP inside MCP Apps</h1>
-    <div class="cols">
-      ${state.columns
-        .map(
-          (col) => `
-        <div class="col">
-          <h2>${col.title} (${col.cards.length})</h2>
-          <ul>${col.cards
-            .map((c) => `<li class="${c.done ? "done" : ""}">${escape(c.title)}</li>`)
-            .join("")}</ul>
-        </div>`,
-        )
-        .join("")}
-    </div>`;
-}
+const SLOP_URL = "ws://127.0.0.1:7411/slop";
 
 function escape(s: string): string {
   return s.replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c]!);
 }
 
-registerAll();
-renderUI();
+function render(tree: SlopNode | null): void {
+  const root = document.getElementById("root");
+  if (!root) return;
+  if (!tree) {
+    root.innerHTML = `<p>Connecting to SLOP provider…</p>`;
+    return;
+  }
+  const cols = tree.children ?? [];
+  root.innerHTML = `
+    <h1>Kanban — SLOP inside MCP Apps</h1>
+    <div class="cols">
+      ${cols
+        .map((col) => {
+          const title = (col.properties?.title as string) ?? col.id;
+          const items = col.children ?? [];
+          return `
+            <div class="col">
+              <h2>${escape(title)} (${items.length})</h2>
+              <ul>
+                ${items
+                  .map((c) => {
+                    const cardTitle = (c.properties?.title as string) ?? c.id;
+                    const done = c.properties?.done === true;
+                    return `<li class="${done ? "done" : ""}">${escape(cardTitle)}</li>`;
+                  })
+                  .join("")}
+              </ul>
+            </div>`;
+        })
+        .join("")}
+    </div>`;
+}
 
-void createMcpAppsBridge({
-  provider: { mode: "postmessage" },
+const bridge = await createMcpAppsBridge({
+  provider: { mode: "ws", url: SLOP_URL },
   subscribe: { depth: -1, minSalience: 0.3 },
   projection: { header: "# Kanban — live state from the iframe" },
-  appInfo: { name: "mcp-apps-bridge-demo", version: "0.1.0" },
+  appInfo: { name: "mcp-apps-bridge-demo", version: "0.1.1" },
 });
+
+render(bridge.getTree());
+bridge.consumer.on("patch", () => render(bridge.getTree()));

--- a/examples/mcp-apps-bridge/src/app.ts
+++ b/examples/mcp-apps-bridge/src/app.ts
@@ -1,0 +1,99 @@
+// Iframe bundle — runs inside the sandboxed MCP Apps view.
+//
+// 1. Boots a tiny in-iframe SLOP provider via @slop-ai/client (postMessage transport).
+// 2. Uses @slop-ai/mcp-apps-bridge to consume it and push salience-filtered
+//    markdown projections into the host model through ext-apps' App.
+
+import { createSlop, action } from "@slop-ai/client";
+import { createMcpAppsBridge } from "@slop-ai/mcp-apps-bridge";
+
+type Card = { id: string; title: string; done: boolean };
+type Column = { id: "todo" | "doing" | "done"; title: string; cards: Card[] };
+
+const state: { columns: Column[] } = {
+  columns: [
+    { id: "todo", title: "Todo", cards: [{ id: "c1", title: "Wire bridge", done: false }] },
+    { id: "doing", title: "Doing", cards: [{ id: "c2", title: "Write demo", done: false }] },
+    { id: "done", title: "Done", cards: [] },
+  ],
+};
+
+const slop = createSlop({ id: "mcp-apps-bridge-demo", name: "MCP Apps Bridge Demo" });
+
+function registerAll() {
+  for (const col of state.columns) {
+    slop.register(col.id, {
+      type: "group",
+      props: { title: col.title, count: col.cards.length },
+      meta: { salience: col.cards.length > 0 ? 0.8 : 0.4 },
+      actions: {
+        add_card: action(
+          { title: "string" } as const,
+          ({ title }) => {
+            col.cards.push({ id: `c${Date.now()}`, title, done: false });
+            registerAll();
+            renderUI();
+          },
+          { label: `Add card to ${col.title}` },
+        ),
+      },
+      items: col.cards.map((c) => ({
+        id: c.id,
+        props: { title: c.title, done: c.done },
+        meta: { salience: c.done ? 0.3 : 0.7 },
+        actions: {
+          toggle: action(
+            () => {
+              c.done = !c.done;
+              registerAll();
+              renderUI();
+            },
+            { idempotent: true, label: "Toggle done" },
+          ),
+          delete: action(
+            () => {
+              col.cards = col.cards.filter((x) => x.id !== c.id);
+              registerAll();
+              renderUI();
+            },
+            { dangerous: true, label: "Delete" },
+          ),
+        },
+      })),
+    });
+  }
+}
+
+function renderUI() {
+  const root = document.getElementById("root");
+  if (!root) return;
+  root.innerHTML = `
+    <h1>Kanban — SLOP inside MCP Apps</h1>
+    <div class="cols">
+      ${state.columns
+        .map(
+          (col) => `
+        <div class="col">
+          <h2>${col.title} (${col.cards.length})</h2>
+          <ul>${col.cards
+            .map((c) => `<li class="${c.done ? "done" : ""}">${escape(c.title)}</li>`)
+            .join("")}</ul>
+        </div>`,
+        )
+        .join("")}
+    </div>`;
+}
+
+function escape(s: string): string {
+  return s.replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c]!);
+}
+
+registerAll();
+renderUI();
+
+void createMcpAppsBridge({
+  provider: { mode: "postmessage" },
+  subscribe: { depth: -1, minSalience: 0.3 },
+  projection: { header: "# Kanban — live state from the iframe" },
+  appInfo: { name: "mcp-apps-bridge-demo", version: "0.1.0" },
+});

--- a/examples/mcp-apps-bridge/src/app.ts
+++ b/examples/mcp-apps-bridge/src/app.ts
@@ -4,12 +4,12 @@
 // the same process. The bridge handles the model-context projection; this file
 // only renders the visible UI from the consumer's mirrored tree.
 
-import { createMcpAppsBridge } from "@slop-ai/mcp-apps-bridge";
 import type { SlopNode } from "@slop-ai/consumer/browser";
+import { createMcpAppsBridge } from "@slop-ai/mcp-apps-bridge";
 
 const SLOP_URL = "ws://127.0.0.1:7411/slop";
 
-function escape(s: string): string {
+function escapeHtml(s: string): string {
   return s.replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c]!);
 }
 
@@ -38,13 +38,13 @@ function render(tree: SlopNode | null): void {
           const items = col.children ?? [];
           return `
             <div class="col">
-              <h2>${escape(title)} (${items.length})</h2>
+              <h2>${escapeHtml(title)} (${items.length})</h2>
               <ul>
                 ${items
                   .map((c) => {
                     const cardTitle = (c.properties?.title as string) ?? c.id;
                     const done = c.properties?.done === true;
-                    return `<li class="${done ? "done" : ""}">${escape(cardTitle)}</li>`;
+                    return `<li class="${done ? "done" : ""}">${escapeHtml(cardTitle)}</li>`;
                   })
                   .join("")}
               </ul>

--- a/examples/mcp-apps-bridge/src/app.ts
+++ b/examples/mcp-apps-bridge/src/app.ts
@@ -13,16 +13,24 @@ function escape(s: string): string {
   return s.replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c]!);
 }
 
+function setStatus(text: string): void {
+  const status = document.getElementById("status");
+  if (status) status.textContent = text;
+}
+
 function render(tree: SlopNode | null): void {
-  const root = document.getElementById("root");
+  const root = document.getElementById("board");
   if (!root) return;
   if (!tree) {
-    root.innerHTML = `<p>Connecting to SLOP provider…</p>`;
+    root.innerHTML = `<p style="opacity:.6">waiting for snapshot…</p>`;
     return;
   }
   const cols = tree.children ?? [];
+  if (cols.length === 0) {
+    root.innerHTML = `<p style="opacity:.6">tree present but no columns yet (root has no children)</p>`;
+    return;
+  }
   root.innerHTML = `
-    <h1>Kanban — SLOP inside MCP Apps</h1>
     <div class="cols">
       ${cols
         .map((col) => {
@@ -46,12 +54,23 @@ function render(tree: SlopNode | null): void {
     </div>`;
 }
 
-const bridge = await createMcpAppsBridge({
-  provider: { mode: "ws", url: SLOP_URL },
-  subscribe: { depth: -1, minSalience: 0.3 },
-  projection: { header: "# Kanban — live state from the iframe" },
-  appInfo: { name: "mcp-apps-bridge-demo", version: "0.1.1" },
-});
+// Render the shell immediately so the iframe is never visually blank, even if
+// the WS connect hangs or throws.
+render(null);
+setStatus("connecting…");
 
-render(bridge.getTree());
-bridge.consumer.on("patch", () => render(bridge.getTree()));
+try {
+  const bridge = await createMcpAppsBridge({
+    provider: { mode: "ws", url: SLOP_URL },
+    subscribe: { depth: -1, minSalience: 0.3 },
+    projection: { header: "# Kanban — live state from the iframe" },
+    appInfo: { name: "mcp-apps-bridge-demo", version: "0.1.1" },
+  });
+
+  setStatus("connected");
+  render(bridge.getTree());
+  bridge.consumer.on("patch", () => render(bridge.getTree()));
+} catch (err) {
+  setStatus(`error: ${err instanceof Error ? err.message : String(err)}`);
+  console.error("[mcp-apps-bridge-demo] bridge init failed:", err);
+}

--- a/examples/mcp-apps-bridge/src/server.ts
+++ b/examples/mcp-apps-bridge/src/server.ts
@@ -1,0 +1,28 @@
+// Minimal MCP server (stdio) for the mcp-apps-bridge demo.
+// Exposes a single tool `open_kanban` that opens the SLOP-powered kanban iframe.
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerSlopView } from "@slop-ai/mcp-apps-bridge/server";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const iframePath = join(here, "iframe.html");
+
+const server = new McpServer(
+  { name: "mcp-apps-bridge-demo", version: "0.1.0" },
+  { capabilities: { tools: {}, resources: {} } },
+);
+
+registerSlopView(server, {
+  toolName: "open_kanban",
+  description: "Open a live view of the SLOP-backed kanban board",
+  resourceUri: "ui://mcp-apps-bridge-demo/kanban",
+  resourceName: "Kanban View",
+  html: () => readFile(iframePath, "utf8"),
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/examples/mcp-apps-bridge/src/server.ts
+++ b/examples/mcp-apps-bridge/src/server.ts
@@ -5,17 +5,14 @@
 // - registerSlopTools mirrors the SLOP affordances as MCP tools, so the
 //   model can act on the board from chat (not just observe it).
 
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-  registerSlopTools,
-  registerSlopView,
-} from "@slop-ai/mcp-apps-bridge/server";
-import { createSlopServer, action } from "@slop-ai/server";
+import { registerSlopTools, registerSlopView } from "@slop-ai/mcp-apps-bridge/server";
+import { action, createSlopServer } from "@slop-ai/server";
 import { bunHandler } from "@slop-ai/server/bun";
-import { readFile } from "node:fs/promises";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
 
 // --- SLOP provider (server-side state) -------------------------------------
 

--- a/examples/mcp-apps-bridge/src/server.ts
+++ b/examples/mcp-apps-bridge/src/server.ts
@@ -107,6 +107,9 @@ registerSlopView(mcp, {
   resourceUri: RESOURCE_URI,
   resourceName: "Kanban View",
   html: () => readFile(iframePath, "utf8"),
+  // Sandboxed iframes (VS Code webview, etc.) block all network by default.
+  // Whitelist the local SLOP provider so the iframe can subscribe over WS.
+  connectDomains: [`ws://127.0.0.1:${PORT}`],
 });
 
 await registerSlopTools(mcp, {

--- a/examples/mcp-apps-bridge/src/server.ts
+++ b/examples/mcp-apps-bridge/src/server.ts
@@ -1,28 +1,117 @@
-// Minimal MCP server (stdio) for the mcp-apps-bridge demo.
-// Exposes a single tool `open_kanban` that opens the SLOP-powered kanban iframe.
+// Single-process demo:
+// - Bun.serve hosts a SLOP provider over WebSocket on /slop.
+// - The same process runs an MCP stdio server.
+// - registerSlopView exposes `open_kanban` (the iframe surface).
+// - registerSlopTools mirrors the SLOP affordances as MCP tools, so the
+//   model can act on the board from chat (not just observe it).
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { registerSlopView } from "@slop-ai/mcp-apps-bridge/server";
+import {
+  registerSlopTools,
+  registerSlopView,
+} from "@slop-ai/mcp-apps-bridge/server";
+import { createSlopServer, action } from "@slop-ai/server";
+import { bunHandler } from "@slop-ai/server/bun";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
+// --- SLOP provider (server-side state) -------------------------------------
+
+type Card = { id: string; title: string; done: boolean };
+type Column = { id: "todo" | "doing" | "done"; title: string; cards: Card[] };
+
+const state: { columns: Column[] } = {
+  columns: [
+    { id: "todo", title: "Todo", cards: [{ id: "c1", title: "Wire bridge", done: false }] },
+    { id: "doing", title: "Doing", cards: [{ id: "c2", title: "Write demo", done: false }] },
+    { id: "done", title: "Done", cards: [] },
+  ],
+};
+
+const slop = createSlopServer({ id: "mcp-apps-bridge-demo", name: "MCP Apps Bridge Demo" });
+
+function registerAll() {
+  for (const col of state.columns) {
+    slop.register(col.id, () => ({
+      type: "group",
+      props: { title: col.title, count: col.cards.length },
+      meta: { salience: col.cards.length > 0 ? 0.8 : 0.4 },
+      actions: {
+        add_card: action(
+          { title: "string" } as const,
+          ({ title }) => {
+            col.cards.push({ id: `c${Date.now()}`, title, done: false });
+            registerAll();
+          },
+          { label: `Add card to ${col.title}` },
+        ),
+      },
+      items: col.cards.map((c) => ({
+        id: c.id,
+        props: { title: c.title, done: c.done },
+        meta: { salience: c.done ? 0.3 : 0.7 },
+        actions: {
+          toggle: action(
+            () => {
+              c.done = !c.done;
+              registerAll();
+            },
+            { idempotent: true, label: "Toggle done" },
+          ),
+          delete: action(
+            () => {
+              col.cards = col.cards.filter((x) => x.id !== c.id);
+              registerAll();
+            },
+            { dangerous: true, label: "Delete" },
+          ),
+        },
+      })),
+    }));
+  }
+}
+registerAll();
+
+// --- WS transport -----------------------------------------------------------
+
+const PORT = Number(process.env.SLOP_PORT ?? 7411);
+const slopHandler = bunHandler(slop as never, { path: "/slop" });
+
+Bun.serve({
+  port: PORT,
+  hostname: "127.0.0.1",
+  fetch(req, srv) {
+    const resp = slopHandler.fetch(req, srv);
+    if (resp) return resp;
+    return new Response("ok");
+  },
+  websocket: slopHandler.websocket,
+});
+
+// --- MCP server -------------------------------------------------------------
+
 const here = dirname(fileURLToPath(import.meta.url));
 const iframePath = join(here, "iframe.html");
+const RESOURCE_URI = "ui://mcp-apps-bridge-demo/kanban";
 
-const server = new McpServer(
-  { name: "mcp-apps-bridge-demo", version: "0.1.0" },
-  { capabilities: { tools: {}, resources: {} } },
+const mcp = new McpServer(
+  { name: "mcp-apps-bridge-demo", version: "0.1.1" },
+  { capabilities: { tools: { listChanged: true }, resources: {} } },
 );
 
-registerSlopView(server, {
+registerSlopView(mcp, {
   toolName: "open_kanban",
   description: "Open a live view of the SLOP-backed kanban board",
-  resourceUri: "ui://mcp-apps-bridge-demo/kanban",
+  resourceUri: RESOURCE_URI,
   resourceName: "Kanban View",
   html: () => readFile(iframePath, "utf8"),
 });
 
-const transport = new StdioServerTransport();
-await server.connect(transport);
+await registerSlopTools(mcp, {
+  url: `ws://127.0.0.1:${PORT}/slop`,
+  uiResourceUri: RESOURCE_URI,
+});
+
+await mcp.connect(new StdioServerTransport());

--- a/examples/mcp-apps-bridge/tsconfig.json
+++ b/examples/mcp-apps-bridge/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "lib": ["ES2022", "DOM"],
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src", "scripts"]
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "examples/full-stack/*",
     "examples/full-stack/*/frontend",
     "examples/desktop/*",
+    "examples/mcp-apps-bridge",
     "website/playground",
     "apps/extension",
     "apps/desktop",

--- a/packages/typescript/integrations/mcp-apps-bridge/README.md
+++ b/packages/typescript/integrations/mcp-apps-bridge/README.md
@@ -1,0 +1,37 @@
+# @slop-ai/mcp-apps-bridge
+
+Render a SLOP provider inside an MCP Apps iframe.
+
+The bridge demultiplexes the sandboxed iframe's `postMessage` channel between MCP Apps (ext-apps `App`) and SLOP (snapshots, patches, invocations), then projects salience-filtered state into `app.updateModelContext()` so the host model sees what the user sees.
+
+See the [MCP Apps Bridge guide](https://docs.slopai.dev/guides/advanced/mcp-bridge/) for usage and the [MCP Interoperability spec](https://docs.slopai.dev/spec/integrations/mcp/) for the protocol-level contract.
+
+## Install
+
+```bash
+bun add @slop-ai/mcp-apps-bridge @modelcontextprotocol/ext-apps
+```
+
+## Iframe
+
+```ts
+import { createMcpAppsBridge } from "@slop-ai/mcp-apps-bridge";
+
+const bridge = await createMcpAppsBridge({
+  provider: { mode: "ws", url: "ws://localhost:3737/slop" },
+  subscribe: { depth: -1, minSalience: 0.3 },
+});
+```
+
+## MCP server
+
+```ts
+import { registerSlopView } from "@slop-ai/mcp-apps-bridge/server";
+
+registerSlopView(server, {
+  toolName: "open_kanban",
+  description: "Live kanban board",
+  resourceUri: "ui://kanban/slop",
+  html: await readFile(new URL("./dist/slop.html", import.meta.url), "utf8"),
+});
+```

--- a/packages/typescript/integrations/mcp-apps-bridge/README.md
+++ b/packages/typescript/integrations/mcp-apps-bridge/README.md
@@ -33,5 +33,11 @@ registerSlopView(server, {
   description: "Live kanban board",
   resourceUri: "ui://kanban/slop",
   html: await readFile(new URL("./dist/slop.html", import.meta.url), "utf8"),
+  // Required when the iframe in `ws` mode runs in a sandboxed host (VS Code,
+  // Claude). Whitelists the origins the iframe is allowed to reach. Must
+  // include the SLOP provider URL above.
+  connectDomains: ["ws://localhost:3737"],
 });
 ```
+
+Pair with `registerSlopTools(server, { url })` if you also want the model to invoke SLOP affordances directly from chat. See the [full guide](https://docs.slopai.dev/guides/advanced/mcp-bridge/) for the complete setup including the WS provider process.

--- a/packages/typescript/integrations/mcp-apps-bridge/README.md
+++ b/packages/typescript/integrations/mcp-apps-bridge/README.md
@@ -4,7 +4,7 @@ Render a SLOP provider inside an MCP Apps iframe.
 
 The bridge demultiplexes the sandboxed iframe's `postMessage` channel between MCP Apps (ext-apps `App`) and SLOP (snapshots, patches, invocations), then projects salience-filtered state into `app.updateModelContext()` so the host model sees what the user sees.
 
-See the [MCP Apps Bridge guide](https://docs.slopai.dev/guides/advanced/mcp-bridge/) for usage and the [MCP Interoperability spec](https://docs.slopai.dev/spec/integrations/mcp/) for the protocol-level contract.
+See the [MCP Apps Bridge guide](https://docs.slopai.dev/guides/advanced/mcp-bridge/) for end-to-end setup, and the [demo](https://github.com/devteapot/slop/tree/main/examples/mcp-apps-bridge) for a runnable reference.
 
 ## Install
 

--- a/packages/typescript/integrations/mcp-apps-bridge/README.md
+++ b/packages/typescript/integrations/mcp-apps-bridge/README.md
@@ -4,7 +4,7 @@ Render a SLOP provider inside an MCP Apps iframe.
 
 The bridge demultiplexes the sandboxed iframe's `postMessage` channel between MCP Apps (ext-apps `App`) and SLOP (snapshots, patches, invocations), then projects salience-filtered state into `app.updateModelContext()` so the host model sees what the user sees.
 
-See the [MCP Apps Bridge guide](https://docs.slopai.dev/guides/advanced/mcp-bridge/) for end-to-end setup, and the [demo](https://github.com/devteapot/slop/tree/main/examples/mcp-apps-bridge) for a runnable reference.
+See the [MCP Apps Bridge guide](https://docs.slopai.dev/guides/advanced/mcp-bridge/) for end-to-end setup, the [MCP Interoperability spec](https://docs.slopai.dev/spec/integrations/mcp/) for the protocol-level contract, and the [demo](https://github.com/devteapot/slop/tree/main/examples/mcp-apps-bridge) for a runnable reference.
 
 ## Install
 

--- a/packages/typescript/integrations/mcp-apps-bridge/__tests__/init-cleanup.test.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/__tests__/init-cleanup.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import { connectBoth, type DisposableApp, type DisposableConsumer } from "../src/init-cleanup";
+
+interface Spy<T> {
+  value: T;
+  calls: number;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function makeConsumer(connect: () => Promise<unknown>): DisposableConsumer & {
+  disconnects: Spy<number>;
+} {
+  const disconnects: Spy<number> = { value: 0, calls: 0 };
+  return {
+    connect,
+    disconnect() {
+      disconnects.value += 1;
+      disconnects.calls += 1;
+    },
+    disconnects,
+  };
+}
+
+function makeApp(connect: () => Promise<unknown>): DisposableApp & {
+  closes: Spy<number>;
+} {
+  const closes: Spy<number> = { value: 0, calls: 0 };
+  return {
+    connect,
+    async close() {
+      closes.value += 1;
+      closes.calls += 1;
+    },
+    closes,
+  };
+}
+
+describe("connectBoth", () => {
+  test("resolves when both connects succeed; nothing torn down", async () => {
+    const c = makeConsumer(() => Promise.resolve());
+    const a = makeApp(() => Promise.resolve());
+    await connectBoth(c, a);
+    expect(c.disconnects.value).toBe(0);
+    expect(a.closes.value).toBe(0);
+  });
+
+  test("consumer rejects fast; later-resolving app is torn down (the race)", async () => {
+    const appGate = deferred<void>();
+    const c = makeConsumer(() => Promise.reject(new Error("ws refused")));
+    const a = makeApp(() => appGate.promise);
+
+    const init = connectBoth(c, a);
+    // Resolve the app side AFTER consumer rejection has propagated.
+    queueMicrotask(() => appGate.resolve());
+
+    await expect(init).rejects.toThrow("ws refused");
+    // The late-successful app must close itself, not leak.
+    expect(a.closes.value).toBe(1);
+    expect(c.disconnects.value).toBe(0);
+  });
+
+  test("app rejects fast; later-resolving consumer is torn down", async () => {
+    const consumerGate = deferred<void>();
+    const c = makeConsumer(() => consumerGate.promise);
+    const a = makeApp(() => Promise.reject(new Error("ext-apps init failed")));
+
+    const init = connectBoth(c, a);
+    queueMicrotask(() => consumerGate.resolve());
+
+    await expect(init).rejects.toThrow("ext-apps init failed");
+    expect(c.disconnects.value).toBe(1);
+    expect(a.closes.value).toBe(0);
+  });
+
+  test("both reject; nothing to tear down", async () => {
+    const c = makeConsumer(() => Promise.reject(new Error("a")));
+    const a = makeApp(() => Promise.reject(new Error("b")));
+    await expect(connectBoth(c, a)).rejects.toBeDefined();
+    expect(c.disconnects.value).toBe(0);
+    expect(a.closes.value).toBe(0);
+  });
+
+  test("consumer fails after app already connected; app is torn down", async () => {
+    const consumerGate = deferred<void>();
+    const c = makeConsumer(() => consumerGate.promise);
+    const a = makeApp(() => Promise.resolve());
+
+    const init = connectBoth(c, a);
+    // Let the app's resolution + flag flip propagate, then fail the consumer.
+    await Promise.resolve();
+    consumerGate.reject(new Error("late ws fail"));
+
+    await expect(init).rejects.toThrow("late ws fail");
+    // App connected before consumer failed → catch handler tears it down.
+    expect(a.closes.value).toBe(1);
+  });
+});

--- a/packages/typescript/integrations/mcp-apps-bridge/__tests__/projection.test.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/__tests__/projection.test.ts
@@ -1,0 +1,96 @@
+import { describe, test, expect } from "bun:test";
+import { createProjector, renderMarkdown } from "../src/projection";
+import type { SlopNode } from "@slop-ai/consumer";
+
+const tree: SlopNode = {
+  id: "root",
+  type: "root",
+  children: [
+    {
+      id: "col-1",
+      type: "group",
+      properties: { name: "Todo" },
+      affordances: [{ action: "add_card", label: "Add card" }],
+      meta: { salience: 0.9 },
+    },
+  ],
+};
+
+describe("renderMarkdown", () => {
+  test("emits state + actions sections", () => {
+    const out = renderMarkdown(tree);
+    expect(out).toContain("### State");
+    expect(out).toContain("### Actions");
+    expect(out).toContain("add_card");
+  });
+
+  test("prepends header when provided", () => {
+    const out = renderMarkdown(tree, "# Kanban");
+    expect(out.startsWith("# Kanban")).toBe(true);
+  });
+
+  test("handles trees with no affordances", () => {
+    const bare: SlopNode = { id: "x", type: "leaf" };
+    const out = renderMarkdown(bare);
+    expect(out).toContain("_no actions available_");
+  });
+});
+
+describe("createProjector", () => {
+  test("coalesces rapid schedules into one apply", async () => {
+    let calls = 0;
+    let lastText = "";
+    const projector = createProjector(
+      (t) => {
+        calls += 1;
+        lastText = t;
+      },
+      { debounceMs: 20 },
+    );
+
+    for (let i = 0; i < 10; i++) projector.schedule(tree);
+    expect(calls).toBe(0);
+
+    await new Promise((r) => setTimeout(r, 40));
+    expect(calls).toBe(1);
+    expect(lastText).toContain("### State");
+    projector.dispose();
+  });
+
+  test("flush runs pending projection synchronously", () => {
+    let calls = 0;
+    const projector = createProjector((_t) => {
+      calls += 1;
+    }, { debounceMs: 1000 });
+
+    projector.schedule(tree);
+    expect(calls).toBe(0);
+    projector.flush();
+    expect(calls).toBe(1);
+    projector.dispose();
+  });
+
+  test("custom format function overrides markdown", () => {
+    let payload = "";
+    const projector = createProjector((t) => {
+      payload = t;
+    }, { debounceMs: 0, format: (t) => `raw:${t.id}` });
+
+    projector.schedule(tree);
+    projector.flush();
+    expect(payload).toBe("raw:root");
+    projector.dispose();
+  });
+
+  test("dispose cancels pending projection", async () => {
+    let calls = 0;
+    const projector = createProjector(() => {
+      calls += 1;
+    }, { debounceMs: 10 });
+
+    projector.schedule(tree);
+    projector.dispose();
+    await new Promise((r) => setTimeout(r, 30));
+    expect(calls).toBe(0);
+  });
+});

--- a/packages/typescript/integrations/mcp-apps-bridge/__tests__/projection.test.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/__tests__/projection.test.ts
@@ -1,6 +1,6 @@
-import { describe, test, expect } from "bun:test";
-import { createProjector, renderMarkdown } from "../src/projection";
+import { describe, expect, test } from "bun:test";
 import type { SlopNode } from "@slop-ai/consumer";
+import { createProjector, renderMarkdown } from "../src/projection";
 
 const tree: SlopNode = {
   id: "root",
@@ -59,9 +59,12 @@ describe("createProjector", () => {
 
   test("flush runs pending projection synchronously", () => {
     let calls = 0;
-    const projector = createProjector((_t) => {
-      calls += 1;
-    }, { debounceMs: 1000 });
+    const projector = createProjector(
+      (_t) => {
+        calls += 1;
+      },
+      { debounceMs: 1000 },
+    );
 
     projector.schedule(tree);
     expect(calls).toBe(0);
@@ -72,9 +75,12 @@ describe("createProjector", () => {
 
   test("custom format function overrides markdown", () => {
     let payload = "";
-    const projector = createProjector((t) => {
-      payload = t;
-    }, { debounceMs: 0, format: (t) => `raw:${t.id}` });
+    const projector = createProjector(
+      (t) => {
+        payload = t;
+      },
+      { debounceMs: 0, format: (t) => `raw:${t.id}` },
+    );
 
     projector.schedule(tree);
     projector.flush();
@@ -84,9 +90,12 @@ describe("createProjector", () => {
 
   test("dispose cancels pending projection", async () => {
     let calls = 0;
-    const projector = createProjector(() => {
-      calls += 1;
-    }, { debounceMs: 10 });
+    const projector = createProjector(
+      () => {
+        calls += 1;
+      },
+      { debounceMs: 10 },
+    );
 
     projector.schedule(tree);
     projector.dispose();

--- a/packages/typescript/integrations/mcp-apps-bridge/__tests__/transport-pm.test.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/__tests__/transport-pm.test.ts
@@ -1,6 +1,6 @@
-import { describe, test, expect, beforeEach } from "bun:test";
-import { SameWindowPostMessageTransport } from "../src/transport-pm";
+import { beforeEach, describe, expect, test } from "bun:test";
 import type { SlopMessage } from "@slop-ai/consumer";
+import { SameWindowPostMessageTransport } from "../src/transport-pm";
 
 // Minimal browser shim — Bun test runs in Node, so we stand up a synthetic
 // `window` + `MessageEvent` surface that mirrors what the transport uses.

--- a/packages/typescript/integrations/mcp-apps-bridge/__tests__/transport-pm.test.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/__tests__/transport-pm.test.ts
@@ -1,0 +1,95 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { SameWindowPostMessageTransport } from "../src/transport-pm";
+import type { SlopMessage } from "@slop-ai/consumer";
+
+// Minimal browser shim — Bun test runs in Node, so we stand up a synthetic
+// `window` + `MessageEvent` surface that mirrors what the transport uses.
+type Listener = (event: { source: unknown; data: unknown }) => void;
+
+class FakeWindow {
+  listeners: Listener[] = [];
+  posted: { data: unknown; origin: string }[] = [];
+
+  addEventListener(type: string, fn: Listener) {
+    if (type === "message") this.listeners.push(fn);
+  }
+  removeEventListener(type: string, fn: Listener) {
+    if (type !== "message") return;
+    const i = this.listeners.indexOf(fn);
+    if (i >= 0) this.listeners.splice(i, 1);
+  }
+  postMessage(data: unknown, origin: string) {
+    this.posted.push({ data, origin });
+  }
+  dispatchFromSource(source: unknown, data: unknown) {
+    for (const fn of this.listeners) fn({ source, data });
+  }
+}
+
+let fakeWindow: FakeWindow;
+
+beforeEach(() => {
+  fakeWindow = new FakeWindow();
+  (globalThis as any).window = fakeWindow;
+});
+
+describe("SameWindowPostMessageTransport", () => {
+  test("wraps outgoing messages in { slop: true, message }", async () => {
+    const transport = new SameWindowPostMessageTransport({
+      targetWindow: fakeWindow as unknown as Window,
+    });
+    const conn = await transport.connect();
+    // connect sends a handshake
+    expect(fakeWindow.posted[0]?.data).toEqual({
+      slop: true,
+      message: { type: "connect" },
+    });
+
+    const invoke: SlopMessage = { type: "invoke", id: "1", path: "/", action: "ping" };
+    conn.send(invoke);
+    expect(fakeWindow.posted.at(-1)?.data).toEqual({ slop: true, message: invoke });
+  });
+
+  test("only delivers frames with slop:true; ignores MCP Apps JSON-RPC frames", async () => {
+    const transport = new SameWindowPostMessageTransport({
+      targetWindow: fakeWindow as unknown as Window,
+    });
+    const conn = await transport.connect();
+
+    const received: SlopMessage[] = [];
+    conn.onMessage((m) => received.push(m));
+
+    // MCP Apps-style JSON-RPC frame — should be ignored.
+    fakeWindow.dispatchFromSource(fakeWindow, {
+      jsonrpc: "2.0",
+      method: "ui/initialize",
+      params: {},
+    });
+    // SLOP frame from wrong source window — ignored.
+    fakeWindow.dispatchFromSource({}, { slop: true, message: { type: "hello" } });
+    // SLOP frame from correct source — delivered.
+    const hello = {
+      type: "hello",
+      provider: {
+        id: "p",
+        name: "P",
+        slop_version: "0.1",
+        capabilities: ["state"],
+      },
+    };
+    fakeWindow.dispatchFromSource(fakeWindow, { slop: true, message: hello });
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toEqual(hello as SlopMessage);
+  });
+
+  test("close() detaches the message listener", async () => {
+    const transport = new SameWindowPostMessageTransport({
+      targetWindow: fakeWindow as unknown as Window,
+    });
+    const conn = await transport.connect();
+    expect(fakeWindow.listeners).toHaveLength(1);
+    conn.close();
+    expect(fakeWindow.listeners).toHaveLength(0);
+  });
+});

--- a/packages/typescript/integrations/mcp-apps-bridge/package.json
+++ b/packages/typescript/integrations/mcp-apps-bridge/package.json
@@ -26,7 +26,7 @@
     "directory": "packages/typescript/integrations/mcp-apps-bridge"
   },
   "scripts": {
-    "build": "bun build src/index.ts src/server.ts --outdir dist --format esm --target browser --external '@slop-ai/*' --external '@modelcontextprotocol/*' && bunx tsc --emitDeclarationOnly --outDir dist",
+    "build": "bun build src/index.ts src/server.ts --outdir dist --format esm --target browser --external '@slop-ai/*' --external '@modelcontextprotocol/*' --external 'zod' && bunx tsc --emitDeclarationOnly --outDir dist",
     "clean": "rm -rf dist"
   },
   "dependencies": {
@@ -34,14 +34,17 @@
   },
   "peerDependencies": {
     "@modelcontextprotocol/ext-apps": "^1.7.0",
-    "@modelcontextprotocol/sdk": "^1.12.0"
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "zod": "^3.25.0"
   },
   "peerDependenciesMeta": {
-    "@modelcontextprotocol/sdk": { "optional": true }
+    "@modelcontextprotocol/sdk": { "optional": true },
+    "zod": { "optional": true }
   },
   "devDependencies": {
     "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.12.0",
-    "@types/node": "^25.6.0"
+    "@types/node": "^25.6.0",
+    "zod": "^3.25.0"
   }
 }

--- a/packages/typescript/integrations/mcp-apps-bridge/package.json
+++ b/packages/typescript/integrations/mcp-apps-bridge/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@slop-ai/mcp-apps-bridge",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Render a SLOP provider inside an MCP Apps iframe. Bridges the ext-apps postMessage channel to a SLOP consumer and projects state into model context.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./server": {
+      "import": "./dist/server.js",
+      "types": "./dist/server.d.ts"
+    }
+  },
+  "files": ["src", "dist"],
+  "sideEffects": false,
+  "license": "MIT",
+  "homepage": "https://docs.slopai.dev/guides/advanced/mcp-bridge",
+  "bugs": "https://github.com/devteapot/slop/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/devteapot/slop",
+    "directory": "packages/typescript/integrations/mcp-apps-bridge"
+  },
+  "scripts": {
+    "build": "bun build src/index.ts src/server.ts --outdir dist --format esm --target browser --external '@slop-ai/*' --external '@modelcontextprotocol/*' && bunx tsc --emitDeclarationOnly --outDir dist",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@slop-ai/consumer": "workspace:*"
+  },
+  "peerDependencies": {
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
+    "@modelcontextprotocol/sdk": "^1.12.0"
+  },
+  "peerDependenciesMeta": {
+    "@modelcontextprotocol/sdk": { "optional": true }
+  },
+  "devDependencies": {
+    "@modelcontextprotocol/ext-apps": "^1.7.0",
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "@types/node": "^25.6.0"
+  }
+}

--- a/packages/typescript/integrations/mcp-apps-bridge/src/bridge.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/src/bridge.ts
@@ -75,27 +75,45 @@ export async function createMcpAppsBridge(
   const transport = buildTransport(options.provider);
   const consumer = new SlopConsumer(transport);
 
-  // Track connection state for partial-failure cleanup. Promise.all rejects
-  // when *either* side fails, but the other side may have already connected
-  // — leaking the open WebSocket and/or the postMessage listeners. The same
-  // applies to a subscribe() rejection after both sides connected.
+  // Track init state for partial-failure cleanup. Promise.all rejects as
+  // soon as one side fails, but the other connect promise may resolve
+  // *after* we've thrown — leaking its WebSocket or postMessage listeners.
+  // We use a shared `failed` flag so a late-successful connect immediately
+  // tears its own side down instead of waiting for the catch handler.
+  let failed = false;
   let consumerConnected = false;
   let appConnected = false;
-  const cleanupOnFailure = () => {
-    if (consumerConnected) consumer.disconnect();
-    if (appConnected) void app.close().catch(() => {});
-  };
+
+  const consumerPromise = consumer.connect().then(
+    () => {
+      if (failed) {
+        consumer.disconnect();
+        return;
+      }
+      consumerConnected = true;
+    },
+    (err) => {
+      failed = true;
+      throw err;
+    },
+  );
+  const appPromise = app.connect().then(
+    () => {
+      if (failed) {
+        void app.close().catch(() => {});
+        return;
+      }
+      appConnected = true;
+    },
+    (err) => {
+      failed = true;
+      throw err;
+    },
+  );
 
   let subscriptionId: string;
   try {
-    await Promise.all([
-      consumer.connect().then(() => {
-        consumerConnected = true;
-      }),
-      app.connect().then(() => {
-        appConnected = true;
-      }),
-    ]);
+    await Promise.all([consumerPromise, appPromise]);
 
     const subCfg = options.subscribe ?? {};
     const sub = await consumer.subscribe(
@@ -113,7 +131,9 @@ export async function createMcpAppsBridge(
     );
     subscriptionId = sub.id;
   } catch (err) {
-    cleanupOnFailure();
+    failed = true;
+    if (consumerConnected) consumer.disconnect();
+    if (appConnected) void app.close().catch(() => {});
     throw err;
   }
 

--- a/packages/typescript/integrations/mcp-apps-bridge/src/bridge.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/src/bridge.ts
@@ -7,6 +7,7 @@ import {
   type SlopNode,
   WebSocketClientTransport,
 } from "@slop-ai/consumer/browser";
+import { connectBoth } from "./init-cleanup";
 import { createProjector, type ProjectionOptions } from "./projection";
 import { SameWindowPostMessageTransport } from "./transport-pm";
 
@@ -73,46 +74,11 @@ export async function createMcpAppsBridge(options: McpAppsBridgeOptions): Promis
   const transport = buildTransport(options.provider);
   const consumer = new SlopConsumer(transport);
 
-  // Track init state for partial-failure cleanup. Promise.all rejects as
-  // soon as one side fails, but the other connect promise may resolve
-  // *after* we've thrown — leaking its WebSocket or postMessage listeners.
-  // We use a shared `failed` flag so a late-successful connect immediately
-  // tears its own side down instead of waiting for the catch handler.
-  let failed = false;
-  let consumerConnected = false;
-  let appConnected = false;
-
-  const consumerPromise = consumer.connect().then(
-    () => {
-      if (failed) {
-        consumer.disconnect();
-        return;
-      }
-      consumerConnected = true;
-    },
-    (err) => {
-      failed = true;
-      throw err;
-    },
-  );
-  const appPromise = app.connect().then(
-    () => {
-      if (failed) {
-        void app.close().catch(() => {});
-        return;
-      }
-      appConnected = true;
-    },
-    (err) => {
-      failed = true;
-      throw err;
-    },
-  );
+  // Race-safe connect: see `connectBoth` for the cleanup guarantees.
+  await connectBoth(consumer, app);
 
   let subscriptionId: string;
   try {
-    await Promise.all([consumerPromise, appPromise]);
-
     const subCfg = options.subscribe ?? {};
     const sub = await consumer.subscribe(subCfg.path ?? "/", subCfg.depth ?? 1, {
       ...(subCfg.maxNodes != null && { max_nodes: subCfg.maxNodes }),
@@ -125,9 +91,8 @@ export async function createMcpAppsBridge(options: McpAppsBridgeOptions): Promis
     });
     subscriptionId = sub.id;
   } catch (err) {
-    failed = true;
-    if (consumerConnected) consumer.disconnect();
-    if (appConnected) void app.close().catch(() => {});
+    consumer.disconnect();
+    void app.close().catch(() => {});
     throw err;
   }
 

--- a/packages/typescript/integrations/mcp-apps-bridge/src/bridge.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/src/bridge.ts
@@ -1,0 +1,138 @@
+import {
+  SlopConsumer,
+  WebSocketClientTransport,
+  type ClientTransport,
+  type ResultMessage,
+  type SlopNode,
+} from "@slop-ai/consumer/browser";
+import { App } from "@modelcontextprotocol/ext-apps";
+import type { Implementation } from "@modelcontextprotocol/sdk/types.js";
+import { SameWindowPostMessageTransport } from "./transport-pm";
+import { createProjector, type ProjectionOptions } from "./projection";
+
+export type ProviderConfig =
+  | { mode: "ws"; url: string }
+  | { mode: "postmessage"; targetWindow?: Window; origin?: string };
+
+export interface SubscribeConfig {
+  path?: string;
+  depth?: number;
+  minSalience?: number;
+  types?: string[];
+  maxNodes?: number;
+}
+
+export interface McpAppsBridgeOptions {
+  /** How the iframe reaches the SLOP provider. */
+  provider: ProviderConfig;
+  /** What subtree to mirror into the host model's context. */
+  subscribe?: SubscribeConfig;
+  /** Projection strategy — defaults to salience-filtered markdown, 250ms debounce. */
+  projection?: ProjectionOptions;
+  /** App metadata advertised to the MCP host during ui/initialize. */
+  appInfo?: Implementation;
+}
+
+export interface McpAppsBridge {
+  app: App;
+  consumer: SlopConsumer;
+  subscriptionId: string;
+  invoke(path: string, action: string, params?: Record<string, unknown>): Promise<ResultMessage>;
+  getTree(): SlopNode | null;
+  /** Force-flush any pending projection update. */
+  flush(): void;
+  dispose(): void;
+}
+
+function buildTransport(cfg: ProviderConfig): ClientTransport {
+  if (cfg.mode === "ws") {
+    return new WebSocketClientTransport(cfg.url);
+  }
+  return new SameWindowPostMessageTransport({
+    targetWindow: cfg.targetWindow,
+    origin: cfg.origin,
+  });
+}
+
+/**
+ * Boot a SLOP session inside an MCP Apps iframe.
+ *
+ * - Instantiates an ext-apps `App` and connects it over the default postMessage transport.
+ * - Opens a `SlopConsumer` against the configured provider (WebSocket or same-window postMessage).
+ * - Subscribes with the requested salience/depth filter.
+ * - Pushes salience-filtered markdown projections of the state tree into `app.updateModelContext`
+ *   on every snapshot or patch, debounced to avoid flooding the host.
+ */
+export async function createMcpAppsBridge(
+  options: McpAppsBridgeOptions,
+): Promise<McpAppsBridge> {
+  const appInfo: Implementation = options.appInfo ?? {
+    name: "slop-bridge",
+    version: "0.1.0",
+  };
+
+  const app = new App(appInfo, {});
+  const transport = buildTransport(options.provider);
+  const consumer = new SlopConsumer(transport);
+
+  // Connect both sides in parallel — host and provider are independent.
+  const [helloMaybe] = await Promise.all([consumer.connect(), app.connect()]);
+  // Surface the provider hello via bridge metadata in case the caller wants to inspect it.
+  void helloMaybe;
+
+  const subCfg = options.subscribe ?? {};
+  const { id: subscriptionId } = await consumer.subscribe(
+    subCfg.path ?? "/",
+    subCfg.depth ?? 1,
+    {
+      ...(subCfg.maxNodes != null && { max_nodes: subCfg.maxNodes }),
+      ...((subCfg.minSalience != null || subCfg.types) && {
+        filter: {
+          ...(subCfg.minSalience != null && { min_salience: subCfg.minSalience }),
+          ...(subCfg.types && { types: subCfg.types }),
+        },
+      }),
+    },
+  );
+
+  const projector = createProjector(
+    (text) => {
+      // Fire-and-forget: the host may reject updates before hello completes,
+      // which we treat as non-fatal and just drop.
+      app.updateModelContext({ content: [{ type: "text", text }] }).catch(() => {});
+    },
+    options.projection ?? {},
+  );
+
+  // Initial projection from the snapshot.
+  const initial = consumer.getTree(subscriptionId);
+  if (initial) projector.schedule(initial);
+
+  // Re-project on every patch (consumer already mirrored the tree).
+  const onPatch = (subId: string) => {
+    if (subId !== subscriptionId) return;
+    const tree = consumer.getTree(subscriptionId);
+    if (tree) projector.schedule(tree);
+  };
+  consumer.on("patch", onPatch);
+
+  let disposed = false;
+
+  return {
+    app,
+    consumer,
+    subscriptionId,
+    invoke: (path, action, params) => consumer.invoke(path, action, params),
+    getTree: () => consumer.getTree(subscriptionId),
+    flush: () => projector.flush(),
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      projector.dispose();
+      consumer.off("patch", onPatch);
+      consumer.unsubscribe(subscriptionId);
+      consumer.disconnect();
+      // ext-apps App has no explicit close; GC handles it when the iframe unmounts.
+    },
+  };
+}

--- a/packages/typescript/integrations/mcp-apps-bridge/src/bridge.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/src/bridge.ts
@@ -1,14 +1,14 @@
-import {
-  SlopConsumer,
-  WebSocketClientTransport,
-  type ClientTransport,
-  type ResultMessage,
-  type SlopNode,
-} from "@slop-ai/consumer/browser";
 import { App } from "@modelcontextprotocol/ext-apps";
 import type { Implementation } from "@modelcontextprotocol/sdk/types.js";
-import { SameWindowPostMessageTransport } from "./transport-pm";
+import {
+  type ClientTransport,
+  type ResultMessage,
+  SlopConsumer,
+  type SlopNode,
+  WebSocketClientTransport,
+} from "@slop-ai/consumer/browser";
 import { createProjector, type ProjectionOptions } from "./projection";
+import { SameWindowPostMessageTransport } from "./transport-pm";
 
 export type ProviderConfig =
   | { mode: "ws"; url: string }
@@ -63,9 +63,7 @@ function buildTransport(cfg: ProviderConfig): ClientTransport {
  * - Pushes salience-filtered markdown projections of the state tree into `app.updateModelContext`
  *   on every snapshot or patch, debounced to avoid flooding the host.
  */
-export async function createMcpAppsBridge(
-  options: McpAppsBridgeOptions,
-): Promise<McpAppsBridge> {
+export async function createMcpAppsBridge(options: McpAppsBridgeOptions): Promise<McpAppsBridge> {
   const appInfo: Implementation = options.appInfo ?? {
     name: "slop-bridge",
     version: "0.1.0",
@@ -116,19 +114,15 @@ export async function createMcpAppsBridge(
     await Promise.all([consumerPromise, appPromise]);
 
     const subCfg = options.subscribe ?? {};
-    const sub = await consumer.subscribe(
-      subCfg.path ?? "/",
-      subCfg.depth ?? 1,
-      {
-        ...(subCfg.maxNodes != null && { max_nodes: subCfg.maxNodes }),
-        ...((subCfg.minSalience != null || subCfg.types) && {
-          filter: {
-            ...(subCfg.minSalience != null && { min_salience: subCfg.minSalience }),
-            ...(subCfg.types && { types: subCfg.types }),
-          },
-        }),
-      },
-    );
+    const sub = await consumer.subscribe(subCfg.path ?? "/", subCfg.depth ?? 1, {
+      ...(subCfg.maxNodes != null && { max_nodes: subCfg.maxNodes }),
+      ...((subCfg.minSalience != null || subCfg.types) && {
+        filter: {
+          ...(subCfg.minSalience != null && { min_salience: subCfg.minSalience }),
+          ...(subCfg.types && { types: subCfg.types }),
+        },
+      }),
+    });
     subscriptionId = sub.id;
   } catch (err) {
     failed = true;
@@ -137,14 +131,11 @@ export async function createMcpAppsBridge(
     throw err;
   }
 
-  const projector = createProjector(
-    (text) => {
-      // Fire-and-forget: the host may reject updates before hello completes,
-      // which we treat as non-fatal and just drop.
-      app.updateModelContext({ content: [{ type: "text", text }] }).catch(() => {});
-    },
-    options.projection ?? {},
-  );
+  const projector = createProjector((text) => {
+    // Fire-and-forget: the host may reject updates before hello completes,
+    // which we treat as non-fatal and just drop.
+    app.updateModelContext({ content: [{ type: "text", text }] }).catch(() => {});
+  }, options.projection ?? {});
 
   // Initial projection from the snapshot.
   const initial = consumer.getTree(subscriptionId);

--- a/packages/typescript/integrations/mcp-apps-bridge/src/bridge.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/src/bridge.ts
@@ -75,25 +75,47 @@ export async function createMcpAppsBridge(
   const transport = buildTransport(options.provider);
   const consumer = new SlopConsumer(transport);
 
-  // Connect both sides in parallel — host and provider are independent.
-  const [helloMaybe] = await Promise.all([consumer.connect(), app.connect()]);
-  // Surface the provider hello via bridge metadata in case the caller wants to inspect it.
-  void helloMaybe;
+  // Track connection state for partial-failure cleanup. Promise.all rejects
+  // when *either* side fails, but the other side may have already connected
+  // — leaking the open WebSocket and/or the postMessage listeners. The same
+  // applies to a subscribe() rejection after both sides connected.
+  let consumerConnected = false;
+  let appConnected = false;
+  const cleanupOnFailure = () => {
+    if (consumerConnected) consumer.disconnect();
+    if (appConnected) void app.close().catch(() => {});
+  };
 
-  const subCfg = options.subscribe ?? {};
-  const { id: subscriptionId } = await consumer.subscribe(
-    subCfg.path ?? "/",
-    subCfg.depth ?? 1,
-    {
-      ...(subCfg.maxNodes != null && { max_nodes: subCfg.maxNodes }),
-      ...((subCfg.minSalience != null || subCfg.types) && {
-        filter: {
-          ...(subCfg.minSalience != null && { min_salience: subCfg.minSalience }),
-          ...(subCfg.types && { types: subCfg.types }),
-        },
+  let subscriptionId: string;
+  try {
+    await Promise.all([
+      consumer.connect().then(() => {
+        consumerConnected = true;
       }),
-    },
-  );
+      app.connect().then(() => {
+        appConnected = true;
+      }),
+    ]);
+
+    const subCfg = options.subscribe ?? {};
+    const sub = await consumer.subscribe(
+      subCfg.path ?? "/",
+      subCfg.depth ?? 1,
+      {
+        ...(subCfg.maxNodes != null && { max_nodes: subCfg.maxNodes }),
+        ...((subCfg.minSalience != null || subCfg.types) && {
+          filter: {
+            ...(subCfg.minSalience != null && { min_salience: subCfg.minSalience }),
+            ...(subCfg.types && { types: subCfg.types }),
+          },
+        }),
+      },
+    );
+    subscriptionId = sub.id;
+  } catch (err) {
+    cleanupOnFailure();
+    throw err;
+  }
 
   const projector = createProjector(
     (text) => {

--- a/packages/typescript/integrations/mcp-apps-bridge/src/bridge.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/src/bridge.ts
@@ -132,7 +132,9 @@ export async function createMcpAppsBridge(
       consumer.off("patch", onPatch);
       consumer.unsubscribe(subscriptionId);
       consumer.disconnect();
-      // ext-apps App has no explicit close; GC handles it when the iframe unmounts.
+      // Close the ext-apps Protocol so postMessage listeners detach cleanly —
+      // matters in long-lived iframes/SPAs where dispose can be called many times.
+      void app.close().catch(() => {});
     },
   };
 }

--- a/packages/typescript/integrations/mcp-apps-bridge/src/index.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/src/index.ts
@@ -1,0 +1,14 @@
+export {
+  createMcpAppsBridge,
+  type McpAppsBridge,
+  type McpAppsBridgeOptions,
+  type ProviderConfig,
+  type SubscribeConfig,
+} from "./bridge";
+export { SameWindowPostMessageTransport } from "./transport-pm";
+export {
+  createProjector,
+  renderMarkdown,
+  type ProjectionFormat,
+  type ProjectionOptions,
+} from "./projection";

--- a/packages/typescript/integrations/mcp-apps-bridge/src/index.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/src/index.ts
@@ -5,10 +5,10 @@ export {
   type ProviderConfig,
   type SubscribeConfig,
 } from "./bridge";
-export { SameWindowPostMessageTransport } from "./transport-pm";
 export {
   createProjector,
-  renderMarkdown,
   type ProjectionFormat,
   type ProjectionOptions,
+  renderMarkdown,
 } from "./projection";
+export { SameWindowPostMessageTransport } from "./transport-pm";

--- a/packages/typescript/integrations/mcp-apps-bridge/src/init-cleanup.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/src/init-cleanup.ts
@@ -1,0 +1,64 @@
+/**
+ * Connect a SLOP consumer and an ext-apps App in parallel with race-safe
+ * cleanup. Promise.all rejects as soon as one side fails, but the other
+ * connect promise may resolve *after* the catch handler ran — leaking the
+ * late-connecting side. A shared `failed` flag lets each `.then` notice a
+ * peer rejection and tear its own side down immediately.
+ *
+ * Exported so the race can be unit-tested with fakes; production callers
+ * use it via `createMcpAppsBridge`.
+ */
+export interface DisposableConsumer {
+  connect(): Promise<unknown>;
+  disconnect(): void;
+}
+
+export interface DisposableApp {
+  connect(): Promise<unknown>;
+  close(): Promise<unknown>;
+}
+
+export async function connectBoth(consumer: DisposableConsumer, app: DisposableApp): Promise<void> {
+  let failed = false;
+  let consumerOk = false;
+  let appOk = false;
+
+  const consumerPromise = consumer.connect().then(
+    () => {
+      if (failed) {
+        consumer.disconnect();
+        return;
+      }
+      consumerOk = true;
+    },
+    (err) => {
+      failed = true;
+      throw err;
+    },
+  );
+  const appPromise = app.connect().then(
+    () => {
+      if (failed) {
+        void app.close().catch(() => {});
+        return;
+      }
+      appOk = true;
+    },
+    (err) => {
+      failed = true;
+      throw err;
+    },
+  );
+
+  try {
+    await Promise.all([consumerPromise, appPromise]);
+  } catch (err) {
+    // Wait for the other side to settle so its `.then` handler can run the
+    // late-cleanup branch above. Without this, a Promise.all rejection
+    // returns before the slower successful connect runs its handler.
+    await Promise.allSettled([consumerPromise, appPromise]);
+    if (consumerOk) consumer.disconnect();
+    if (appOk) void app.close().catch(() => {});
+    throw err;
+  }
+}

--- a/packages/typescript/integrations/mcp-apps-bridge/src/projection.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/src/projection.ts
@@ -1,0 +1,90 @@
+import { affordancesToTools, formatTree } from "@slop-ai/consumer/browser";
+import type { SlopNode } from "@slop-ai/consumer/browser";
+
+export type ProjectionFormat = "markdown" | ((tree: SlopNode) => string);
+
+export interface ProjectionOptions {
+  /** Coalesce rapid patches into a single model-context update. Default 250ms. */
+  debounceMs?: number;
+  /** Projection strategy. Default: markdown using formatTree + affordance list. */
+  format?: ProjectionFormat;
+  /** Optional header prepended to every projection (e.g., app name). */
+  header?: string;
+}
+
+/**
+ * Default markdown projection: state tree (via `formatTree`) plus the affordance
+ * list (via `affordancesToTools`) so the model sees both "what is" and "what can
+ * be done from here." Mirrors the pattern in the Claude slop-mcp-proxy integration.
+ */
+export function renderMarkdown(tree: SlopNode, header?: string): string {
+  const toolSet = affordancesToTools(tree);
+  const actionsText =
+    toolSet.tools.length === 0
+      ? "_no actions available_"
+      : toolSet.tools
+          .map((t) => {
+            const resolved = toolSet.resolve(t.function.name);
+            const action = resolved?.action ?? t.function.name;
+            const pathInfo = resolved?.path
+              ? `on \`${resolved.path}\``
+              : `${resolved?.targets?.length ?? 0} targets`;
+            return `  - **${action}** ${pathInfo}: ${t.function.description}`;
+          })
+          .join("\n");
+
+  const body =
+    `### State\n\`\`\`\n${formatTree(tree)}\n\`\`\`\n\n` +
+    `### Actions (${toolSet.tools.length})\n${actionsText}\n`;
+
+  return header ? `${header}\n\n${body}` : body;
+}
+
+/**
+ * Create a debounced projector. Each call to `schedule(tree)` replaces the
+ * pending projection; `flush()` forces the next-scheduled projection to fire
+ * immediately (useful for tests and unmount).
+ */
+export function createProjector(
+  apply: (text: string) => void,
+  options: ProjectionOptions = {},
+): {
+  schedule(tree: SlopNode): void;
+  flush(): void;
+  dispose(): void;
+} {
+  const debounceMs = options.debounceMs ?? 250;
+  const format = options.format ?? "markdown";
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let pendingTree: SlopNode | null = null;
+
+  function run() {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    if (!pendingTree) return;
+    const text =
+      format === "markdown" ? renderMarkdown(pendingTree, options.header) : format(pendingTree);
+    pendingTree = null;
+    apply(text);
+  }
+
+  return {
+    schedule(tree: SlopNode) {
+      pendingTree = tree;
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(run, debounceMs);
+    },
+    flush() {
+      run();
+    },
+    dispose() {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      pendingTree = null;
+    },
+  };
+}

--- a/packages/typescript/integrations/mcp-apps-bridge/src/projection.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/src/projection.ts
@@ -1,5 +1,5 @@
-import { affordancesToTools, formatTree } from "@slop-ai/consumer/browser";
 import type { SlopNode } from "@slop-ai/consumer/browser";
+import { affordancesToTools, formatTree } from "@slop-ai/consumer/browser";
 
 export type ProjectionFormat = "markdown" | ((tree: SlopNode) => string);
 
@@ -26,16 +26,13 @@ export function renderMarkdown(tree: SlopNode, header?: string): string {
           .map((t) => {
             const resolved = toolSet.resolve(t.function.name);
             const action = resolved?.action ?? t.function.name;
-            const pathInfo = resolved?.path
-              ? `on \`${resolved.path}\``
-              : `${resolved?.targets?.length ?? 0} targets`;
+            const pathInfo = resolved?.path ? `on \`${resolved.path}\`` : `${resolved?.targets?.length ?? 0} targets`;
             return `  - **${action}** ${pathInfo}: ${t.function.description}`;
           })
           .join("\n");
 
   const body =
-    `### State\n\`\`\`\n${formatTree(tree)}\n\`\`\`\n\n` +
-    `### Actions (${toolSet.tools.length})\n${actionsText}\n`;
+    `### State\n\`\`\`\n${formatTree(tree)}\n\`\`\`\n\n` + `### Actions (${toolSet.tools.length})\n${actionsText}\n`;
 
   return header ? `${header}\n\n${body}` : body;
 }
@@ -64,8 +61,7 @@ export function createProjector(
       timer = null;
     }
     if (!pendingTree) return;
-    const text =
-      format === "markdown" ? renderMarkdown(pendingTree, options.header) : format(pendingTree);
+    const text = format === "markdown" ? renderMarkdown(pendingTree, options.header) : format(pendingTree);
     pendingTree = null;
     apply(text);
   }

--- a/packages/typescript/integrations/mcp-apps-bridge/src/server.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/src/server.ts
@@ -31,6 +31,14 @@ export interface RegisterSlopViewOptions {
    * top of the MCP Apps mime-type default.
    */
   resourceMeta?: Record<string, unknown>;
+  /**
+   * Origins the iframe is allowed to make network requests to (CSP `connect-src`).
+   * Sandboxed hosts (e.g. VS Code's webview) block all network by default — list
+   * any WebSocket/HTTP origins the iframe needs to reach the SLOP provider.
+   *
+   * @example ["ws://127.0.0.1:7411"]
+   */
+  connectDomains?: string[];
 }
 
 /**
@@ -63,12 +71,33 @@ export function registerSlopView(
 
   const resourceName = options.resourceName ?? options.toolName;
   const htmlSource = options.html;
+  const baseMeta = (options.resourceMeta?._meta as Record<string, unknown>) ?? {};
+  const baseUi = (baseMeta.ui as Record<string, unknown>) ?? {};
+  const mergedMeta: Record<string, unknown> = {
+    ...options.resourceMeta,
+    _meta: {
+      ...baseMeta,
+      ui: {
+        ...baseUi,
+        ...(options.connectDomains && {
+          csp: { connectDomains: options.connectDomains, ...((baseUi.csp as object) ?? {}) },
+        }),
+      },
+    },
+  };
+
+  // ext-apps spec: when resources/read content items carry their own _meta.ui,
+  // it takes precedence over the listing-level metadata. Hosts (notably VS Code)
+  // tend to read CSP from the content item, so we duplicate the declaration here.
+  const contentMeta = options.connectDomains
+    ? { ui: { csp: { connectDomains: options.connectDomains } } }
+    : undefined;
 
   registerAppResource(
     server as Pick<McpServer, "registerResource">,
     resourceName,
     options.resourceUri,
-    options.resourceMeta ?? {},
+    mergedMeta,
     async () => {
       const text = typeof htmlSource === "function" ? await htmlSource() : htmlSource;
       return {
@@ -77,6 +106,7 @@ export function registerSlopView(
             uri: options.resourceUri,
             mimeType: RESOURCE_MIME_TYPE,
             text,
+            ...(contentMeta && { _meta: contentMeta }),
           },
         ],
       };

--- a/packages/typescript/integrations/mcp-apps-bridge/src/server.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/src/server.ts
@@ -73,25 +73,29 @@ export function registerSlopView(
   const htmlSource = options.html;
   const baseMeta = (options.resourceMeta?._meta as Record<string, unknown>) ?? {};
   const baseUi = (baseMeta.ui as Record<string, unknown>) ?? {};
+  const baseCsp = (baseUi.csp as Record<string, unknown>) ?? {};
+
+  // Merge connectDomains into the caller-supplied CSP block. Caller wins on
+  // collisions inside csp (so an explicit empty connectDomains still beats us).
+  const mergedCsp: Record<string, unknown> = {
+    ...(options.connectDomains && { connectDomains: options.connectDomains }),
+    ...baseCsp,
+  };
+  const mergedUi: Record<string, unknown> = {
+    ...baseUi,
+    ...(Object.keys(mergedCsp).length > 0 && { csp: mergedCsp }),
+  };
   const mergedMeta: Record<string, unknown> = {
     ...options.resourceMeta,
-    _meta: {
-      ...baseMeta,
-      ui: {
-        ...baseUi,
-        ...(options.connectDomains && {
-          csp: { connectDomains: options.connectDomains, ...((baseUi.csp as object) ?? {}) },
-        }),
-      },
-    },
+    _meta: { ...baseMeta, ui: mergedUi },
   };
 
   // ext-apps spec: when resources/read content items carry their own _meta.ui,
   // it takes precedence over the listing-level metadata. Hosts (notably VS Code)
-  // tend to read CSP from the content item, so we duplicate the declaration here.
-  const contentMeta = options.connectDomains
-    ? { ui: { csp: { connectDomains: options.connectDomains } } }
-    : undefined;
+  // tend to read CSP from the content item, so we duplicate the FULL merged UI
+  // metadata — not just connectDomains — to keep listing and content in sync.
+  const hasUiMeta = Object.keys(mergedUi).length > 0;
+  const contentMeta = hasUiMeta ? { ui: mergedUi } : undefined;
 
   registerAppResource(
     server as Pick<McpServer, "registerResource">,
@@ -172,7 +176,7 @@ export async function registerSlopTools(
   const prefix = options.toolNamePrefix ?? "";
 
   function buildHandler(
-    resolved: { path: string | null; action: string },
+    resolved: { path: string | null; action: string; targets?: string[] },
   ): (args: Record<string, unknown> | undefined) => Promise<{
     content: { type: "text"; text: string }[];
     isError?: boolean;
@@ -186,7 +190,22 @@ export async function registerSlopTools(
           return {
             isError: true,
             content: [
-              { type: "text" as const, text: `missing required \`target\` parameter` },
+              { type: "text" as const, text: "missing required `target` parameter" },
+            ],
+          };
+        }
+        // Restrict invocation to targets that actually exposed this affordance
+        // in the current snapshot. Without this gate a model could invoke the
+        // grouped action on any path the provider happens to handle, including
+        // nodes outside the salience-filtered subscription.
+        if (resolved.targets && !resolved.targets.includes(target)) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: `target \`${target}\` is not a valid path for action \`${resolved.action}\`. Valid: ${resolved.targets.slice(0, 5).join(", ")}${resolved.targets.length > 5 ? ", …" : ""}`,
+              },
             ],
           };
         }
@@ -194,13 +213,17 @@ export async function registerSlopTools(
         delete params.target;
       }
       const result = await consumer.invoke(path, resolved.action, params);
+      if (result.status === "error") {
+        const code = result.error?.code ?? "error";
+        const message = result.error?.message ?? "(no message)";
+        return {
+          isError: true,
+          content: [{ type: "text" as const, text: `[${code}] ${message}` }],
+        };
+      }
       const data = result.data ?? result.status ?? "ok";
-      const text =
-        typeof data === "string" ? data : JSON.stringify(data, null, 2);
-      return {
-        content: [{ type: "text" as const, text }],
-        ...(result.status === "error" && { isError: true }),
-      };
+      const text = typeof data === "string" ? data : JSON.stringify(data, null, 2);
+      return { content: [{ type: "text" as const, text }] };
     };
   }
 

--- a/packages/typescript/integrations/mcp-apps-bridge/src/server.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/src/server.ts
@@ -3,7 +3,17 @@ import {
   registerAppResource,
   registerAppTool,
 } from "@modelcontextprotocol/ext-apps/server";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer, RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { SlopConsumer, WebSocketClientTransport, affordancesToTools } from "@slop-ai/consumer";
+import type { SlopNode } from "@slop-ai/consumer";
+import { z } from "zod";
+
+// Permissive object schema — accepts any JSON-serializable record so the model
+// can call tools with arbitrary keys (e.g. `target`, `title`). We carry the
+// real shape in the tool description until the SDK accepts JSON Schema
+// directly (or we add JSON Schema → Zod conversion). The cast bypasses the
+// SDK's overly-narrow ZodRawShapeCompat constraint.
+const PASSTHROUGH = z.object({}).passthrough() as never;
 
 export interface RegisterSlopViewOptions {
   /** MCP tool name that opens the view. Example: `open_kanban`. */
@@ -75,3 +85,191 @@ export function registerSlopView(
 }
 
 export { RESOURCE_MIME_TYPE };
+
+// ---------------------------------------------------------------------------
+// registerSlopTools — model-callable affordances backed by an upstream SLOP provider
+// ---------------------------------------------------------------------------
+
+export interface RegisterSlopToolsOptions {
+  /** WebSocket URL of the upstream SLOP provider. */
+  url: string;
+  /** Subscription depth. Default `-1` (entire tree). */
+  depth?: number;
+  /** Salience floor for the subscription. */
+  minSalience?: number;
+  /**
+   * Optional prefix prepended to every generated MCP tool name. Useful when
+   * multiple SLOP providers share an MCP server and tool-name collisions are
+   * possible.
+   */
+  toolNamePrefix?: string;
+  /**
+   * If true, mark every generated tool with the given UI resource URI so the
+   * host opens (or reuses) the bridged view when the model invokes one.
+   */
+  uiResourceUri?: string;
+}
+
+export interface SlopToolsHandle {
+  /** Number of MCP tools currently registered against the provider. */
+  size(): number;
+  /** Force a re-sync against the current SLOP tree (normally automatic). */
+  sync(): void;
+  /** Stop syncing, unsubscribe, and remove all registered tools. */
+  dispose(): void;
+}
+
+/**
+ * Walk an upstream SLOP provider's affordances and expose each one as an MCP
+ * tool the host model can call from chat. Resyncs on every patch and emits
+ * `tools/listChanged` so MCP clients re-fetch the tool catalog.
+ *
+ * SLOP affordances become MCP tools schemaless for v0.1 — the affordance
+ * description carries enough signal for the model. Future versions can
+ * convert SLOP JSON Schema params into Zod for stricter validation.
+ */
+export async function registerSlopTools(
+  server: McpServer,
+  options: RegisterSlopToolsOptions,
+): Promise<SlopToolsHandle> {
+  const consumer = new SlopConsumer(new WebSocketClientTransport(options.url));
+  await consumer.connect();
+  const { id: subId } = await consumer.subscribe("/", options.depth ?? -1, {
+    ...(options.minSalience != null && { filter: { min_salience: options.minSalience } }),
+  });
+
+  const registered = new Map<string, RegisteredTool>();
+  const prefix = options.toolNamePrefix ?? "";
+
+  function buildHandler(
+    resolved: { path: string | null; action: string },
+  ): (args: Record<string, unknown> | undefined) => Promise<{
+    content: { type: "text"; text: string }[];
+    isError?: boolean;
+  }> {
+    return async (args) => {
+      let path = resolved.path;
+      let params: Record<string, unknown> = { ...(args ?? {}) };
+      if (path === null) {
+        const target = params.target;
+        if (typeof target !== "string") {
+          return {
+            isError: true,
+            content: [
+              { type: "text" as const, text: `missing required \`target\` parameter` },
+            ],
+          };
+        }
+        path = target;
+        delete params.target;
+      }
+      const result = await consumer.invoke(path, resolved.action, params);
+      const data = result.data ?? result.status ?? "ok";
+      const text =
+        typeof data === "string" ? data : JSON.stringify(data, null, 2);
+      return {
+        content: [{ type: "text" as const, text }],
+        ...(result.status === "error" && { isError: true }),
+      };
+    };
+  }
+
+  function sync(): void {
+    const tree: SlopNode | null = consumer.getTree(subId);
+    if (!tree) return;
+    const toolSet = affordancesToTools(tree);
+
+    const wantedNames = new Set<string>();
+    for (const t of toolSet.tools) {
+      const name = `${prefix}${t.function.name}`;
+      wantedNames.add(name);
+      const resolved = toolSet.resolve(t.function.name);
+      if (!resolved) continue;
+      const handler = buildHandler(resolved);
+      const description = describeWithParams(
+        t.function.description,
+        t.function.parameters,
+        resolved.targets,
+      );
+      const meta = options.uiResourceUri
+        ? { ui: { resourceUri: options.uiResourceUri } }
+        : undefined;
+      const existing = registered.get(name);
+      if (existing) {
+        existing.update({
+          description,
+          callback: handler as never,
+          ...(meta && { _meta: meta }),
+        });
+      } else {
+        const reg = server.registerTool(
+          name,
+          {
+            description,
+            inputSchema: PASSTHROUGH,
+            ...(meta && { _meta: meta }),
+          },
+          handler as never,
+        );
+        registered.set(name, reg);
+      }
+    }
+    // Remove tools whose backing affordance disappeared.
+    for (const [name, reg] of registered) {
+      if (!wantedNames.has(name)) {
+        reg.remove();
+        registered.delete(name);
+      }
+    }
+    server.sendToolListChanged();
+  }
+
+  // Initial sync; debounce subsequent patch-driven syncs to avoid storms.
+  sync();
+  let resyncTimer: ReturnType<typeof setTimeout> | null = null;
+  const onPatch = (s: string) => {
+    if (s !== subId) return;
+    if (resyncTimer) clearTimeout(resyncTimer);
+    resyncTimer = setTimeout(sync, 50);
+  };
+  consumer.on("patch", onPatch);
+
+  let disposed = false;
+
+  // The MCP SDK only accepts Zod schemas for inputSchema; we inline JSON-schema
+  // hints into the tool description until JSON-Schema → Zod conversion lands.
+  function describeWithParams(
+    base: string,
+    params: Record<string, unknown> | undefined,
+    targets?: string[],
+  ): string {
+    const props = (params?.properties as Record<string, { type?: string; description?: string }>) ?? {};
+    const required = (params?.required as string[]) ?? [];
+    const lines = Object.entries(props).map(([k, v]) => {
+      const req = required.includes(k) ? " (required)" : "";
+      const type = v.type ?? "any";
+      const hint = v.description ? ` — ${v.description}` : "";
+      return `  - ${k}: ${type}${req}${hint}`;
+    });
+    const targetHint =
+      targets && targets.length
+        ? `\nValid \`target\` paths: ${targets.slice(0, 5).join(", ")}${targets.length > 5 ? ", …" : ""}`
+        : "";
+    return lines.length ? `${base}\nParameters:\n${lines.join("\n")}${targetHint}` : `${base}${targetHint}`;
+  }
+
+  return {
+    size: () => registered.size,
+    sync,
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      if (resyncTimer) clearTimeout(resyncTimer);
+      consumer.off("patch", onPatch);
+      for (const reg of registered.values()) reg.remove();
+      registered.clear();
+      consumer.unsubscribe(subId);
+      consumer.disconnect();
+    },
+  };
+}

--- a/packages/typescript/integrations/mcp-apps-bridge/src/server.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/src/server.ts
@@ -1,11 +1,7 @@
-import {
-  RESOURCE_MIME_TYPE,
-  registerAppResource,
-  registerAppTool,
-} from "@modelcontextprotocol/ext-apps/server";
+import { RESOURCE_MIME_TYPE, registerAppResource, registerAppTool } from "@modelcontextprotocol/ext-apps/server";
 import type { McpServer, RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { SlopConsumer, WebSocketClientTransport, affordancesToTools } from "@slop-ai/consumer";
 import type { SlopNode } from "@slop-ai/consumer";
+import { affordancesToTools, SlopConsumer, WebSocketClientTransport } from "@slop-ai/consumer";
 import { z } from "zod";
 
 // Permissive object schema — accepts any JSON-serializable record so the model
@@ -175,23 +171,21 @@ export async function registerSlopTools(
   const registered = new Map<string, RegisteredTool>();
   const prefix = options.toolNamePrefix ?? "";
 
-  function buildHandler(
-    resolved: { path: string | null; action: string; targets?: string[] },
-  ): (args: Record<string, unknown> | undefined) => Promise<{
+  function buildHandler(resolved: { path: string | null; action: string; targets?: string[] }): (
+    args: Record<string, unknown> | undefined,
+  ) => Promise<{
     content: { type: "text"; text: string }[];
     isError?: boolean;
   }> {
     return async (args) => {
       let path = resolved.path;
-      let params: Record<string, unknown> = { ...(args ?? {}) };
+      const params: Record<string, unknown> = { ...(args ?? {}) };
       if (path === null) {
         const target = params.target;
         if (typeof target !== "string") {
           return {
             isError: true,
-            content: [
-              { type: "text" as const, text: "missing required `target` parameter" },
-            ],
+            content: [{ type: "text" as const, text: "missing required `target` parameter" }],
           };
         }
         // Restrict invocation to targets that actually exposed this affordance
@@ -239,14 +233,8 @@ export async function registerSlopTools(
       const resolved = toolSet.resolve(t.function.name);
       if (!resolved) continue;
       const handler = buildHandler(resolved);
-      const description = describeWithParams(
-        t.function.description,
-        t.function.parameters,
-        resolved.targets,
-      );
-      const meta = options.uiResourceUri
-        ? { ui: { resourceUri: options.uiResourceUri } }
-        : undefined;
+      const description = describeWithParams(t.function.description, t.function.parameters, resolved.targets);
+      const meta = options.uiResourceUri ? { ui: { resourceUri: options.uiResourceUri } } : undefined;
       const existing = registered.get(name);
       if (existing) {
         existing.update({
@@ -291,11 +279,7 @@ export async function registerSlopTools(
 
   // The MCP SDK only accepts Zod schemas for inputSchema; we inline JSON-schema
   // hints into the tool description until JSON-Schema → Zod conversion lands.
-  function describeWithParams(
-    base: string,
-    params: Record<string, unknown> | undefined,
-    targets?: string[],
-  ): string {
+  function describeWithParams(base: string, params: Record<string, unknown> | undefined, targets?: string[]): string {
     const props = (params?.properties as Record<string, { type?: string; description?: string }>) ?? {};
     const required = (params?.required as string[]) ?? [];
     const lines = Object.entries(props).map(([k, v]) => {

--- a/packages/typescript/integrations/mcp-apps-bridge/src/server.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/src/server.ts
@@ -1,0 +1,77 @@
+import {
+  RESOURCE_MIME_TYPE,
+  registerAppResource,
+  registerAppTool,
+} from "@modelcontextprotocol/ext-apps/server";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export interface RegisterSlopViewOptions {
+  /** MCP tool name that opens the view. Example: `open_kanban`. */
+  toolName: string;
+  /** Tool description shown to the model and host. */
+  description?: string;
+  /** Fully-qualified UI resource URI. Example: `ui://kanban/slop`. */
+  resourceUri: string;
+  /** Display name for the resource entry. Defaults to the tool name. */
+  resourceName?: string;
+  /** HTML (or fetcher) served for the `ui://` resource — the iframe bundle. */
+  html: string | (() => string | Promise<string>);
+  /**
+   * Optional overrides for the resource metadata (CSP, extra meta). Merged on
+   * top of the MCP Apps mime-type default.
+   */
+  resourceMeta?: Record<string, unknown>;
+}
+
+/**
+ * Register a SLOP-backed MCP App surface on an MCP server.
+ *
+ * Thin facade over `registerAppTool` + `registerAppResource` from
+ * `@modelcontextprotocol/ext-apps/server`:
+ * - The tool returns no text content; the UI resource is the payload.
+ * - The resource callback serves the provided HTML under `RESOURCE_MIME_TYPE`.
+ *
+ * Callers who need richer behavior (tool arguments, conditional UI, server-side
+ * state) should call the underlying ext-apps helpers directly.
+ */
+export function registerSlopView(
+  server: Pick<McpServer, "registerTool" | "registerResource">,
+  options: RegisterSlopViewOptions,
+): void {
+  const description = options.description ?? `Open a live SLOP view (${options.toolName})`;
+
+  registerAppTool(
+    server as Pick<McpServer, "registerTool">,
+    options.toolName,
+    {
+      description,
+      inputSchema: undefined,
+      _meta: { ui: { resourceUri: options.resourceUri } },
+    },
+    async () => ({ content: [] }),
+  );
+
+  const resourceName = options.resourceName ?? options.toolName;
+  const htmlSource = options.html;
+
+  registerAppResource(
+    server as Pick<McpServer, "registerResource">,
+    resourceName,
+    options.resourceUri,
+    options.resourceMeta ?? {},
+    async () => {
+      const text = typeof htmlSource === "function" ? await htmlSource() : htmlSource;
+      return {
+        contents: [
+          {
+            uri: options.resourceUri,
+            mimeType: RESOURCE_MIME_TYPE,
+            text,
+          },
+        ],
+      };
+    },
+  );
+}
+
+export { RESOURCE_MIME_TYPE };

--- a/packages/typescript/integrations/mcp-apps-bridge/src/transport-pm.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/src/transport-pm.ts
@@ -1,9 +1,4 @@
-import type {
-  ClientTransport,
-  Connection,
-  MessageHandler,
-  SlopMessage,
-} from "@slop-ai/consumer/browser";
+import type { ClientTransport, Connection, MessageHandler, SlopMessage } from "@slop-ai/consumer/browser";
 
 /**
  * Consumer-side postMessage transport for same-window SLOP providers.
@@ -40,10 +35,7 @@ export class SameWindowPostMessageTransport implements ClientTransport {
     window.addEventListener("message", listener);
 
     // Handshake — identical to the Chrome-extension flow, but over window.postMessage.
-    this.targetWindow.postMessage(
-      { slop: true, message: { type: "connect" } },
-      this.originFilter,
-    );
+    this.targetWindow.postMessage({ slop: true, message: { type: "connect" } }, this.originFilter);
 
     return {
       send: (m: SlopMessage) => {

--- a/packages/typescript/integrations/mcp-apps-bridge/src/transport-pm.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/src/transport-pm.ts
@@ -1,0 +1,66 @@
+import type {
+  ClientTransport,
+  Connection,
+  MessageHandler,
+  SlopMessage,
+} from "@slop-ai/consumer/browser";
+
+/**
+ * Consumer-side postMessage transport for same-window SLOP providers.
+ *
+ * Mirrors the provider-side envelope from `@slop-ai/client` —
+ * `{ slop: true, message }` — so a provider instantiated with
+ * `createSlop({ transport: createPostMessageTransport() })` inside the same
+ * iframe as this bridge can be consumed without any network egress.
+ *
+ * Demultiplexing: only frames with `event.data?.slop === true` are claimed,
+ * so MCP Apps JSON-RPC frames pass through untouched to the ext-apps
+ * `App` listener running in the same window.
+ */
+export class SameWindowPostMessageTransport implements ClientTransport {
+  private targetWindow: Window;
+  private originFilter: string;
+
+  constructor(options: { targetWindow?: Window; origin?: string } = {}) {
+    this.targetWindow = options.targetWindow ?? window;
+    this.originFilter = options.origin ?? "*";
+  }
+
+  async connect(): Promise<Connection> {
+    const messageHandlers: MessageHandler[] = [];
+    const closeHandlers: (() => void)[] = [];
+
+    const listener = (event: MessageEvent) => {
+      if (event.source !== this.targetWindow) return;
+      if (event.data?.slop !== true) return;
+      const msg = event.data.message as SlopMessage | undefined;
+      if (!msg || typeof (msg as { type?: unknown }).type !== "string") return;
+      for (const h of messageHandlers) h(msg);
+    };
+    window.addEventListener("message", listener);
+
+    // Handshake — identical to the Chrome-extension flow, but over window.postMessage.
+    this.targetWindow.postMessage(
+      { slop: true, message: { type: "connect" } },
+      this.originFilter,
+    );
+
+    return {
+      send: (m: SlopMessage) => {
+        this.targetWindow.postMessage({ slop: true, message: m }, this.originFilter);
+      },
+      onMessage: (h: MessageHandler) => {
+        messageHandlers.push(h);
+      },
+      onClose: (h: () => void) => {
+        closeHandlers.push(h);
+      },
+      close: () => {
+        window.removeEventListener("message", listener);
+        for (const h of closeHandlers) h();
+        messageHandlers.length = 0;
+        closeHandlers.length = 0;
+      },
+    };
+  }
+}

--- a/packages/typescript/integrations/mcp-apps-bridge/tsconfig.json
+++ b/packages/typescript/integrations/mcp-apps-bridge/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "declaration": true,
+    "lib": ["ES2022", "DOM"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/website/docs/content-manifest.mjs
+++ b/website/docs/content-manifest.mjs
@@ -81,7 +81,7 @@ export const docsPages = [
   }),
   page("docs/guides/advanced/mcp-bridge.md", "guides/advanced/mcp-bridge.md", {
     label: "MCP Apps Bridge",
-    description: "Expose SLOP providers through MCP Apps and model-context projections",
+    description: "Render a SLOP provider inside an MCP Apps host (VS Code, Claude, Goose) with model-callable affordances",
     redirects: ["/guides-advanced/mcp-bridge"],
   }),
   page("docs/guides/advanced/openclaw.md", "guides/advanced/openclaw.md", {

--- a/website/docs/content-manifest.mjs
+++ b/website/docs/content-manifest.mjs
@@ -81,7 +81,8 @@ export const docsPages = [
   }),
   page("docs/guides/advanced/mcp-bridge.md", "guides/advanced/mcp-bridge.md", {
     label: "MCP Apps Bridge",
-    description: "Render a SLOP provider inside an MCP Apps host (VS Code, Claude, Goose) with model-callable affordances",
+    description:
+      "Render a SLOP provider inside an MCP Apps host (VS Code, Claude, Goose) with model-callable affordances",
     redirects: ["/guides-advanced/mcp-bridge"],
   }),
   page("docs/guides/advanced/openclaw.md", "guides/advanced/openclaw.md", {

--- a/website/docs/src/content/docs/guides/advanced/mcp-bridge.md
+++ b/website/docs/src/content/docs/guides/advanced/mcp-bridge.md
@@ -10,7 +10,7 @@ The `@slop-ai/mcp-apps-bridge` package handles three things:
 - **`registerSlopView`** — server-side helper that wires the MCP tool + `ui://` resource + sandbox CSP.
 - **`registerSlopTools`** — server-side helper that mirrors every SLOP affordance as a callable MCP tool, with `tools/listChanged` resync on every patch.
 
-For an end-to-end runnable example, see [`examples/mcp-apps-bridge`](https://github.com/devteapot/slop/tree/main/examples/mcp-apps-bridge).
+This guide is the developer-facing complement to the normative [MCP Interoperability spec](/spec/integrations/mcp). For an end-to-end runnable example, see [`examples/mcp-apps-bridge`](https://github.com/devteapot/slop/tree/main/examples/mcp-apps-bridge).
 
 ## When to use this
 
@@ -172,4 +172,4 @@ If the iframe shows `error: WebSocket connection failed`, the most common cause 
 
 ## Future direction
 
-When MCP standardizes event-driven resource subscriptions (tracked in the [2026 roadmap](https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/)), the bridge will offer a third `mode: "mcp-tunnel"` that doesn't require the iframe to open a WebSocket — all SLOP traffic flows over MCP's own subscription channel. Until then, `ws` + `connectDomains` is the recommended pattern.
+When MCP standardizes event-driven resource subscriptions (tracked in the [2026 roadmap](https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/)), the bridge will offer a third `mode: "mcp-tunnel"` that doesn't require the iframe to open a WebSocket — all SLOP traffic flows over MCP's own subscription channel. Until then, `ws` + `connectDomains` is the recommended pattern. See the ["No formal MCP extension" entry](/spec/limitations#no-formal-mcp-extension) for the planned SEP.

--- a/website/docs/src/content/docs/guides/advanced/mcp-bridge.md
+++ b/website/docs/src/content/docs/guides/advanced/mcp-bridge.md
@@ -1,95 +1,175 @@
 ---
 title: "MCP Apps Bridge"
-description: "Expose SLOP providers through MCP Apps and model-context projections"
+description: "Render a SLOP provider inside an MCP Apps host (VS Code, Claude, Goose) with model-callable affordances"
 ---
-Expose a SLOP provider inside an MCP Apps host (Claude, ChatGPT, Goose, VS Code) so an embedded SLOP consumer can subscribe to live state, project selected state into model context, and invoke affordances from the chat surface.
+Expose a SLOP provider inside an MCP Apps host (Claude, ChatGPT, Goose, VS Code Insiders) so the host model can subscribe to live state and call your app's affordances directly from chat.
 
-This guide is the developer-facing complement to the normative [MCP Interoperability](/spec/integrations/mcp) spec.
+The `@slop-ai/mcp-apps-bridge` package handles three things:
+
+- **Iframe-side bridge** — runs inside the sandboxed `ui://` view, opens a SLOP consumer, projects salience-filtered state into `app.updateModelContext`.
+- **`registerSlopView`** — server-side helper that wires the MCP tool + `ui://` resource + sandbox CSP.
+- **`registerSlopTools`** — server-side helper that mirrors every SLOP affordance as a callable MCP tool, with `tools/listChanged` resync on every patch.
+
+This guide is the developer-facing complement to the normative [MCP Interoperability spec](../../../spec/integrations/mcp.md). For an end-to-end runnable example, see [`examples/mcp-apps-bridge`](https://github.com/devteapot/slop/tree/main/examples/mcp-apps-bridge).
 
 ## When to use this
 
-Use the MCP Apps bridge when:
+- Your users interact with SLOP-aware apps through a chat UI (Claude / VS Code chat / Goose / etc.) and you want the model to both *observe* state and *act* on it inside the same conversation.
+- You already have a SLOP provider — adding the bridge is a server file plus an iframe bundle.
 
-- Your users interact with SLOP-aware apps through Claude or ChatGPT rather than a standalone SLOP consumer.
-- You want a single integration that reaches MCP Apps hosts without implementing each host's UI extension API separately.
-- You already have a SLOP provider and do not want to rewrite it as an MCP tool server.
+If your target host doesn't support MCP Apps yet, use the [Claude Code integration](/guides/advanced/claude-code) (proxy pattern) instead.
 
-Use the [MCP proxy](/guides/advanced/claude-code) instead when your target host doesn't support MCP Apps yet, or when you want a flat tool catalog rather than live state.
-
-## How it works
-
-MCP Apps lets an MCP tool return a `ui://` resource. The host fetches it and renders it in a sandboxed iframe, wiring a JSON-RPC channel over `postMessage`. That `postMessage` channel is already a [native SLOP transport](/spec/core/transport#postmessage-convention), so the bridge is a thin multiplexer.
+## Architecture
 
 ```
-MCP host ──► open_slop_view tool
-                │
-                ▼
-        iframe (ui://slop/...)
-        ├── @slop-ai/spa consumer
-        └── SLOP provider (in-iframe OR WS relay)
+┌─ host (VS Code Insiders / Claude / Goose) ─────────────────────────┐
+│                                                                     │
+│   MCP client ──stdio──▶ MCP server                                  │
+│        │                  │                                          │
+│        │                  ├── SLOP provider (yours)                 │
+│        │                  │                                          │
+│        │                  ├── registerSlopView  ── tool + ui://     │
+│        │                  └── registerSlopTools ── one MCP tool     │
+│        │                                              per affordance │
+│        ▼                                                             │
+│   sandboxed iframe (open_*your_view*)                                │
+│        │                                                             │
+│        └── createMcpAppsBridge ──ws──▶ same SLOP provider           │
+│              ├── consumer mirrors tree                               │
+│              ├── projector → app.updateModelContext (debounced)     │
+│              └── you render UI from consumer.getTree()              │
+└─────────────────────────────────────────────────────────────────────┘
 ```
 
-Inside the iframe, SLOP frames carry `{ slop: true, message }`. MCP Apps frames don't. The adapter routes on that field.
+A single Node process typically hosts the SLOP provider, the MCP server, and the WS endpoint. The iframe is a thin client.
 
-## Minimum integration
+## Server: register the view + the tools
 
-1. **Expose one MCP Apps tool** whose sole job is to open the view:
+```ts
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  registerSlopView,
+  registerSlopTools,
+} from "@slop-ai/mcp-apps-bridge/server";
+import { createSlopServer } from "@slop-ai/server";
+import { bunHandler } from "@slop-ai/server/bun";
+import { readFile } from "node:fs/promises";
 
-   ```ts
-   import {
-     RESOURCE_MIME_TYPE,
-     registerAppResource,
-     registerAppTool,
-   } from "@modelcontextprotocol/ext-apps/server";
-   import { readFile } from "node:fs/promises";
+const PORT = 7411;
+const slop = createSlopServer({ id: "kanban", name: "Kanban" });
+// register your nodes + actions on slop ...
 
-   const resourceUri = "ui://your-app/slop";
+// Expose the SLOP provider over WebSocket (Bun example; use attachSlop for Node).
+const slopHandler = bunHandler(slop, { path: "/slop" });
+Bun.serve({
+  port: PORT,
+  hostname: "127.0.0.1",
+  fetch(req, srv) {
+    return slopHandler.fetch(req, srv) ?? new Response("ok");
+  },
+  websocket: slopHandler.websocket,
+});
 
-   registerAppTool(
-     server,
-     "open_slop_view",
-     {
-       description: "Open a live view of your app state",
-       inputSchema: {},
-       _meta: { ui: { resourceUri } },
-     },
-     async () => ({ content: [] }),
-   );
+const RESOURCE_URI = "ui://my-app/view";
+const mcp = new McpServer(
+  { name: "my-app", version: "0.1.0" },
+  { capabilities: { tools: { listChanged: true }, resources: {} } },
+);
 
-   registerAppResource(
-     server,
-     "SLOP View",
-     resourceUri,
-     {},
-     async () => {
-       const html = await readFile(new URL("./dist/slop.html", import.meta.url), "utf8");
-       return {
-         contents: [{ uri: resourceUri, mimeType: RESOURCE_MIME_TYPE, text: html }],
-       };
-     },
-   );
-   ```
+registerSlopView(mcp, {
+  toolName: "open_kanban",
+  description: "Open a live view of the kanban board",
+  resourceUri: RESOURCE_URI,
+  resourceName: "Kanban View",
+  html: () => readFile(new URL("./dist/iframe.html", import.meta.url), "utf8"),
+  // CRITICAL for sandboxed hosts: whitelist the SLOP provider's WS origin.
+  // Without this, VS Code's webview blocks the iframe's WS connection.
+  connectDomains: [`ws://127.0.0.1:${PORT}`],
+});
 
-   `registerAppResource`'s second argument is a display name for the host. The `RESOURCE_MIME_TYPE` default is supplied by the helper, so the metadata object can be empty; it's still set explicitly on the returned `contents[]` so the host sees the MCP Apps MIME type.
+await registerSlopTools(mcp, {
+  url: `ws://127.0.0.1:${PORT}/slop`,
+  uiResourceUri: RESOURCE_URI, // tags every tool with the iframe surface
+});
 
-2. **Serve the UI resource** as a static HTML bundle that loads `@slop-ai/spa` (for in-iframe providers) or `@slop-ai/consumer` + a WebSocket relay (for remote providers).
+await mcp.connect(new StdioServerTransport());
+```
 
-3. **Project state into the model** by calling `app.updateModelContext()` with a salience-filtered snapshot whenever the SLOP consumer receives a meaningful snapshot or patch. Do not ship raw trees — the model's context window is limited; use `min_salience` on the subscription and debounce updates.
+What `registerSlopTools` does: connects to the SLOP provider as a consumer, walks the affordances via `affordancesToTools`, and registers one MCP tool per `(action, schema)` group (so 1000 cards each with a `delete` affordance produce **one** `delete` MCP tool with a `target` parameter, not 1000). Resyncs on every patch and emits `tools/listChanged`.
 
-4. **Route invocations** from the UI to the SLOP provider. If you want the model itself to call affordances, expose each affordance as an MCP tool on the server and forward the invocation through the iframe.
+## Iframe: render + project
+
+The iframe bundle is plain HTML/JS served by `registerSlopView`. Bundle it however you like (Bun, Vite, esbuild) — the demo uses a single-file HTML wrapper.
+
+```ts
+import { createMcpAppsBridge } from "@slop-ai/mcp-apps-bridge";
+import type { SlopNode } from "@slop-ai/consumer/browser";
+
+const bridge = await createMcpAppsBridge({
+  provider: { mode: "ws", url: "ws://127.0.0.1:7411/slop" },
+  subscribe: { depth: -1, minSalience: 0.3 },
+  projection: { header: "# Kanban — live state from the iframe" },
+});
+
+// Render UI from the consumer's mirrored tree.
+function render(tree: SlopNode | null) { /* your DOM updates */ }
+render(bridge.getTree());
+bridge.consumer.on("patch", () => render(bridge.getTree()));
+```
+
+The bridge's other mode is `{ mode: "postmessage" }` for client-only setups where the SLOP provider runs inside the iframe via `@slop-ai/client`. Use `ws` mode whenever there's a server-side authoritative state.
+
+## Provider modes
+
+| Mode | When to use | Tradeoffs |
+|---|---|---|
+| `ws` | Server-side authoritative state. The MCP server, SLOP provider, and tool-registering consumer all run in one process. | Requires `connectDomains` for sandboxed hosts. The architecture every non-toy app wants. |
+| `postmessage` | Client-only / no backend. SLOP provider lives in the iframe via `@slop-ai/client`. | Model can't act on state via `registerSlopTools` (server has no consumer to discover affordances from). State is iframe-local. |
+
+## How the model sees state
+
+The bridge calls `app.updateModelContext` with a debounced markdown projection of the salience-filtered tree on every snapshot/patch. The projection includes the state tree (via `formatTree`) **and** the affordance list (via `affordancesToTools`). The model receives this in context on the *next* turn after the iframe opens — so the very first response after `open_*` won't see state yet, but every subsequent turn will.
+
+To validate: open the view, then ask a question whose answer depends on tree contents. The model should answer without making another tool call.
+
+## Caveats and known gotchas
+
+- **Sandboxed network.** Hosts like VS Code's webview default to "no network." If you don't pass `connectDomains` to `registerSlopView`, your `ws` iframe will silently fail to connect. The bridge surfaces this as `error: WebSocket connection failed` in the iframe status line if you wrap `createMcpAppsBridge` in a try/catch.
+- **First-turn latency.** `app.updateModelContext` lands asynchronously after the tool returns. The model that just called `open_*` won't see state until its next turn.
+- **Tool descriptions inline param info.** The MCP SDK only accepts Zod schemas for `inputSchema`, not raw JSON Schema. `registerSlopTools` works around this with a permissive passthrough schema and stuffs the SLOP affordance's params + valid `target` paths into the tool *description*. The model handles this fine; future versions will convert SLOP JSON Schema → Zod for proper validation.
+- **`tools/list_changed` is chatty.** Currently fires once per patch resync; in apps with high patch frequency, consider widening the bridge's resync debounce (PRs welcome).
+- **Big trees flood context.** The default projection ships the entire salience-filtered tree as markdown on every patch. For apps with thousands of nodes use a stricter `subscribe.minSalience` and a custom `projection.format` that summarizes rather than emits every node. See the [scaling extension](/spec/extensions/scaling).
 
 ## Security
 
 The host's iframe sandbox and user-consent prompts are defense in depth. They are **not** the authorization boundary. Your SLOP provider must re-authorize every affordance invocation against live state and caller identity, exactly as it would for a direct WebSocket consumer.
 
-For remote providers, the iframe's WebSocket relay should use a short-lived token minted by your backend for that app session. Do not put provider bearer tokens into MCP tool `content`, `structuredContent`, or any model-visible context. Keep iframe origins and CSP as narrow as the host allows.
+For remote providers (production), use a short-lived token in the WS URL minted per-session by your backend. Don't put bearer tokens in MCP tool `content` or anywhere model-visible — they end up in conversation transcripts.
 
-## Limitations
+## Validating in real hosts
 
-- **No native model-visible SLOP subscription.** MCP resources can support change subscriptions, and Streamable HTTP can carry server-to-client notifications, but MCP Apps still require explicit model-context updates. Debounce `updateModelContext` — every call consumes context tokens.
-- **No cross-tool affordances.** An affordance triggered from the UI runs through the bridge, not as a first-class MCP tool call, so the model doesn't see it in its tool trace. If you want the model to invoke affordances, publish them as MCP tools as well.
-- **Host support is uneven.** MCP Apps shipped in January 2026. Older MCP hosts fall back to rendering the tool's text result; ship a plain-text summary alongside the `ui://` resource for graceful degradation.
+The smoke test we use:
+
+1. Build the demo: `cd examples/mcp-apps-bridge && bun run build`.
+2. Register the server in **VS Code Insiders** (Cmd+Shift+P → `MCP: Open User Configuration`):
+   ```jsonc
+   {
+     "servers": {
+       "slop-kanban": {
+         "type": "stdio",
+         "command": "bun",
+         "args": ["<absolute-path-to>/dist/server.js"]
+       }
+     }
+   }
+   ```
+3. Reload the window, open Copilot Chat, ask: `Use the open_kanban tool`. The iframe should render with status `connected`.
+4. Ask: `What cards are in todo?` — model should answer without another tool call.
+5. Ask: `Add a card called "Ship it" to todo` — the model calls `add_card`, the iframe re-renders, and the next turn's context reflects the new card.
+
+If the iframe shows `error: WebSocket connection failed`, the most common cause is missing `connectDomains` (or VS Code holding a cached MCP server connection — Stop + Start the server in `MCP: List Servers`).
 
 ## Future direction
 
-If MCP standardizes event-driven resource updates or a SLOP-specific extension, the bridge can move from `updateModelContext` projections to a direct `slop/subscribe` stream over MCP. See the [MCP extension future work entry](/spec/limitations#no-formal-mcp-extension) for the planned SEP.
+When MCP standardizes event-driven resource subscriptions (tracked in the [2026 roadmap](https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/)), the bridge will offer a third `mode: "mcp-tunnel"` that doesn't require the iframe to open a WebSocket — all SLOP traffic flows over MCP's own subscription channel. Until then, `ws` + `connectDomains` is the recommended pattern. See the ["No formal MCP extension" entry](/spec/limitations#no-formal-mcp-extension) for the planned SEP.

--- a/website/docs/src/content/docs/guides/advanced/mcp-bridge.md
+++ b/website/docs/src/content/docs/guides/advanced/mcp-bridge.md
@@ -10,7 +10,7 @@ The `@slop-ai/mcp-apps-bridge` package handles three things:
 - **`registerSlopView`** — server-side helper that wires the MCP tool + `ui://` resource + sandbox CSP.
 - **`registerSlopTools`** — server-side helper that mirrors every SLOP affordance as a callable MCP tool, with `tools/listChanged` resync on every patch.
 
-This guide is the developer-facing complement to the normative [MCP Interoperability spec](../../../spec/integrations/mcp.md). For an end-to-end runnable example, see [`examples/mcp-apps-bridge`](https://github.com/devteapot/slop/tree/main/examples/mcp-apps-bridge).
+For an end-to-end runnable example, see [`examples/mcp-apps-bridge`](https://github.com/devteapot/slop/tree/main/examples/mcp-apps-bridge).
 
 ## When to use this
 
@@ -172,4 +172,4 @@ If the iframe shows `error: WebSocket connection failed`, the most common cause 
 
 ## Future direction
 
-When MCP standardizes event-driven resource subscriptions (tracked in the [2026 roadmap](https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/)), the bridge will offer a third `mode: "mcp-tunnel"` that doesn't require the iframe to open a WebSocket — all SLOP traffic flows over MCP's own subscription channel. Until then, `ws` + `connectDomains` is the recommended pattern. See the ["No formal MCP extension" entry](/spec/limitations#no-formal-mcp-extension) for the planned SEP.
+When MCP standardizes event-driven resource subscriptions (tracked in the [2026 roadmap](https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/)), the bridge will offer a third `mode: "mcp-tunnel"` that doesn't require the iframe to open a WebSocket — all SLOP traffic flows over MCP's own subscription channel. Until then, `ws` + `connectDomains` is the recommended pattern.


### PR DESCRIPTION
## Summary

Adds `@slop-ai/mcp-apps-bridge`, the iframe + server adapter that lets a SLOP provider render inside an MCP Apps host. The iframe runs a `SlopConsumer` and `ext-apps` `App` in the same window, demuxes the `{ slop: true, message }` envelope from MCP JSON-RPC frames, and pushes salience-filtered markdown projections of the state tree into `app.updateModelContext` on every snapshot/patch (250ms debounce).

A small server helper (`registerSlopView`) wraps `registerAppTool` + `registerAppResource` from `@modelcontextprotocol/ext-apps/server` so publishing a SLOP view is a ~10-line change on an existing MCP server.

A demo MCP server (`examples/mcp-apps-bridge/`) exposes `open_kanban` backed by an in-iframe kanban provider, used to validate the bridge end-to-end.

## What's in the package

```
packages/typescript/integrations/mcp-apps-bridge/
├── src/
│   ├── bridge.ts             — createMcpAppsBridge({ provider, subscribe, projection })
│   ├── transport-pm.ts       — SameWindowPostMessageTransport (consumer-side, demuxes against MCP frames)
│   ├── projection.ts         — salience-filtered markdown renderer + debounced projector
│   ├── server.ts             — registerSlopView() facade
│   └── index.ts              — exports
├── __tests__/                — projection + transport unit tests (10 pass)
└── README.md
```

Two subpath exports mirror upstream `ext-apps` + `/server`:
- `@slop-ai/mcp-apps-bridge` — iframe entry
- `@slop-ai/mcp-apps-bridge/server` — server helper

## Validation

- ✅ Unit tests (10 pass): postMessage envelope demux, projection debounce coalescing, custom format hook, dispose cancels pending projections.
- ✅ Repo-wide `bun run build` stays green.
- ✅ MCP Inspector smoke: `tools/list` → `open_kanban`, `resources/read` → 340KB iframe HTML.
- ✅ **VS Code Insiders end-to-end**: iframe renders inline in chat, model answers state questions on follow-up turns without extra tool calls (state arrives via `updateModelContext`).
- ⏭️ Goose validation deferred — same wire format, expected to work; will verify in a follow-up.

## Test plan

- [ ] Reviewer can run `cd examples/mcp-apps-bridge && bun run build && bunx @modelcontextprotocol/inspector bun dist/server.js` and see the tool + resource listed.
- [ ] Reviewer with VS Code Insiders can wire `slop-kanban` into MCP user config, ask "use the open_kanban tool", and see the iframe render.
- [ ] Reviewer can ask a follow-up about the board state and confirm the model answers correctly without an extra tool call.

## Related

- Implements the bridge described in `spec/integrations/mcp.md` (added in #44).
- Out of scope (follow-ups): `exposeAffordancesAsTools` (model-initiated affordance invocation), CSP metadata, Goose validation, WS-mode end-to-end test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)