### PR TITLE
[codex] Add turnkey MCP Apps bridge server

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -331,7 +331,7 @@
       "name": "@slop-ai/discovery",
       "version": "0.1.0",
       "bin": {
-        "slop-discovery": "./dist/cli.js",
+        "slop-discovery": "dist/cli.js",
       },
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.114",
@@ -348,24 +348,19 @@
     "packages/typescript/integrations/mcp-apps-bridge": {
       "name": "@slop-ai/mcp-apps-bridge",
       "version": "0.1.0",
+      "bin": {
+        "slop-mcp-apps-bridge": "dist/cli.js",
+      },
       "dependencies": {
+        "@modelcontextprotocol/ext-apps": "^1.7.0",
+        "@modelcontextprotocol/sdk": "^1.12.0",
         "@slop-ai/consumer": "workspace:*",
+        "@slop-ai/discovery": "workspace:*",
+        "zod": "^3.25.0",
       },
       "devDependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.7.0",
-        "@modelcontextprotocol/sdk": "^1.12.0",
         "@types/node": "^25.6.0",
-        "zod": "^3.25.0",
       },
-      "peerDependencies": {
-        "@modelcontextprotocol/ext-apps": "^1.7.0",
-        "@modelcontextprotocol/sdk": "^1.12.0",
-        "zod": "^3.25.0",
-      },
-      "optionalPeers": [
-        "@modelcontextprotocol/sdk",
-        "zod",
-      ],
     },
     "packages/typescript/integrations/openclaw-plugin": {
       "name": "@slop-ai/openclaw-plugin",

--- a/docs/guides/advanced/mcp-bridge.md
+++ b/docs/guides/advanced/mcp-bridge.md
@@ -1,23 +1,46 @@
 # MCP Apps Bridge
 
-Expose a SLOP provider inside an MCP Apps host (Claude, ChatGPT, Goose, VS Code Insiders) so the host model can subscribe to live state and call your app's affordances directly from chat.
+Expose SLOP providers inside MCP Apps hosts (Claude, ChatGPT, Goose, VS Code Insiders) so the host model can subscribe to live state and call app affordances directly from chat.
 
-The `@slop-ai/mcp-apps-bridge` package handles three things:
+The `@slop-ai/mcp-apps-bridge` package has two surfaces:
 
-- **Iframe-side bridge** — runs inside the sandboxed `ui://` view, opens a SLOP consumer, projects salience-filtered state into `app.updateModelContext`.
-- **`registerSlopView`** — server-side helper that wires the MCP tool + `ui://` resource + sandbox CSP.
-- **`registerSlopTools`** — server-side helper that mirrors every SLOP affordance as a callable MCP tool, with `tools/listChanged` resync on every patch.
+- **Installed bridge** — a stdio MCP server that discovers local SLOP providers, exposes `list_apps` and `open_app`, renders a generic MCP Apps view, and mirrors affordances as MCP tools. This is the main adoption path.
+- **Custom MCP App helpers** — lower-level primitives for app authors who want to ship a tailored iframe and MCP server: `createMcpAppsBridge`, `registerSlopView`, and `registerSlopTools`.
 
-This guide is the developer-facing complement to the normative [MCP Interoperability spec](../../../spec/integrations/mcp.md). For an end-to-end runnable example, see [`examples/mcp-apps-bridge`](https://github.com/devteapot/slop/tree/main/examples/mcp-apps-bridge).
+This guide is the developer-facing complement to the normative [MCP Interoperability spec](../../../spec/integrations/mcp.md). For an end-to-end runnable custom MCP App example, see [`examples/mcp-apps-bridge`](https://github.com/devteapot/slop/tree/main/examples/mcp-apps-bridge).
 
 ## When to use this
 
-- Your users interact with SLOP-aware apps through a chat UI (Claude / VS Code chat / Goose / etc.) and you want the model to both *observe* state and *act* on it inside the same conversation.
-- You already have a SLOP provider — adding the bridge is a server file plus an iframe bundle.
+- Use the **installed bridge** when you already have SLOP providers and want them available in MCP clients with minimal setup.
+- Use the **custom MCP App helpers** when you want a branded or app-specific iframe instead of the generic bridge view.
 
 If your target host doesn't support MCP Apps yet, use the [Claude Code integration](./claude-code.md) (proxy pattern) instead.
 
-## Architecture
+## Installed bridge
+
+Most users should start here:
+
+```bash
+npx -y @slop-ai/mcp-apps-bridge
+```
+
+Configure the command in your MCP client:
+
+```jsonc
+{
+  "servers": {
+    "slop": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@slop-ai/mcp-apps-bridge"]
+    }
+  }
+}
+```
+
+Then ask the host model to call `list_apps` and `open_app`. The bridge handles discovery, the generic `ui://` app view, model context updates, and generated SLOP action tools.
+
+## Custom MCP App architecture
 
 ```
 ┌─ host (VS Code Insiders / Claude / Goose) ─────────────────────────┐
@@ -39,7 +62,7 @@ If your target host doesn't support MCP Apps yet, use the [Claude Code integrati
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
-A single Node process typically hosts the SLOP provider, the MCP server, and the WS endpoint. The iframe is a thin client.
+In custom mode, a single Node process typically hosts the SLOP provider, the MCP server, and the WS endpoint. The iframe is a thin client.
 
 ## Server: register the view + the tools
 
@@ -145,9 +168,17 @@ The host's iframe sandbox and user-consent prompts are defense in depth. They ar
 
 For remote providers (production), use a short-lived token in the WS URL minted per-session by your backend. Don't put bearer tokens in MCP tool `content` or anywhere model-visible — they end up in conversation transcripts.
 
-## Validating in real hosts
+## Validating the installed bridge
 
-The smoke test we use:
+1. Start a SLOP provider that registers through discovery.
+2. Register `npx -y @slop-ai/mcp-apps-bridge` in VS Code, Claude Desktop, Goose, or the MCP Inspector.
+3. Ask the host model to call `list_apps`.
+4. Ask it to open one of the discovered apps with `open_app`.
+5. Verify that the generic app view renders and generated action tools can mutate the provider.
+
+## Validating the custom example
+
+The custom MCP App smoke test we use:
 
 1. Build the demo: `cd examples/mcp-apps-bridge && bun run build`.
 2. Register the server in **VS Code Insiders** (Cmd+Shift+P → `MCP: Open User Configuration`):
@@ -162,7 +193,7 @@ The smoke test we use:
      }
    }
    ```
-3. Reload the window, open Copilot Chat, ask: `Use the open_kanban tool`. The iframe should render with status `connected`.
+3. Reload the window, open Copilot Chat, ask: `Use the open_kanban tool`. The iframe should render with status `connected`. This example does not expose `list_apps`; it is already one specific MCP App server.
 4. Ask: `What cards are in todo?` — model should answer without another tool call.
 5. Ask: `Add a card called "Ship it" to todo` — the model calls `add_card`, the iframe re-renders, and the next turn's context reflects the new card.
 

--- a/examples/mcp-apps-bridge/README.md
+++ b/examples/mcp-apps-bridge/README.md
@@ -1,6 +1,8 @@
-# mcp-apps-bridge demo
+# Custom MCP Apps bridge demo
 
-End-to-end example of a SLOP provider rendered inside an MCP Apps host (Claude / VS Code Insiders / Goose).
+Advanced example of a custom MCP App backed by a SLOP provider.
+
+This example intentionally runs its own MCP server. It is not the default installed bridge flow and it does not expose `list_apps` or `open_app`. Use it when you want to understand or build an app-specific MCP App iframe. For the normal adoption path, install `@slop-ai/mcp-apps-bridge` in the MCP client and let it discover regular SLOP providers.
 
 A single Node process runs three things:
 
@@ -43,6 +45,8 @@ bunx @modelcontextprotocol/inspector bun dist/server.js
 ```
 
 Reload window, then in chat: `Use the open_kanban tool to show me the board.`
+
+Do not ask this example to list discovered apps. It is already a specific MCP App server, so the relevant entrypoint is `open_kanban`.
 
 **Goose** — `~/.config/goose/config.yaml`:
 

--- a/packages/typescript/integrations/discovery/README.md
+++ b/packages/typescript/integrations/discovery/README.md
@@ -1,0 +1,91 @@
+# @slop-ai/discovery
+
+Provider discovery, bridge, and agent-tool helpers for SLOP consumers.
+
+Use this package when an integration needs to find local SLOP providers, connect to browser-tab providers through the extension bridge, expose lifecycle tools such as `list_apps`, or derive dynamic tools from provider affordances.
+
+See the [Discovery & Bridge guide](https://docs.slopai.dev/sdk/discovery/) for the full behavior contract.
+
+## Install
+
+```bash
+bun add @slop-ai/discovery
+```
+
+Install `@slop-ai/consumer` directly only when your integration also uses the lower-level protocol client APIs.
+
+## Entrypoints
+
+```ts
+import { createBridgeClient, createBridgeServer, BridgeRelayTransport } from "@slop-ai/discovery";
+import { createDiscoveryService } from "@slop-ai/discovery/service";
+import { createToolHandlers, createDynamicTools } from "@slop-ai/discovery/tools";
+```
+
+| Entrypoint | Purpose |
+| --- | --- |
+| `@slop-ai/discovery` | Bridge primitives and shared descriptor types. |
+| `@slop-ai/discovery/service` | Provider scanning, bridge startup, connection orchestration, idle cleanup, and reconnect handling. |
+| `@slop-ai/discovery/tools` | Host-agnostic lifecycle handlers and affordance-to-tool mapping. |
+| `@slop-ai/discovery/anthropic-agent-sdk` | Optional Anthropic Agent SDK helpers. |
+
+## Discovery service
+
+```ts
+import { createDiscoveryService } from "@slop-ai/discovery/service";
+
+const discovery = createDiscoveryService({
+  autoConnect: false,
+});
+
+discovery.start();
+
+const providers = discovery.getDiscovered();
+console.log(providers.map((provider) => provider.name));
+
+const provider = await discovery.ensureConnected("todo-app");
+const tree = provider?.consumer.getTree(provider.subscriptionId);
+
+console.log(tree);
+
+discovery.stop();
+```
+
+By default, the service scans `~/.slop/providers/` and `/tmp/slop/providers/`, watches for descriptor changes, and tries to use the extension bridge at `ws://127.0.0.1:9339/slop-bridge`. If no bridge is already running, the first discovery service hosts one.
+
+## Tool helpers
+
+```ts
+import { createDiscoveryService } from "@slop-ai/discovery/service";
+import { createDynamicTools, createToolHandlers } from "@slop-ai/discovery/tools";
+
+const discovery = createDiscoveryService({ autoConnect: true });
+const handlers = createToolHandlers(discovery);
+
+discovery.start();
+
+await handlers.listApps();
+await handlers.connectApp({ app: "todo-app" });
+
+const dynamicTools = createDynamicTools(discovery);
+const tool = dynamicTools.tools[0];
+const target = tool ? dynamicTools.resolve(tool.name) : null;
+
+console.log(tool, target);
+```
+
+`createToolHandlers()` returns lifecycle handlers for host integrations. `createDynamicTools()` converts connected provider affordances into namespaced tool definitions that can be registered by hosts with runtime tool catalogs.
+
+## CLI
+
+The package also ships `slop-discovery`, an MCP stdio server that exposes discovery lifecycle tools:
+
+```bash
+slop-discovery
+```
+
+## Documentation
+
+- Discovery & Bridge guide: https://docs.slopai.dev/sdk/discovery/
+- Consumer guide: https://docs.slopai.dev/guides/consumer/
+- API index: https://docs.slopai.dev/api/

--- a/packages/typescript/integrations/mcp-apps-bridge/README.md
+++ b/packages/typescript/integrations/mcp-apps-bridge/README.md
@@ -1,43 +1,189 @@
 # @slop-ai/mcp-apps-bridge
 
-Render a SLOP provider inside an MCP Apps iframe.
+Installable MCP Apps bridge for local SLOP providers.
 
-The bridge demultiplexes the sandboxed iframe's `postMessage` channel between MCP Apps (ext-apps `App`) and SLOP (snapshots, patches, invocations), then projects salience-filtered state into `app.updateModelContext()` so the host model sees what the user sees.
+Run it as a stdio MCP server and connect it to an MCP Apps host. It discovers SLOP apps through `@slop-ai/discovery`, exposes `open_app`, serves a generic interactive `ui://` view, and mirrors SLOP affordances as MCP tools.
 
-See the [MCP Apps Bridge guide](https://docs.slopai.dev/guides/advanced/mcp-bridge/) for end-to-end setup, the [MCP Interoperability spec](https://docs.slopai.dev/spec/integrations/mcp/) for the protocol-level contract, and the [demo](https://github.com/devteapot/slop/tree/main/examples/mcp-apps-bridge) for a runnable reference.
+See the [MCP Apps Bridge guide](https://docs.slopai.dev/guides/advanced/mcp-bridge/) for architecture details and [`examples/mcp-apps-bridge`](https://github.com/devteapot/slop/tree/main/examples/mcp-apps-bridge) for a custom app-specific bridge.
 
-## Install
+## Quick start
+
+No project setup is required for the default local bridge:
 
 ```bash
-bun add @slop-ai/mcp-apps-bridge @modelcontextprotocol/ext-apps
+npx -y @slop-ai/mcp-apps-bridge
 ```
 
-## Iframe
+The command starts a stdio MCP server. It writes logs to stderr and keeps stdout reserved for MCP, so most users run it through a client configuration rather than directly in a terminal.
+
+## Consumer configs
+
+### VS Code
+
+Open `MCP: Open User Configuration` or add `.vscode/mcp.json`:
+
+```jsonc
+{
+  "servers": {
+    "slop": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@slop-ai/mcp-apps-bridge"]
+    }
+  }
+}
+```
+
+Reload the window, start the server from `MCP: List Servers`, then ask Copilot Chat:
+
+```text
+List my SLOP apps, then open the kanban app.
+```
+
+### Claude Desktop
+
+Add the server under `mcpServers` in `claude_desktop_config.json`, then restart Claude:
+
+```json
+{
+  "mcpServers": {
+    "slop": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@slop-ai/mcp-apps-bridge"]
+    }
+  }
+}
+```
+
+Ask Claude to list SLOP apps or call `open_app`. If your Claude host supports MCP Apps resources, it will render the `ui://` view. If it only supports tools, it can still call the generated SLOP action tools.
+
+### Goose
+
+Add a command-line extension in Goose Desktop, or edit `~/.config/goose/config.yaml`:
+
+```yaml
+extensions:
+  slop:
+    type: stdio
+    cmd: npx
+    args: ["-y", "@slop-ai/mcp-apps-bridge"]
+    enabled: true
+```
+
+Restart Goose and ask it to open a discovered SLOP app.
+
+### MCP Inspector
+
+Use the inspector for a quick local smoke test:
+
+```bash
+bunx @modelcontextprotocol/inspector npx -y @slop-ai/mcp-apps-bridge
+```
+
+Call `list_apps`, then call `open_app` with an app name or ID.
+
+### Tool-only MCP clients
+
+Clients that support MCP tools but not MCP Apps iframes can still use the server. They will not render the generic app view, but they can call:
+
+- `list_apps`
+- `open_app`
+- `app_action`
+- `app_action_batch`
+- dynamic app-specific tools registered from connected affordances
+
+## What the server exposes
+
+| Tool | Purpose |
+| --- | --- |
+| `list_apps` | Lists discovered SLOP providers from local descriptor files and the browser bridge. |
+| `open_app` | Connects to a provider, returns its current state, and opens the generic MCP Apps view. |
+| `slop_get_state` | App-only helper used by the generic iframe to refresh provider state. |
+| `app_action` | Invokes one SLOP affordance by app, path, action, and params. |
+| `app_action_batch` | Invokes multiple affordances sequentially in one call. |
+| dynamic tools | When an app is connected, its affordances are exposed as namespaced MCP tools such as `kanban__todo__add_card`. |
+
+The generic view refreshes state through app-only server tools, so it can display providers discovered through Unix sockets, WebSockets, and the local browser bridge. It also calls `app.updateModelContext()` with the visible state so later model turns can reason over the app without another read tool call.
+
+## Local install
+
+For a pinned local install:
+
+```bash
+bun add @slop-ai/mcp-apps-bridge
+```
+
+Then point clients at the installed bin:
+
+```json
+{
+  "servers": {
+    "slop": {
+      "type": "stdio",
+      "command": "bunx",
+      "args": ["slop-mcp-apps-bridge"]
+    }
+  }
+}
+```
+
+## Library API
+
+The package still exports primitives for custom MCP App servers. Use these when you want an app-specific iframe instead of the generic discovery view.
+
+### Iframe bundle
 
 ```ts
 import { createMcpAppsBridge } from "@slop-ai/mcp-apps-bridge";
 
+const root = document.getElementById("app");
+
 const bridge = await createMcpAppsBridge({
   provider: { mode: "ws", url: "ws://localhost:3737/slop" },
   subscribe: { depth: -1, minSalience: 0.3 },
+  projection: { header: "# Local SLOP app" },
 });
+
+function render() {
+  if (!root) return;
+  root.textContent = JSON.stringify(bridge.getTree(), null, 2);
+}
+
+render();
+bridge.consumer.on("patch", render);
 ```
 
-## MCP server
+### MCP server helpers
 
 ```ts
-import { registerSlopView } from "@slop-ai/mcp-apps-bridge/server";
+import { readFile } from "node:fs/promises";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerSlopTools, registerSlopView } from "@slop-ai/mcp-apps-bridge/server";
+
+const SLOP_URL = process.env.SLOP_URL ?? "ws://127.0.0.1:3737/slop";
+const RESOURCE_URI = "ui://local-slop/app";
+
+const server = new McpServer(
+  { name: "local-slop", version: "0.1.0" },
+  { capabilities: { tools: { listChanged: true }, resources: {} } },
+);
 
 registerSlopView(server, {
-  toolName: "open_kanban",
-  description: "Live kanban board",
-  resourceUri: "ui://kanban/slop",
-  html: await readFile(new URL("./dist/slop.html", import.meta.url), "utf8"),
-  // Required when the iframe in `ws` mode runs in a sandboxed host (VS Code,
-  // Claude). Whitelists the origins the iframe is allowed to reach. Must
-  // include the SLOP provider URL above.
-  connectDomains: ["ws://localhost:3737"],
+  toolName: "open_slop_app",
+  description: "Open the live SLOP app",
+  resourceUri: RESOURCE_URI,
+  html: () => readFile(new URL("./iframe.html", import.meta.url), "utf8"),
+  connectDomains: [new URL(SLOP_URL).origin],
 });
+
+await registerSlopTools(server, {
+  url: SLOP_URL,
+  uiResourceUri: RESOURCE_URI,
+});
+
+await server.connect(new StdioServerTransport());
 ```
 
-Pair with `registerSlopTools(server, { url })` if you also want the model to invoke SLOP affordances directly from chat. See the [full guide](https://docs.slopai.dev/guides/advanced/mcp-bridge/) for the complete setup including the WS provider process.
+Use the custom helper path when you already have a known WebSocket provider and want a tailored UI. Use the default `slop-mcp-apps-bridge` binary when you want local discovery and a generic view.

--- a/packages/typescript/integrations/mcp-apps-bridge/README.md
+++ b/packages/typescript/integrations/mcp-apps-bridge/README.md
@@ -1,10 +1,19 @@
 # @slop-ai/mcp-apps-bridge
 
-Installable MCP Apps bridge for local SLOP providers.
+Expose local SLOP providers to MCP Apps hosts.
 
-Run it as a stdio MCP server and connect it to an MCP Apps host. It discovers SLOP apps through `@slop-ai/discovery`, exposes `open_app`, serves a generic interactive `ui://` view, and mirrors SLOP affordances as MCP tools.
+The default experience is an installed stdio MCP server. Connect it to VS Code, Claude Desktop, Goose, or another MCP client, and it discovers local SLOP apps through `@slop-ai/discovery`. The server exposes `list_apps`, `open_app`, a generic interactive `ui://` view, and MCP tools backed by each app's SLOP affordances.
 
-See the [MCP Apps Bridge guide](https://docs.slopai.dev/guides/advanced/mcp-bridge/) for architecture details and [`examples/mcp-apps-bridge`](https://github.com/devteapot/slop/tree/main/examples/mcp-apps-bridge) for a custom app-specific bridge.
+The package also exports lower-level helpers for app authors who want to build a custom MCP App surface instead of using the generic view.
+
+## Which path should I use?
+
+| Path | Use it when | What you configure |
+| --- | --- | --- |
+| Installed bridge | You already have SLOP providers and want them available in MCP clients. This is the main adoption path. | One MCP server command: `npx -y @slop-ai/mcp-apps-bridge`. |
+| Custom MCP App | You are building a polished app-specific iframe and MCP server. | `registerSlopView`, `registerSlopTools`, and `createMcpAppsBridge`. |
+
+See the [MCP Apps Bridge guide](https://docs.slopai.dev/guides/advanced/mcp-bridge/) for architecture details and [`examples/mcp-apps-bridge`](https://github.com/devteapot/slop/tree/main/examples/mcp-apps-bridge) for the custom MCP App path.
 
 ## Quick start
 
@@ -128,9 +137,9 @@ Then point clients at the installed bin:
 }
 ```
 
-## Library API
+## Advanced Library API
 
-The package still exports primitives for custom MCP App servers. Use these when you want an app-specific iframe instead of the generic discovery view.
+The package exports primitives for custom MCP App servers. Use these when you want an app-specific iframe instead of the generic discovery view. Most users should start with the installed bridge above.
 
 ### Iframe bundle
 
@@ -186,4 +195,4 @@ await registerSlopTools(server, {
 await server.connect(new StdioServerTransport());
 ```
 
-Use the custom helper path when you already have a known WebSocket provider and want a tailored UI. Use the default `slop-mcp-apps-bridge` binary when you want local discovery and a generic view.
+Use the custom helper path when you already have a known WebSocket provider and want a tailored UI. Use the default `slop-mcp-apps-bridge` binary when you want local discovery and the generic view.

--- a/packages/typescript/integrations/mcp-apps-bridge/package.json
+++ b/packages/typescript/integrations/mcp-apps-bridge/package.json
@@ -2,7 +2,7 @@
   "name": "@slop-ai/mcp-apps-bridge",
   "version": "0.1.0",
   "type": "module",
-  "description": "Render a SLOP provider inside an MCP Apps iframe. Bridges the ext-apps postMessage channel to a SLOP consumer and projects state into model context.",
+  "description": "Expose local SLOP providers to MCP Apps hosts with a discovery-backed bridge and optional custom app helpers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/typescript/integrations/mcp-apps-bridge/package.json
+++ b/packages/typescript/integrations/mcp-apps-bridge/package.json
@@ -5,6 +5,9 @@
   "description": "Render a SLOP provider inside an MCP Apps iframe. Bridges the ext-apps postMessage channel to a SLOP consumer and projects state into model context.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "slop-mcp-apps-bridge": "dist/cli.js"
+  },
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -26,25 +29,17 @@
     "directory": "packages/typescript/integrations/mcp-apps-bridge"
   },
   "scripts": {
-    "build": "bun build src/index.ts src/server.ts --outdir dist --format esm --target browser --external '@slop-ai/*' --external '@modelcontextprotocol/*' --external 'zod' && bunx tsc --emitDeclarationOnly --outDir dist",
+    "build": "bun build src/index.ts src/server.ts --outdir dist --format esm --target browser --external '@slop-ai/*' --external '@modelcontextprotocol/*' --external 'zod' && bun build src/cli.ts --outdir dist --format esm --target node --external '@slop-ai/*' --external '@modelcontextprotocol/*' --external 'zod' && bun build src/standalone-app.ts --outfile dist/standalone-app.js --format esm --target browser && bunx tsc --emitDeclarationOnly --outDir dist",
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@slop-ai/consumer": "workspace:*"
-  },
-  "peerDependencies": {
+    "@slop-ai/consumer": "workspace:*",
+    "@slop-ai/discovery": "workspace:*",
     "@modelcontextprotocol/ext-apps": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.12.0",
     "zod": "^3.25.0"
-  },
-  "peerDependenciesMeta": {
-    "@modelcontextprotocol/sdk": { "optional": true },
-    "zod": { "optional": true }
   },
   "devDependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.7.0",
-    "@modelcontextprotocol/sdk": "^1.12.0",
-    "@types/node": "^25.6.0",
-    "zod": "^3.25.0"
+    "@types/node": "^25.6.0"
   }
 }

--- a/packages/typescript/integrations/mcp-apps-bridge/src/cli.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/src/cli.ts
@@ -1,0 +1,576 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { McpServer, type RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { RESOURCE_MIME_TYPE, registerAppResource, registerAppTool } from "@modelcontextprotocol/ext-apps/server";
+import { affordancesToTools, formatTree, type SlopNode } from "@slop-ai/consumer";
+import { createDiscoveryService, type ConnectedProvider, type ProviderDescriptor } from "@slop-ai/discovery/service";
+import { createDynamicTools, createToolHandlers, type DynamicToolSet } from "@slop-ai/discovery/tools";
+import { z } from "zod";
+
+const VERSION = readPackageVersion();
+const RESOURCE_URI = "ui://slop/discovered-app";
+const PASSTHROUGH = z.object({}).passthrough() as never;
+
+type ToolContent = { type: "text"; text: string };
+type ToolResult = {
+  content: ToolContent[];
+  isError?: boolean;
+  structuredContent?: Record<string, unknown>;
+};
+
+interface ProviderSummary {
+  id: string;
+  name: string;
+  transport: ProviderDescriptor["transport"]["type"];
+  source: ProviderDescriptor["source"] | "local";
+  connected: boolean;
+  status?: ConnectedProvider["status"];
+}
+
+interface ActionSummary {
+  name: string;
+  description: string;
+  path: string | null;
+  action: string;
+  targets?: string[];
+  parameters: Record<string, unknown>;
+}
+
+interface SelectedProviderState {
+  id: string;
+  name: string;
+  tree: SlopNode | null;
+  formatted: string;
+  actions: ActionSummary[];
+}
+
+interface StatePayload {
+  updatedAt: number;
+  providers: ProviderSummary[];
+  selected?: SelectedProviderState;
+}
+
+interface OpenAppArgs {
+  app?: string;
+}
+
+interface AppActionArgs {
+  app: string;
+  path: string;
+  action: string;
+  params?: Record<string, unknown>;
+}
+
+interface AppActionBatchArgs {
+  app: string;
+  actions: {
+    path: string;
+    action: string;
+    params?: Record<string, unknown>;
+  }[];
+}
+
+const log = {
+  info: (...args: unknown[]) => console.error("[slop-mcp-apps-bridge]", ...args),
+  error: (...args: unknown[]) => console.error("[slop-mcp-apps-bridge] ERROR:", ...args),
+};
+
+function readPackageVersion(): string {
+  try {
+    const json = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as { version?: unknown };
+    return typeof json.version === "string" ? json.version : "0.1.0";
+  } catch {
+    return "0.1.0";
+  }
+}
+
+const discovery = createDiscoveryService({
+  logger: log,
+  autoConnect: false,
+  // Client-hosted MCP servers should not crash if the OS refuses another
+  // watcher. Periodic scans still pick up providers without consuming fds.
+  watchProviders: false,
+});
+const handlers = createToolHandlers(discovery);
+const server = new McpServer(
+  { name: "slop-mcp-apps-bridge", version: VERSION },
+  { capabilities: { tools: { listChanged: true }, resources: {} } },
+);
+
+let dynamicToolSet: DynamicToolSet = createDynamicTools(discovery);
+const registeredDynamicTools = new Map<string, RegisteredTool>();
+let standaloneHtml: string | null = null;
+
+function printHelp(): void {
+  console.log(`slop-mcp-apps-bridge ${VERSION}
+
+Start a stdio MCP server that discovers local SLOP apps and exposes them as MCP Apps.
+
+Usage:
+  slop-mcp-apps-bridge
+  npx -y @slop-ai/mcp-apps-bridge
+
+Client configuration example:
+  {
+    "servers": {
+      "slop": {
+        "type": "stdio",
+        "command": "npx",
+        "args": ["-y", "@slop-ai/mcp-apps-bridge"]
+      }
+    }
+  }
+`);
+}
+
+function jsonResult(payload: StatePayload): ToolResult {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload) }],
+    structuredContent: payload as unknown as Record<string, unknown>,
+  };
+}
+
+function errorResult(message: string): ToolResult {
+  return { isError: true, content: [{ type: "text", text: message }] };
+}
+
+function normalizeArgs(args: unknown): Record<string, unknown> {
+  return typeof args === "object" && args !== null ? { ...(args as Record<string, unknown>) } : {};
+}
+
+function notifyToolListChanged(): void {
+  try {
+    server.sendToolListChanged();
+  } catch {
+    // This can happen before the stdio transport is connected.
+  }
+}
+
+function providerMatches(provider: ConnectedProvider | ProviderDescriptor, idOrName: string): boolean {
+  const query = idOrName.toLowerCase();
+  return provider.id.toLowerCase() === query || provider.name.toLowerCase() === query;
+}
+
+function summaryMatches(provider: ProviderSummary, idOrName: string): boolean {
+  const query = idOrName.toLowerCase();
+  return provider.id.toLowerCase() === query || provider.name.toLowerCase() === query;
+}
+
+function summarizeProviders(): ProviderSummary[] {
+  const connected = discovery.getProviders();
+  const connectedById = new Map(connected.map((provider) => [provider.id, provider]));
+  const summaries: ProviderSummary[] = [];
+  const seen = new Set<string>();
+
+  for (const descriptor of discovery.getDiscovered()) {
+    const provider = connectedById.get(descriptor.id);
+    summaries.push({
+      id: descriptor.id,
+      name: provider?.name ?? descriptor.name,
+      transport: descriptor.transport.type,
+      source: descriptor.source ?? "local",
+      connected: !!provider,
+      status: provider?.status,
+    });
+    seen.add(descriptor.id);
+  }
+
+  for (const provider of connected) {
+    if (seen.has(provider.id)) continue;
+    summaries.push({
+      id: provider.id,
+      name: provider.name,
+      transport: provider.descriptor.transport.type,
+      source: provider.descriptor.source ?? "local",
+      connected: true,
+      status: provider.status,
+    });
+  }
+
+  return summaries;
+}
+
+function describeActions(provider: ConnectedProvider, tree: SlopNode | null): ActionSummary[] {
+  if (!tree) return [];
+  const toolSet = affordancesToTools(tree);
+  return toolSet.tools.flatMap((tool) => {
+    const resolved = toolSet.resolve(tool.function.name);
+    if (!resolved) return [];
+    return [
+      {
+        name: `${provider.id.replace(/[^a-zA-Z0-9]/g, "_")}__${tool.function.name}`,
+        description: tool.function.description,
+        path: resolved.path,
+        action: resolved.action,
+        targets: resolved.targets,
+        parameters: tool.function.parameters,
+      },
+    ];
+  });
+}
+
+async function getStatePayload(app?: string, connect = false): Promise<StatePayload> {
+  let selected: ConnectedProvider | null = null;
+
+  if (app) {
+    selected = connect
+      ? await discovery.ensureConnected(app)
+      : (discovery.getProviders().find((p) => providerMatches(p, app)) ?? null);
+  }
+
+  const providers = summarizeProviders();
+  const payload: StatePayload = {
+    updatedAt: Date.now(),
+    providers,
+  };
+
+  if (selected) {
+    const tree = selected.consumer.getTree(selected.subscriptionId);
+    payload.selected = {
+      id: selected.id,
+      name: selected.name,
+      tree,
+      formatted: tree ? formatTree(tree) : "(no state yet)",
+      actions: describeActions(selected, tree),
+    };
+  } else if (app && !providers.some((provider) => summaryMatches(provider, app))) {
+    log.info(`App not found: ${app}`);
+  }
+
+  return payload;
+}
+
+function summarizeState(payload: StatePayload): string {
+  if (payload.selected) {
+    const actionCount = payload.selected.actions.length;
+    return (
+      `Opened ${payload.selected.name} (id: ${payload.selected.id}).\n\n` +
+      `Available actions: ${actionCount}\n\n` +
+      `Current state:\n\n${payload.selected.formatted}`
+    );
+  }
+
+  if (payload.providers.length === 0) {
+    return "No SLOP applications found. Start a SLOP-enabled app, then call list_apps or open_app again.";
+  }
+
+  const lines = payload.providers.map((provider) => {
+    const status = provider.connected ? "connected" : "available";
+    return `- ${provider.name} (id: ${provider.id}, ${provider.transport}, ${status})`;
+  });
+  return `Available SLOP applications:\n${lines.join("\n")}`;
+}
+
+function describeWithParams(base: string, params: Record<string, unknown> | undefined, targets?: string[]): string {
+  const props = (params?.properties as Record<string, { type?: string; description?: string }>) ?? {};
+  const required = (params?.required as string[]) ?? [];
+  const lines = Object.entries(props).map(([key, value]) => {
+    const requiredHint = required.includes(key) ? " (required)" : "";
+    const type = value.type ?? "any";
+    const hint = value.description ? ` - ${value.description}` : "";
+    return `  - ${key}: ${type}${requiredHint}${hint}`;
+  });
+  const targetHint =
+    targets && targets.length
+      ? `\nValid target paths: ${targets.slice(0, 8).join(", ")}${targets.length > 8 ? ", ..." : ""}`
+      : "";
+  return lines.length ? `${base}\nParameters:\n${lines.join("\n")}${targetHint}` : `${base}${targetHint}`;
+}
+
+async function invokeDynamicTool(toolName: string, args: unknown): Promise<ToolResult> {
+  const resolved = dynamicToolSet.resolve(toolName);
+  if (!resolved) return errorResult(`Unknown tool: ${toolName}`);
+
+  const provider = discovery.getProvider(resolved.providerId);
+  if (!provider) return errorResult(`App "${resolved.providerId}" is disconnected. Call open_app to reconnect.`);
+
+  let invokePath = resolved.path;
+  const params = normalizeArgs(args);
+
+  if (invokePath === null) {
+    const target = params.target;
+    if (typeof target !== "string") {
+      return errorResult('Missing required "target" parameter.');
+    }
+    if (resolved.targets && !resolved.targets.includes(target)) {
+      return errorResult(`Invalid target "${target}". Valid targets: ${resolved.targets.join(", ")}`);
+    }
+    invokePath = target;
+    delete params.target;
+  }
+
+  const result = await provider.consumer.invoke(invokePath, resolved.action, params);
+  if (result.status === "error") {
+    const code = result.error?.code ?? "error";
+    const message = result.error?.message ?? "(no message)";
+    return errorResult(`Action failed: [${code}] ${message}`);
+  }
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: `Done.${result.data ? ` Result: ${JSON.stringify(result.data)}` : ""}`,
+      },
+    ],
+  };
+}
+
+function syncDynamicTools(): void {
+  const next = createDynamicTools(discovery);
+  const wanted = new Set(next.tools.map((tool) => tool.name));
+  let changed = false;
+
+  dynamicToolSet = next;
+
+  for (const tool of next.tools) {
+    const description = describeWithParams(tool.description, tool.inputSchema, tool.targets);
+    const existing = registeredDynamicTools.get(tool.name);
+    if (existing) {
+      existing.update({
+        description,
+        paramsSchema: PASSTHROUGH,
+        callback: ((args: unknown) => invokeDynamicTool(tool.name, args)) as never,
+      });
+      continue;
+    }
+
+    registeredDynamicTools.set(
+      tool.name,
+      server.registerTool(
+        tool.name,
+        {
+          description,
+          inputSchema: PASSTHROUGH,
+        },
+        ((args: unknown) => invokeDynamicTool(tool.name, args)) as never,
+      ),
+    );
+    changed = true;
+  }
+
+  for (const [name, tool] of registeredDynamicTools) {
+    if (wanted.has(name)) continue;
+    tool.remove();
+    registeredDynamicTools.delete(name);
+    changed = true;
+  }
+
+  if (changed) notifyToolListChanged();
+}
+
+async function readStandaloneHtml(): Promise<string> {
+  if (standaloneHtml) return standaloneHtml;
+  const script = await readFile(new URL("./standalone-app.js", import.meta.url), "utf8");
+  standaloneHtml = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SLOP Apps</title>
+  </head>
+  <body>
+    <div id="app">Loading SLOP app...</div>
+    <script type="module">${script.replaceAll("</script", "<\\/script")}</script>
+  </body>
+</html>`;
+  return standaloneHtml;
+}
+
+registerAppResource(
+  server,
+  "SLOP App View",
+  RESOURCE_URI,
+  {
+    description: "Generic view for discovered SLOP applications",
+  },
+  async () => {
+    const html = await readStandaloneHtml();
+    return {
+      contents: [
+        {
+          uri: RESOURCE_URI,
+          mimeType: RESOURCE_MIME_TYPE,
+          text: html,
+        },
+      ],
+    };
+  },
+);
+
+server.registerTool(
+  "list_apps",
+  {
+    description: "List SLOP-enabled applications available on this computer.",
+    inputSchema: {},
+  },
+  async () => handlers.listApps(),
+);
+
+registerAppTool(
+  server,
+  "open_app",
+  {
+    description:
+      "Open a discovered SLOP application as an MCP App view. Use list_apps first if you do not know the app name or ID.",
+    inputSchema: {
+      app: z.string().optional().describe("SLOP app name or ID to open."),
+    } as never,
+    _meta: {
+      ui: { resourceUri: RESOURCE_URI },
+    },
+  },
+  (async (args: OpenAppArgs): Promise<ToolResult> => {
+    const app = typeof args.app === "string" ? args.app : undefined;
+    const payload = await getStatePayload(app, true);
+    syncDynamicTools();
+
+    if (app && !payload.selected) {
+      return {
+        ...jsonResult(payload),
+        content: [{ type: "text", text: `App "${app}" not found or could not connect.\n\n${summarizeState(payload)}` }],
+      };
+    }
+
+    return {
+      ...jsonResult(payload),
+      content: [{ type: "text", text: summarizeState(payload) }],
+    };
+  }) as never,
+);
+
+server.registerTool(
+  "slop_get_state",
+  {
+    description: "App-only helper used by the SLOP MCP Apps iframe to refresh discovered provider state.",
+    inputSchema: {
+      app: z.string().optional().describe("SLOP app name or ID to connect and read."),
+    } as never,
+    _meta: {
+      ui: { visibility: ["app"] },
+    },
+  },
+  (async (args: OpenAppArgs): Promise<ToolResult> => {
+    const app = typeof args.app === "string" ? args.app : undefined;
+    const payload = await getStatePayload(app, !!app);
+    syncDynamicTools();
+    return jsonResult(payload);
+  }) as never,
+);
+
+server.registerTool(
+  "app_action",
+  {
+    description:
+      "Perform a single SLOP affordance on an application. Use the exact app, path, action, and params shown by open_app or the app view.",
+    inputSchema: {
+      app: z.string().describe("SLOP app name or ID."),
+      path: z.string().describe("Path to the node to act on, for example '/' or '/todos/todo-1'."),
+      action: z.string().describe("Affordance/action name to invoke."),
+      params: z.record(z.unknown()).optional().describe("Optional action parameters."),
+    } as never,
+  },
+  (async (args: AppActionArgs): Promise<ToolResult> => {
+    const provider = await discovery.ensureConnected(args.app);
+    if (!provider) return errorResult(`App "${args.app}" not found or could not connect.`);
+
+    const result = await provider.consumer.invoke(args.path, args.action, args.params ?? {});
+    if (result.status === "error") {
+      return errorResult(
+        `Action failed: [${result.error?.code ?? "error"}] ${result.error?.message ?? "(no message)"}`,
+      );
+    }
+
+    syncDynamicTools();
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Done. ${args.action} on ${args.path} succeeded.${result.data ? ` Result: ${JSON.stringify(result.data)}` : ""}`,
+        },
+      ],
+    };
+  }) as never,
+);
+
+server.registerTool(
+  "app_action_batch",
+  {
+    description:
+      "Perform multiple SLOP affordances on an application in one call. Prefer this for repeated or bulk operations.",
+    inputSchema: {
+      app: z.string().describe("SLOP app name or ID."),
+      actions: z
+        .array(
+          z.object({
+            path: z.string().describe("Path to the node to act on."),
+            action: z.string().describe("Affordance/action name to invoke."),
+            params: z.record(z.unknown()).optional().describe("Optional action parameters."),
+          }),
+        )
+        .describe("Actions to perform sequentially."),
+    } as never,
+  },
+  (async (args: AppActionBatchArgs): Promise<ToolResult> => {
+    const provider = await discovery.ensureConnected(args.app);
+    if (!provider) return errorResult(`App "${args.app}" not found or could not connect.`);
+
+    const lines: string[] = [];
+    let failed = 0;
+
+    for (const action of args.actions) {
+      const result = await provider.consumer.invoke(action.path, action.action, action.params ?? {});
+      if (result.status === "error") {
+        failed++;
+        lines.push(
+          `FAIL: ${action.action} on ${action.path} - [${result.error?.code ?? "error"}] ${result.error?.message ?? "(no message)"}`,
+        );
+      } else {
+        lines.push(`OK: ${action.action} on ${action.path}`);
+      }
+    }
+
+    syncDynamicTools();
+    return {
+      isError: failed > 0,
+      content: [{ type: "text", text: lines.join("\n") }],
+    };
+  }) as never,
+);
+
+discovery.onStateChange(() => {
+  syncDynamicTools();
+});
+
+async function main(): Promise<void> {
+  const arg = process.argv[2];
+  if (arg === "--help" || arg === "-h") {
+    printHelp();
+    return;
+  }
+  if (arg === "--version" || arg === "-v") {
+    console.log(VERSION);
+    return;
+  }
+
+  discovery.start();
+  log.info("Discovery started");
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  log.info("MCP server running on stdio");
+
+  const stop = () => {
+    discovery.stop();
+    process.exit(0);
+  };
+  process.on("SIGINT", stop);
+  process.on("SIGTERM", stop);
+}
+
+main().catch((error: unknown) => {
+  log.error("Fatal:", error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/packages/typescript/integrations/mcp-apps-bridge/src/standalone-app.ts
+++ b/packages/typescript/integrations/mcp-apps-bridge/src/standalone-app.ts
@@ -1,0 +1,352 @@
+import { App } from "@modelcontextprotocol/ext-apps";
+
+type ToolContent = { type: string; text?: string };
+
+interface ProviderSummary {
+  id: string;
+  name: string;
+  transport: string;
+  source: string;
+  connected: boolean;
+  status?: string;
+}
+
+interface ActionSummary {
+  name: string;
+  description: string;
+  path: string | null;
+  action: string;
+  targets?: string[];
+  parameters: Record<string, unknown>;
+}
+
+interface SelectedProviderState {
+  id: string;
+  name: string;
+  tree: unknown;
+  formatted: string;
+  actions: ActionSummary[];
+}
+
+interface StatePayload {
+  updatedAt: number;
+  providers: ProviderSummary[];
+  selected?: SelectedProviderState;
+}
+
+const app = new App({ name: "slop-mcp-apps-bridge", version: "0.1.0" }, {});
+let selectedApp: string | null = null;
+let connected = false;
+let latestContext = "";
+let pollTimer: number | null = null;
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"]/g, (char) => {
+    switch (char) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      default:
+        return char;
+    }
+  });
+}
+
+function readJsonPayload(result: { structuredContent?: unknown; content?: ToolContent[] }): StatePayload {
+  if (result.structuredContent && typeof result.structuredContent === "object") {
+    return result.structuredContent as StatePayload;
+  }
+  const text = result.content?.find((part) => part.type === "text" && typeof part.text === "string")?.text;
+  if (!text) throw new Error("Server returned no state payload.");
+  return JSON.parse(text) as StatePayload;
+}
+
+async function fetchState(appId: string | null): Promise<StatePayload> {
+  const result = await app.callServerTool({
+    name: "slop_get_state",
+    arguments: appId ? { app: appId } : {},
+  });
+  return readJsonPayload(result);
+}
+
+async function updateModelContext(payload: StatePayload): Promise<void> {
+  if (!payload.selected) return;
+  const actions = payload.selected.actions
+    .map((action) => {
+      const location = action.path
+        ? ` on ${action.path}`
+        : action.targets
+          ? ` on ${action.targets.length} targets`
+          : "";
+      return `- ${action.action}${location}: ${action.description}`;
+    })
+    .join("\n");
+  const context =
+    `# ${payload.selected.name}\n\n` +
+    `Connected SLOP app id: ${payload.selected.id}\n\n` +
+    `## State\n\n\`\`\`\n${payload.selected.formatted}\n\`\`\`\n\n` +
+    `## Actions\n\n${actions || "(none)"}`;
+
+  if (context === latestContext) return;
+  latestContext = context;
+
+  try {
+    await app.updateModelContext({ content: [{ type: "text", text: context }] });
+  } catch {
+    // Some hosts render MCP Apps but do not yet accept context updates.
+  }
+}
+
+function renderShell(): void {
+  const root = document.getElementById("app");
+  if (!root) return;
+  root.innerHTML = `
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.4;
+      }
+      body {
+        margin: 0;
+        background: Canvas;
+        color: CanvasText;
+      }
+      .shell {
+        min-height: 100vh;
+        display: grid;
+        grid-template-columns: minmax(190px, 260px) minmax(0, 1fr);
+        border-top: 1px solid color-mix(in srgb, CanvasText 12%, transparent);
+      }
+      .sidebar {
+        border-right: 1px solid color-mix(in srgb, CanvasText 12%, transparent);
+        padding: 14px;
+        overflow: auto;
+      }
+      .main {
+        padding: 14px;
+        min-width: 0;
+        overflow: auto;
+      }
+      h1, h2 {
+        margin: 0;
+        letter-spacing: 0;
+      }
+      h1 {
+        font-size: 16px;
+        line-height: 1.2;
+      }
+      h2 {
+        font-size: 13px;
+        margin-top: 18px;
+        margin-bottom: 8px;
+      }
+      .status {
+        color: color-mix(in srgb, CanvasText 62%, transparent);
+        font-size: 12px;
+        margin-top: 4px;
+      }
+      .toolbar {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-top: 12px;
+      }
+      button {
+        border: 1px solid color-mix(in srgb, CanvasText 18%, transparent);
+        border-radius: 6px;
+        background: color-mix(in srgb, Canvas 88%, CanvasText 12%);
+        color: CanvasText;
+        padding: 6px 9px;
+        font: inherit;
+        cursor: pointer;
+      }
+      button:hover {
+        background: color-mix(in srgb, Canvas 80%, CanvasText 20%);
+      }
+      .provider {
+        width: 100%;
+        text-align: left;
+        margin: 4px 0;
+        display: grid;
+        gap: 2px;
+      }
+      .provider[data-selected="true"] {
+        border-color: color-mix(in srgb, Highlight 70%, CanvasText 15%);
+        outline: 2px solid color-mix(in srgb, Highlight 24%, transparent);
+      }
+      .name {
+        font-weight: 650;
+        overflow-wrap: anywhere;
+      }
+      .meta, .empty {
+        color: color-mix(in srgb, CanvasText 62%, transparent);
+        font-size: 12px;
+      }
+      .state {
+        margin: 0;
+        padding: 12px;
+        border: 1px solid color-mix(in srgb, CanvasText 12%, transparent);
+        border-radius: 6px;
+        overflow: auto;
+        white-space: pre-wrap;
+        background: color-mix(in srgb, Canvas 94%, CanvasText 6%);
+        font: 12px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      }
+      .actions {
+        display: grid;
+        gap: 6px;
+      }
+      .action {
+        border: 1px solid color-mix(in srgb, CanvasText 12%, transparent);
+        border-radius: 6px;
+        padding: 8px;
+      }
+      .action code {
+        font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      }
+      @media (max-width: 680px) {
+        .shell {
+          grid-template-columns: 1fr;
+        }
+        .sidebar {
+          border-right: 0;
+          border-bottom: 1px solid color-mix(in srgb, CanvasText 12%, transparent);
+        }
+      }
+    </style>
+    <div class="shell">
+      <aside class="sidebar">
+        <h1>SLOP Apps</h1>
+        <div class="status" id="status">Connecting...</div>
+        <div class="toolbar">
+          <button id="refresh" type="button">Refresh</button>
+        </div>
+        <h2>Providers</h2>
+        <div id="providers"></div>
+      </aside>
+      <main class="main">
+        <div id="details">
+          <p class="empty">Select a provider or ask the model to call <code>open_app</code>.</p>
+        </div>
+      </main>
+    </div>`;
+
+  document.getElementById("refresh")?.addEventListener("click", () => {
+    void refresh();
+  });
+}
+
+function renderProviders(payload: StatePayload): void {
+  const target = document.getElementById("providers");
+  if (!target) return;
+  if (payload.providers.length === 0) {
+    target.innerHTML = `<p class="empty">No SLOP providers found.</p>`;
+    return;
+  }
+
+  target.innerHTML = payload.providers
+    .map((provider) => {
+      const selected = selectedApp === provider.id || payload.selected?.id === provider.id;
+      const status = provider.connected ? (provider.status ?? "connected") : "available";
+      return `
+        <button class="provider" type="button" data-app="${escapeHtml(provider.id)}" data-selected="${selected ? "true" : "false"}">
+          <span class="name">${escapeHtml(provider.name)}</span>
+          <span class="meta">${escapeHtml(provider.id)} · ${escapeHtml(provider.transport)} · ${escapeHtml(status)}</span>
+        </button>`;
+    })
+    .join("");
+
+  target.querySelectorAll<HTMLButtonElement>("[data-app]").forEach((button) => {
+    button.addEventListener("click", () => {
+      selectedApp = button.dataset.app ?? null;
+      void refresh();
+    });
+  });
+}
+
+function renderDetails(payload: StatePayload): void {
+  const details = document.getElementById("details");
+  if (!details) return;
+  if (!payload.selected) {
+    details.innerHTML = `<p class="empty">No provider selected.</p>`;
+    return;
+  }
+
+  const actions = payload.selected.actions
+    .map((action) => {
+      const location = action.path ?? (action.targets ? `${action.targets.length} targets` : "dynamic target");
+      return `
+        <div class="action">
+          <div><code>${escapeHtml(action.action)}</code> <span class="meta">${escapeHtml(location)}</span></div>
+          <div class="meta">${escapeHtml(action.description)}</div>
+        </div>`;
+    })
+    .join("");
+
+  details.innerHTML = `
+    <h1>${escapeHtml(payload.selected.name)}</h1>
+    <div class="status">id: ${escapeHtml(payload.selected.id)}</div>
+    <h2>State</h2>
+    <pre class="state">${escapeHtml(payload.selected.formatted)}</pre>
+    <h2>Actions</h2>
+    <div class="actions">${actions || `<p class="empty">No affordances exposed.</p>`}</div>`;
+}
+
+async function refresh(): Promise<void> {
+  const status = document.getElementById("status");
+  try {
+    if (status) status.textContent = "Refreshing...";
+    const payload = await fetchState(selectedApp);
+    if (!selectedApp && payload.selected?.id) selectedApp = payload.selected.id;
+    renderProviders(payload);
+    renderDetails(payload);
+    await updateModelContext(payload);
+    if (status) {
+      const time = new Date(payload.updatedAt).toLocaleTimeString();
+      status.textContent = `Updated ${time}`;
+    }
+  } catch (error) {
+    if (status) status.textContent = "Error";
+    const details = document.getElementById("details");
+    if (details) {
+      details.innerHTML = `<p class="empty">${escapeHtml(error instanceof Error ? error.message : String(error))}</p>`;
+    }
+  }
+}
+
+app.addEventListener("toolinput", (params) => {
+  const appArg = params.arguments?.app;
+  if (typeof appArg === "string" && appArg.length > 0) {
+    selectedApp = appArg;
+  }
+  if (connected) void refresh();
+});
+
+renderShell();
+
+try {
+  await app.connect();
+  connected = true;
+  await refresh();
+  pollTimer = window.setInterval(() => {
+    void refresh();
+  }, 2000);
+} catch (error) {
+  const status = document.getElementById("status");
+  if (status) status.textContent = "Connection failed";
+  const details = document.getElementById("details");
+  if (details) {
+    details.innerHTML = `<p class="empty">${escapeHtml(error instanceof Error ? error.message : String(error))}</p>`;
+  }
+}
+
+window.addEventListener("beforeunload", () => {
+  if (pollTimer !== null) window.clearInterval(pollTimer);
+  void app.close().catch(() => {});
+});

