### PR TITLE
[codex] Fix npm trusted publishing release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,10 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
-      - name: Setup Node.js for npm provenance
+      - name: Setup Node.js for npm trusted publishing
         uses: actions/setup-node@v6
         with:
+          node-version: "24"
           registry-url: https://registry.npmjs.org
 
       - name: Install workspace dependencies
@@ -32,7 +33,6 @@ jobs:
         run: bun run release:publish-packages "${{ github.event.release.tag_name }}"
         env:
           NPM_TAG: ${{ github.event.release.prerelease && 'next' || '' }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-python:
     name: Publish Python package

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -52,7 +52,13 @@ The extension and desktop app `package.json` / `manifest.json` / `tauri.conf.jso
 
 ### npm packages
 
-No secret required. npm publishing uses [Trusted Publishing](https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions) via GitHub OIDC. Each `@slop-ai/*` package must have `devteapot/slop` + `release.yml` configured as a trusted publisher in its npmjs.com settings.
+No secret required. npm publishing uses [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) via GitHub OIDC. Each `@slop-ai/*` package must have `devteapot/slop` + `release.yml` configured as a trusted publisher in its npmjs.com settings.
+
+New `@slop-ai/*` package names need the same package-level trusted publisher
+setup before they can be published by the release workflow. If npm cannot
+configure trusted publishing before the first publish for a new package, publish
+the initial package version manually or with a temporary token, then enable the
+trusted publisher and remove that token.
 
 ### Chrome Web Store
 
@@ -155,7 +161,7 @@ git push origin "packages/go/slop-ai/v0.2.0"
 ## Notes
 
 - Release tags use SemVer: `vX.Y.Z` for stable releases, `vX.Y.Z-rc.N` (or any pre-release suffix) for release candidates. Pre-release npm packages are published under the `next` dist-tag.
-- TypeScript packages are published via `npm publish --provenance` using npm Trusted Publishing (OIDC). No `NPM_TOKEN` secret is required — the workflow uses `id-token: write` permissions and GitHub's OIDC provider. Builds still use Bun; only the publish step uses npm for provenance support.
+- TypeScript packages are published via `npm publish --provenance` using npm Trusted Publishing (OIDC). No `NPM_TOKEN` secret is required — the workflow uses `id-token: write` permissions, GitHub's OIDC provider, and Node 24 so the npm CLI supports trusted publishing. Builds still use Bun; only the publish step uses npm for provenance support.
 - The desktop workflow builds distributable binaries, but platform signing and notarization can be layered on separately if you want trusted installers.
 - The release workflow now expects the macOS signing + notarization secrets above on macOS runners and will fail the macOS desktop build if they are missing.
 - The Go module path now matches the monorepo subdirectory: `github.com/devteapot/slop/packages/go/slop-ai`.


### PR DESCRIPTION
## Summary

- Update the release npm publish job to use Node 24 for npm Trusted Publishing support.
- Stop passing the expired `NPM_TOKEN`/`NODE_AUTH_TOKEN` to `npm publish`, so configured packages use OIDC.
- Document the one-time bootstrap requirement for new `@slop-ai/*` package names before CI can publish them with Trusted Publishing.

## Why

The `v0.2.0-rc.1` release exposed that npm publishing was falling back to the expired token. The workflow also used Node 20/npm 10, while current npm Trusted Publishing requires a newer npm CLI; using Node 24 lets the publish step use the OIDC flow for existing packages that already have trusted publisher configuration.

## Validation

- `bun run preflight --files .github/workflows/release.yml docs/releasing.md`
