### PR TITLE
[codex] Fix Rust Unix transport gating on Windows

### DIFF
--- a/packages/rust/slop-ai/src/discovery/service.rs
+++ b/packages/rust/slop-ai/src/discovery/service.rs
@@ -9,9 +9,11 @@ use tokio::time::{sleep, timeout};
 
 use crate::consumer::{ClientTransport, SlopConsumer};
 use crate::error::{Result, SlopError};
-use crate::transport::unix_client::UnixClientTransport;
 use crate::transport::ws_client::WsClientTransport;
 use crate::types::PatchOp;
+
+#[cfg(unix)]
+use crate::transport::unix_client::UnixClientTransport;
 
 use super::bridge::{Bridge, BridgeClient, BridgeServer, ProviderChangeCallback};
 use super::relay_transport::BridgeRelayTransport;
@@ -728,9 +730,12 @@ fn create_transport(
     bridge: Option<Arc<dyn Bridge>>,
 ) -> Option<Box<dyn ClientTransport + Send + Sync>> {
     match descriptor.transport.transport_type.as_str() {
+        #[cfg(unix)]
         "unix" => descriptor.transport.path.as_ref().map(|path| {
             Box::new(UnixClientTransport::new(path)) as Box<dyn ClientTransport + Send + Sync>
         }),
+        #[cfg(not(unix))]
+        "unix" => None,
         "ws" => descriptor.transport.url.as_ref().map(|url| {
             Box::new(WsClientTransport::new(url)) as Box<dyn ClientTransport + Send + Sync>
         }),

--- a/packages/rust/slop-ai/src/lib.rs
+++ b/packages/rust/slop-ai/src/lib.rs
@@ -17,7 +17,7 @@
 //! | Feature | Transport | Use case |
 //! |---------|-----------|----------|
 //! | `websocket` | [`transport::websocket`], [`WsClientTransport`] | Browser-compatible, cross-network |
-//! | `unix` | [`transport::unix`], [`UnixClientTransport`] | Fast local IPC |
+//! | `unix` | [`transport::unix`], [`UnixClientTransport`] *(Unix targets only)* | Fast local IPC |
 //! | `stdio` | [`transport::stdio`] | CLI tools, child processes |
 //! | `axum` | [`transport::axum`] | Embed in an Axum HTTP server |
 //!
@@ -99,5 +99,5 @@ pub use transport::ws_client::WsClientTransport;
 #[cfg(feature = "websocket")]
 pub use transport::ws_accepted::AcceptedWsTransport;
 
-#[cfg(feature = "unix")]
+#[cfg(all(feature = "unix", unix))]
 pub use transport::unix_client::UnixClientTransport;

--- a/packages/rust/slop-ai/src/transport/mod.rs
+++ b/packages/rust/slop-ai/src/transport/mod.rs
@@ -15,10 +15,10 @@ pub mod ws_client;
 #[cfg(feature = "websocket")]
 pub mod ws_accepted;
 
-#[cfg(feature = "unix")]
+#[cfg(all(feature = "unix", unix))]
 pub mod unix;
 
-#[cfg(feature = "unix")]
+#[cfg(all(feature = "unix", unix))]
 pub mod unix_client;
 
 #[cfg(feature = "stdio")]


### PR DESCRIPTION
## Summary

- Gate the Rust SDK Unix transport modules and public re-export behind both the `unix` feature and a Unix target cfg.
- Keep discovery from trying to instantiate Unix socket transports on non-Unix targets.
- Clarify in the crate docs that the Unix transport is Unix-target only.

## Root cause

The Windows desktop release build enables the Rust SDK's default features, including `unix`. That caused `tokio::net::UnixListener` and `UnixStream` imports to compile on Windows, where they are unavailable.

## Validation

- `cargo check` in `packages/rust/slop-ai`
- `cargo check --target x86_64-pc-windows-msvc` in `packages/rust/slop-ai`
- `cargo test` in `packages/rust/slop-ai`

The desktop Windows target check also progressed past the `slop-ai` crate locally, then failed in `ring` C compilation because this macOS machine does not have the Windows C sysroot/MSVC toolchain available.