--- a/packages/typescript/integrations/mcp-apps-bridge/tsconfig.json
+++ b/packages/typescript/integrations/mcp-apps-bridge/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "declaration": true,
     "lib": ["ES2022", "DOM"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "skipLibCheck": true

--- a/website/docs/content-manifest.mjs
+++ b/website/docs/content-manifest.mjs
@@ -81,8 +81,7 @@ export const docsPages = [
   }),
   page("docs/guides/advanced/mcp-bridge.md", "guides/advanced/mcp-bridge.md", {
     label: "MCP Apps Bridge",
-    description:
-      "Render a SLOP provider inside an MCP Apps host (VS Code, Claude, Goose) with model-callable affordances",
+    description: "Expose SLOP providers inside MCP Apps hosts through the installed bridge or custom app helpers",
     redirects: ["/guides-advanced/mcp-bridge"],
   }),
   page("docs/guides/advanced/openclaw.md", "guides/advanced/openclaw.md", {

--- a/website/docs/src/content/docs/guides/advanced/mcp-bridge.md
+++ b/website/docs/src/content/docs/guides/advanced/mcp-bridge.md
@@ -1,25 +1,48 @@
 ---
 title: "MCP Apps Bridge"
-description: "Render a SLOP provider inside an MCP Apps host (VS Code, Claude, Goose) with model-callable affordances"
+description: "Expose SLOP providers inside MCP Apps hosts through the installed bridge or custom app helpers"
 ---
-Expose a SLOP provider inside an MCP Apps host (Claude, ChatGPT, Goose, VS Code Insiders) so the host model can subscribe to live state and call your app's affordances directly from chat.
+Expose SLOP providers inside MCP Apps hosts (Claude, ChatGPT, Goose, VS Code Insiders) so the host model can subscribe to live state and call app affordances directly from chat.
 
-The `@slop-ai/mcp-apps-bridge` package handles three things:
+The `@slop-ai/mcp-apps-bridge` package has two surfaces:
 
-- **Iframe-side bridge** — runs inside the sandboxed `ui://` view, opens a SLOP consumer, projects salience-filtered state into `app.updateModelContext`.
-- **`registerSlopView`** — server-side helper that wires the MCP tool + `ui://` resource + sandbox CSP.
-- **`registerSlopTools`** — server-side helper that mirrors every SLOP affordance as a callable MCP tool, with `tools/listChanged` resync on every patch.
+- **Installed bridge** — a stdio MCP server that discovers local SLOP providers, exposes `list_apps` and `open_app`, renders a generic MCP Apps view, and mirrors affordances as MCP tools. This is the main adoption path.
+- **Custom MCP App helpers** — lower-level primitives for app authors who want to ship a tailored iframe and MCP server: `createMcpAppsBridge`, `registerSlopView`, and `registerSlopTools`.
 
-This guide is the developer-facing complement to the normative [MCP Interoperability spec](/spec/integrations/mcp). For an end-to-end runnable example, see [`examples/mcp-apps-bridge`](https://github.com/devteapot/slop/tree/main/examples/mcp-apps-bridge).
+This guide is the developer-facing complement to the normative [MCP Interoperability spec](/spec/integrations/mcp). For an end-to-end runnable custom MCP App example, see [`examples/mcp-apps-bridge`](https://github.com/devteapot/slop/tree/main/examples/mcp-apps-bridge).
 
 ## When to use this
 
-- Your users interact with SLOP-aware apps through a chat UI (Claude / VS Code chat / Goose / etc.) and you want the model to both *observe* state and *act* on it inside the same conversation.
-- You already have a SLOP provider — adding the bridge is a server file plus an iframe bundle.
+- Use the **installed bridge** when you already have SLOP providers and want them available in MCP clients with minimal setup.
+- Use the **custom MCP App helpers** when you want a branded or app-specific iframe instead of the generic bridge view.
 
 If your target host doesn't support MCP Apps yet, use the [Claude Code integration](/guides/advanced/claude-code) (proxy pattern) instead.
 
-## Architecture
+## Installed bridge
+
+Most users should start here:
+
+```bash
+npx -y @slop-ai/mcp-apps-bridge
+```
+
+Configure the command in your MCP client:
+
+```jsonc
+{
+  "servers": {
+    "slop": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@slop-ai/mcp-apps-bridge"]
+    }
+  }
+}
+```
+
+Then ask the host model to call `list_apps` and `open_app`. The bridge handles discovery, the generic `ui://` app view, model context updates, and generated SLOP action tools.
+
+## Custom MCP App architecture
 
 ```
 ┌─ host (VS Code Insiders / Claude / Goose) ─────────────────────────┐
@@ -41,7 +64,7 @@ If your target host doesn't support MCP Apps yet, use the [Claude Code integrati
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
-A single Node process typically hosts the SLOP provider, the MCP server, and the WS endpoint. The iframe is a thin client.
+In custom mode, a single Node process typically hosts the SLOP provider, the MCP server, and the WS endpoint. The iframe is a thin client.
 
 ## Server: register the view + the tools
 
@@ -147,9 +170,17 @@ The host's iframe sandbox and user-consent prompts are defense in depth. They ar
 
 For remote providers (production), use a short-lived token in the WS URL minted per-session by your backend. Don't put bearer tokens in MCP tool `content` or anywhere model-visible — they end up in conversation transcripts.
 
-## Validating in real hosts
+## Validating the installed bridge
 
-The smoke test we use:
+1. Start a SLOP provider that registers through discovery.
+2. Register `npx -y @slop-ai/mcp-apps-bridge` in VS Code, Claude Desktop, Goose, or the MCP Inspector.
+3. Ask the host model to call `list_apps`.
+4. Ask it to open one of the discovered apps with `open_app`.
+5. Verify that the generic app view renders and generated action tools can mutate the provider.
+
+## Validating the custom example
+
+The custom MCP App smoke test we use:
 
 1. Build the demo: `cd examples/mcp-apps-bridge && bun run build`.
 2. Register the server in **VS Code Insiders** (Cmd+Shift+P → `MCP: Open User Configuration`):
@@ -164,7 +195,7 @@ The smoke test we use:
      }
    }
    ```
-3. Reload the window, open Copilot Chat, ask: `Use the open_kanban tool`. The iframe should render with status `connected`.
+3. Reload the window, open Copilot Chat, ask: `Use the open_kanban tool`. The iframe should render with status `connected`. This example does not expose `list_apps`; it is already one specific MCP App server.
 4. Ask: `What cards are in todo?` — model should answer without another tool call.
 5. Ask: `Add a card called "Ship it" to todo` — the model calls `add_card`, the iframe re-renders, and the next turn's context reflects the new card.
 


### PR DESCRIPTION
## Summary
- add the missing package README for `@slop-ai/discovery`
- make `@slop-ai/mcp-apps-bridge` installable as a stdio MCP server via `npx -y @slop-ai/mcp-apps-bridge`
- wire the bridge server through `@slop-ai/discovery` so it can list/open discovered providers and expose SLOP affordances as MCP tools
- add a bundled generic MCP Apps iframe that refreshes state through app-only server tools and updates model context
- clarify the product split: the installed bridge is the default adoption path, while `examples/mcp-apps-bridge` remains the advanced custom MCP App example
- update README/docs with VS Code, Claude Desktop, Goose, MCP Inspector, tool-only client setup, and validation guidance for both paths

## Validation
- `bun run preflight --files docs/guides/advanced/mcp-bridge.md examples/mcp-apps-bridge/README.md packages/typescript/integrations/mcp-apps-bridge/README.md packages/typescript/integrations/mcp-apps-bridge/package.json website/docs/content-manifest.mjs website/docs/src/content/docs/guides/advanced/mcp-bridge.md`
- `bun run preflight --files packages/typescript/integrations/mcp-apps-bridge/README.md packages/typescript/integrations/mcp-apps-bridge/package.json packages/typescript/integrations/mcp-apps-bridge/tsconfig.json packages/typescript/integrations/mcp-apps-bridge/src/cli.ts packages/typescript/integrations/mcp-apps-bridge/src/standalone-app.ts packages/typescript/integrations/discovery/README.md`
- `bun run build`
- `bun test` in `packages/typescript/integrations/mcp-apps-bridge`
- `bun test` in `packages/typescript/integrations/discovery`
- `bun run format:check`
- stdio MCP smoke test: connect with `@modelcontextprotocol/sdk` client, list tools, read `ui://slop/discovered-app`, call `slop_get_state`
- `env npm_config_cache=/tmp/npm-cache npm pack --dry-run` from both `packages/typescript/integrations/discovery` and `packages/typescript/integrations/mcp-apps-bridge`

## Notes
- A full local `bun run preflight --files bun.lock ...` also tried to build every example because `bun.lock` changed and failed in the unrelated Angular SPA example (`provideExperimentalZonelessChangeDetection` no longer exported by the installed Angular version). The relevant package checks and CI-shaped TypeScript package build pass.
