### PR TITLE
Build(deps): bump @anthropic-ai/sdk to 0.122.0

### DIFF
--- a/apps/extension/build.ts
+++ b/apps/extension/build.ts
@@ -1,8 +1,13 @@
 import { cpSync, existsSync, mkdirSync } from "fs";
-import { join } from "path";
+import { join, resolve } from "path";
 
 const dir = import.meta.dir;
 const dist = join(dir, "dist");
+
+function copyUnlessSame(src: string, dest: string, options?: { force?: boolean; recursive?: boolean }) {
+  if (resolve(src) === resolve(dest)) return;
+  cpSync(src, dest, options);
+}
 
 mkdirSync(dist, { recursive: true });
 
@@ -33,11 +38,11 @@ for (const { entry, out } of entryPoints) {
 // Copy static files
 cpSync(join(dir, "src/options/options.html"), join(dist, "../options.html"));
 cpSync(join(dir, "src/ui/chat.css"), join(dist, "chat.css"));
-cpSync(join(dir, "manifest.json"), join(dist, "../manifest.json"), { force: true });
+copyUnlessSame(join(dir, "manifest.json"), join(dist, "../manifest.json"), { force: true });
 
 // Copy icons if they exist
 if (existsSync(join(dir, "icons"))) {
-  cpSync(join(dir, "icons"), join(dist, "../icons"), { recursive: true });
+  copyUnlessSame(join(dir, "icons"), join(dist, "../icons"), { recursive: true });
 }
 
 console.log("Extension built to dist/");

--- a/bun.lock
+++ b/bun.lock
@@ -350,7 +350,7 @@
       },
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.185",
-        "@anthropic-ai/sdk": "^0.117.1",
+        "@anthropic-ai/sdk": "^0.122.0",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "@slop-ai/consumer": "workspace:*",
         "ws": "^8.18.0",
@@ -537,7 +537,7 @@
 
     "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.205", "", { "os": "win32", "cpu": "x64" }, "sha512-kg2kkXyeSoFLruO3Ic2IruLxzBR0xCUtmlJHdWi3SYW7JhAKNJg4fcrdJsWcardmEw23Y2UDGDJbRyxqSVx6wg=="],
 
-    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.117.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-Yn2QlXfyCiKJ5YGCOOay7ZE78ISvII2XY621WMCiflmG8IYgwx59IBwPExxki3Xk9jKUtnD/Sj6UvplWr0rZxg=="],
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.122.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-GGPNftt0caaz9MDlmNQGHX8855Ojaduyy5pm9Sm1h7HalCn0cWNb5/bweadJF+4yzbal+QL6ztBa09WAAOzLmQ=="],
 
     "@anthropic-ai/vertex-sdk": ["@anthropic-ai/vertex-sdk@0.14.4", "", { "dependencies": { "@anthropic-ai/sdk": ">=0.50.3 <1", "google-auth-library": "^9.4.2" } }, "sha512-BZUPRWghZxfSFtAxU563wH+jfWBPoedAwsVxG35FhmNsjeV8tyfN+lFriWhCpcZApxA4NdT6Soov+PzfnxxD5g=="],
 

--- a/packages/typescript/integrations/discovery/package.json
+++ b/packages/typescript/integrations/discovery/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@slop-ai/consumer": "workspace:*",
-    "@anthropic-ai/sdk": "^0.117.1",
+    "@anthropic-ai/sdk": "^0.122.0",
     "@anthropic-ai/claude-agent-sdk": "^0.3.185",
     "@modelcontextprotocol/sdk": "^1.12.0",
     "ws": "^8.18.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Takes the `@anthropic-ai/sdk` minor from Dependabot's grouped #101 (`0.117.1` → `0.122.0`) without the Electron **44** major.

- `packages/typescript/integrations/discovery/package.json`: `^0.122.0`
- `bun.lock` refreshed so `bun install --frozen-lockfile` resolves `@anthropic-ai/sdk@0.122.0` (no unrelated packages re-resolved)
- `apps/extension/build.ts`: skip `cpSync` when src and dest resolve to the same path for `manifest.json` and `icons/` — newer Bun throws EINVAL on same-path copy. `options.html` still copies from `src/`. Formatted with Biome so Format Check stays green.

#101 is left open for the Electron 44 major (macOS 12 dropped, 32-bit gone, clipboard out of the renderer). Not merging.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3562c4bd-38a2-4db9-8509-b001aae50236?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3562c4bd-38a2-4db9-8509-b001aae50236&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

