### PR TITLE
Build(deps): bump Anthropic SDK to 0.115.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -350,7 +350,7 @@
       },
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.185",
-        "@anthropic-ai/sdk": "^0.112.3",
+        "@anthropic-ai/sdk": "^0.115.0",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "@slop-ai/consumer": "workspace:*",
         "ws": "^8.18.0",
@@ -537,7 +537,7 @@
 
     "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.205", "", { "os": "win32", "cpu": "x64" }, "sha512-kg2kkXyeSoFLruO3Ic2IruLxzBR0xCUtmlJHdWi3SYW7JhAKNJg4fcrdJsWcardmEw23Y2UDGDJbRyxqSVx6wg=="],
 
-    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.112.5", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-FaaGkyS4/zW4n+8Pr9jQkyo5zWcBNw+R+heCLXdoKDUEuALbPALBk6zLAlmsU+veREiaATxVG0TwkK/cQ3NZsQ=="],
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.115.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ=="],
 
     "@anthropic-ai/vertex-sdk": ["@anthropic-ai/vertex-sdk@0.14.4", "", { "dependencies": { "@anthropic-ai/sdk": ">=0.50.3 <1", "google-auth-library": "^9.4.2" } }, "sha512-BZUPRWghZxfSFtAxU563wH+jfWBPoedAwsVxG35FhmNsjeV8tyfN+lFriWhCpcZApxA4NdT6Soov+PzfnxxD5g=="],
 

--- a/packages/typescript/integrations/discovery/package.json
+++ b/packages/typescript/integrations/discovery/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@slop-ai/consumer": "workspace:*",
-    "@anthropic-ai/sdk": "^0.112.3",
+    "@anthropic-ai/sdk": "^0.115.0",
     "@anthropic-ai/claude-agent-sdk": "^0.3.185",
     "@modelcontextprotocol/sdk": "^1.12.0",
     "ws": "^8.18.0",


### PR DESCRIPTION
Resolves the compatible half of closed Dependabot PR #91.

## What changed

- Updated `@anthropic-ai/sdk` from the `^0.112.3` range (locked at 0.112.5) to `^0.115.0`.
- Updated `bun.lock` precisely to 0.115.0.
- Deliberately left jsdom on 29.x because jsdom 30 raises the Node minimum to `^22.22.2 || ^24.15.0 || >=26.0.0`; that policy change should not be bundled into an unrelated SDK update.

## Why

Anthropic SDK 0.113–0.115 contains additive API/model support and an abort-listener cleanup, with no breaking change noted. It remains compatible with the Claude Agent SDK peer range.

## Validation

Using the same Bun 1.3.14 version observed in CI:

- `bun install --frozen-lockfile`
- `bun run build`
- `bun run test` (232 tests passed)
- Anthropic client import/construction smoke test

The original #91 failure was caused solely by an omitted lockfile update.