### PR TITLE
Build(deps): bump tokio to 1.53.1

### DIFF
--- a/packages/rust/slop-ai/Cargo.lock
+++ b/packages/rust/slop-ai/Cargo.lock
@@ -700,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.53.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",


### PR DESCRIPTION
Recreates the validated dependency update from Dependabot PR #90 after its source branch was deleted when the PR was closed.

## What changed

- Updated the Rust SDK lockfile from Tokio 1.53.0 to 1.53.1.
- Preserved the original Dependabot-authored commit.

## Why

Tokio 1.53.1 is a patch release that restores Windows MSRV compatibility and fixes an unstable timer race.

## Validation

- Existing GitHub checks on #90 passed, including Rust SDK and desktop smoke build.
- Fresh validation against current `main`: `cargo test --locked --manifest-path packages/rust/slop-ai/Cargo.toml` (88 unit tests and 7 doc tests passed).