### PR TITLE
[codex] Fix discovery npm bin path

### DIFF
--- a/packages/typescript/integrations/discovery/package.json
+++ b/packages/typescript/integrations/discovery/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "slop-discovery": "./dist/cli.js"
+    "slop-discovery": "dist/cli.js"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary

- Normalize the `@slop-ai/discovery` npm `bin` target from `./dist/cli.js` to `dist/cli.js`.

## Why

The `v0.2.0-rc.2` npm release job reached the new `@slop-ai/discovery` package and npm warned that the `slop-discovery` bin entry was invalid and would be removed from the packed package. This keeps the package CLI installable before the manual bootstrap publish.

## Validation

- `bun run build` in `packages/typescript/integrations/discovery`
- `env npm_config_cache=/tmp/npm-cache npm pack --dry-run` in `packages/typescript/integrations/discovery`
- `bun run preflight --files packages/typescript/integrations/discovery/package.json`
